### PR TITLE
Potential fix for code scanning alert no. 4: Insecure randomness

### DIFF
--- a/src/components/onboarding/steps/BasicInfoStep.tsx
+++ b/src/components/onboarding/steps/BasicInfoStep.tsx
@@ -17,7 +17,9 @@ export const BasicInfoStep = ({ firstName, lastName, username, email, avatarUrl,
   useEffect(() => {
     // Generate username when first or last name changes
     if (firstName || lastName) {
-      const randomSuffix = Math.floor(Math.random() * 10000).toString().padStart(4, '0');
+      const array = new Uint32Array(1);
+      window.crypto.getRandomValues(array);
+      const randomSuffix = (array[0] % 10000).toString().padStart(4, '0');
       const baseUsername = `${firstName.toLowerCase()}${lastName.toLowerCase()}${randomSuffix}`;
       const generatedUsername = baseUsername.replace(/[^a-z0-9]/g, '');
       onUpdate('username', generatedUsername);


### PR DESCRIPTION
Potential fix for [https://github.com/sss97133/nuke/security/code-scanning/4](https://github.com/sss97133/nuke/security/code-scanning/4)

To fix the problem, we need to replace the use of `Math.random()` with a cryptographically secure random number generator. In a browser environment, we can use `window.crypto.getRandomValues` to generate a secure random number. This ensures that the generated random suffix is not easily predictable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
