### PR TITLE
Fix: Downgrade typescript-eslint to version 6.14.0 to resolve build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.3",
-    "typescript-eslint": "^6.15.0",
+    "typescript-eslint": "^6.14.0",
     "vite": "^5.0.10"
   }
 }


### PR DESCRIPTION
## Fix TypeScript-ESLint Build Error in Lovable

This PR specifically addresses the build error in the Lovable deployment:

```
error: No version matching "^6.15.0" found for specifier "typescript-eslint" (but package exists)
error: typescript-eslint@^6.15.0 failed to resolve
```

### The Fix
- Changed `typescript-eslint` from version `^6.15.0` to `^6.14.0`
- Version 6.14.0 is confirmed to exist in the npm registry
- This maintains all the security benefits while ensuring compatibility with the build environment

### Why This Works
The version 6.15.0 of typescript-eslint appears to not be available in the Lovable npm registry or build environment. By downgrading to a slightly older but still very recent version (6.14.0), we ensure that the package can be found and installed during the build process.

### Impact
This should be the final fix needed to make the Lovable deployment work successfully. The change is minimal and focused on just one development dependency.

### Future Considerations
For future dependency updates, consider:
1. Checking if specific versions actually exist in npm before updating
2. Using exact versions (without ^) for more predictable builds
3. Being cautious with very recent dependency versions that might not yet be available in all environments