### PR TITLE
Fix: Replace unavailable ChartLine icon with LineChart icon

### DIFF
--- a/src/components/documentation/guides/CoreDocumentation.tsx
+++ b/src/components/documentation/guides/CoreDocumentation.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
-import { BookOpen, FileText, Settings, Car, Package, Wrench, Users, BarChart, Building, Video, ChartLine, Coins, LayoutPanelTop } from 'lucide-react';
+import { BookOpen, FileText, Settings, Car, Package, Wrench, Users, BarChart, Building, Video, LineChart, Coins, LayoutPanelTop } from 'lucide-react';
 import { DocSection } from '../layout/DocSection';
 import { DocLink } from '../layout/DocLink';
 
@@ -84,7 +84,7 @@ export const CoreDocumentation: React.FC<CoreDocumentationProps> = ({ onDocLinkC
         
         <Separator />
         
-        <DocSection icon={<ChartLine className="h-5 w-5 text-green-500" />} title="Market Analysis">
+        <DocSection icon={<LineChart className="h-5 w-5 text-green-500" />} title="Market Analysis">
           <div className="grid gap-3 mt-2">
             <DocLink href="/docs/market-analysis/valuation" onClick={onDocLinkClick}>
               Vehicle Valuation Tools


### PR DESCRIPTION
## Fix for Icon Import Issue

This PR fixes the build error that occurred during deployment:

```
error during build:
src/components/documentation/guides/CoreDocumentation.tsx (5:95): "ChartLine" is not exported by "node_modules/lucide-react/dist/esm/lucide-react.js", imported by "src/components/documentation/guides/CoreDocumentation.tsx".
```

### Changes:

- Replaced the unavailable `ChartLine` icon with the existing `LineChart` icon from the Lucide icon library
- This is a direct substitution that maintains the same visual effect

The issue was related to differences in available icons between different versions of lucide-react. The `LineChart` icon is a standard component that exists in the current version and serves the same purpose.

This fix should allow the build to complete successfully and deployments to proceed without errors.