### PR TITLE
Fix: Update ESLint TypeScript dependencies for Vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,17 +86,17 @@
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
+    "@typescript-eslint/eslint-plugin": "^6.14.0",
+    "@typescript-eslint/parser": "^6.14.0",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.56.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
     "globals": "^13.24.0",
-    "lovable-tagger": "^1.1.3",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.3",
-    "typescript-eslint": "^6.14.0",
     "vite": "^5.0.10"
   }
 }


### PR DESCRIPTION
## Dependency Fix for Vercel Deployment

This PR fixes the deployment issue with Vercel by updating the ESLint TypeScript dependencies.

### Problem
The build was failing with the error:
```
npm error notarget No matching version found for typescript-eslint@^6.14.0.
```

### Solution
- Removed the generic `typescript-eslint` package (which doesn't exist as a direct npm package)
- Added the specific packages:
  - `@typescript-eslint/eslint-plugin`: "^6.14.0"
  - `@typescript-eslint/parser`: "^6.14.0"
- Removed the `lovable-tagger` dependency which is no longer needed

This change should allow the project to build successfully on Vercel.

### Testing
After merging, we should redeploy on Vercel to verify the build succeeds.
