### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/vehicles/forms/components/ImageUpload.tsx
+++ b/src/components/vehicles/forms/components/ImageUpload.tsx
@@ -30,6 +30,16 @@ export const ImageUpload: React.FC<ImageUploadProps> = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
   
+  // Function to validate object URLs
+  const isValidObjectURL = (url: string) => {
+    try {
+      const objUrl = new URL(url);
+      return objUrl.protocol === 'blob:';
+    } catch (e) {
+      return false;
+    }
+  };
+  
   // Handle file selection
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
@@ -80,7 +90,9 @@ export const ImageUpload: React.FC<ImageUploadProps> = ({
       ? [...previewUrls, ...newPreviewUrls]
       : newPreviewUrls;
     
-    setPreviewUrls(updatedPreviewUrls);
+    // Validate the URLs before setting them
+    const validatedUrls = updatedPreviewUrls.filter(url => isValidObjectURL(url));
+    setPreviewUrls(validatedUrls);
     
     // Simulate uploading
     setIsUploading(true);


### PR DESCRIPTION
Potential fix for [https://github.com/sss97133/nuke/security/code-scanning/3](https://github.com/sss97133/nuke/security/code-scanning/3)

To fix the problem, we should ensure that the `url` used in the `src` attribute of the `img` tag is safe and cannot be manipulated to inject malicious content. One way to achieve this is by validating the `url` before using it. Since `URL.createObjectURL(file)` is used to generate the `url`, we can add a check to ensure that the `url` is a valid object URL.

- Validate the `url` before using it in the `src` attribute of the `img` tag.
- Ensure that the `url` is a valid object URL created by `URL.createObjectURL(file)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
