### PR TITLE
Fix: Replace unavailable ChartBar icon with BarChart2 icon

### DIFF
--- a/src/components/parts/BudgetPlanner.tsx
+++ b/src/components/parts/BudgetPlanner.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useToast } from '@/hooks/use-toast';
-import { ChartBar, DollarSign, ChartPie, Calendar } from 'lucide-react';
+import { BarChart2, DollarSign, ChartPie, Calendar } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -107,7 +107,7 @@ const BudgetPlanner = () => {
             <CardContent className="p-6">
               <div className="flex items-center space-x-4">
                 <div className="p-2 bg-green-100 rounded-full">
-                  <ChartBar className="h-6 w-6 text-green-600" />
+                  <BarChart2 className="h-6 w-6 text-green-600" />
                 </div>
                 <div>
                   <p className="text-sm font-medium text-muted-foreground">Actual Spending</p>


### PR DESCRIPTION
## Fix for Another Icon Import Issue

This PR fixes another build error that occurred during deployment:

```
error during build:
src/components/parts/BudgetPlanner.tsx (5:9): "ChartBar" is not exported by "node_modules/lucide-react/dist/esm/lucide-react.js", imported by "src/components/parts/BudgetPlanner.tsx".
```

### Changes:

- Replaced the unavailable `ChartBar` icon with the existing `BarChart2` icon from the Lucide icon library
- This is a direct substitution that maintains the same visual effect in the Budget Planner component

This is the second icon fix we've had to make (after the `ChartLine` → `LineChart` fix in PR #24). The issue is related to differences in available icons between different versions of lucide-react. The `BarChart2` icon is a standard component that exists in the current version and serves the same purpose.

This fix should allow the build to complete successfully and deployments to proceed without errors.