### PR TITLE
Fix: Remove lovable-tagger from Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
-import { componentTagger } from "lovable-tagger";
 
 export default defineConfig(({ mode }) => ({
   server: {
@@ -11,9 +10,7 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     react(),
-    mode === 'development' &&
-    componentTagger(),
-  ].filter(Boolean),
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
@@ -30,4 +27,3 @@ export default defineConfig(({ mode }) => ({
     },
   },
 }));
-


### PR DESCRIPTION
## Fixes for Vercel Deployment - Part 2

This PR continues the fixes needed for successful Vercel deployment.

### Problem Fixed
- Error: `Cannot find package 'lovable-tagger' imported from /vercel/path0/vite.config.ts`
- The build failed even after fixing the TypeScript ESLint dependencies because we still had references to lovable-tagger in the Vite config

### Solution
- Removed the lovable-tagger import and reference from vite.config.ts
- Simplified the plugins configuration

This change should allow the project to build successfully on Vercel. Once this is merged, we should be able to deploy properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the build setup by removing unused conditional configurations to simplify the development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->