### PR TITLE
Fix toast export issue causing build failure

### DIFF
--- a/src/components/ui/use-toast.ts
+++ b/src/components/ui/use-toast.ts
@@ -1,3 +1,10 @@
-import { useToast, toast } from "@/hooks/use-toast";
+import { useToast } from "@/hooks/use-toast";
 
-export { useToast, toast };
+// Re-export the useToast hook
+export { useToast };
+
+// Re-export the toast function from the hook
+export const toast = (props: Parameters<ReturnType<typeof useToast>['toast']>[0]) => {
+  const { toast } = useToast();
+  return toast(props);
+};


### PR DESCRIPTION
## Description
This PR fixes the build error reported in Vercel deployment:

```
src/components/ui/use-toast.ts (1:19): "toast" is not exported by "src/hooks/use-toast.ts", imported by "src/components/ui/use-toast.ts".
```

## Root Cause
The issue was that `toast` is not directly exported from `hooks/use-toast.ts`. Instead, it's a function that's part of the object returned by the `useToast` hook.

## Fix
Modified `components/ui/use-toast.ts` to:
1. Import only the `useToast` hook
2. Re-export the `useToast` hook
3. Create a wrapper function that accesses and calls the `toast` function from the hook

This approach maintains the expected API while fixing the build error.

## Testing
This change should allow the Vercel build to complete successfully.
