### PR TITLE
Fix Twitch authentication redirect issue

### DIFF
--- a/src/components/streaming/services/config/twitchConfig.ts
+++ b/src/components/streaming/services/config/twitchConfig.ts
@@ -17,9 +17,17 @@ export const getClientId = (): string | null => {
 
 /**
  * Gets the redirect URI for OAuth
+ * Uses a hardcoded URL for deployed environments to avoid lovable.ai redirect issues
  */
 export const getRedirectUri = (): string => {
-  return `${window.location.origin}/streaming`;
+  // For local development
+  if (window.location.hostname === 'localhost') {
+    return `${window.location.origin}/streaming`;
+  }
+  
+  // For production, use a hardcoded URL to nuke-kohl.vercel.app
+  // This ensures the auth callback always goes to the right place
+  return 'https://nuke-kohl.vercel.app/streaming';
 };
 
 /**


### PR DESCRIPTION
## Description
This PR fixes the Twitch authentication issue where clicking "Connect Twitch Account" redirects to lovable.ai instead of Twitch.

## Problem
When deployed to lovable.ai, the Twitch authentication redirects to the current domain rather than handling the full OAuth flow. This breaks the authentication flow and prevents users from connecting their Twitch accounts.

## Solution
Modified the `getRedirectUri` function in `twitchConfig.ts` to:
1. Use the normal origin URL for localhost (for development purposes)
2. Use a hardcoded Vercel URL (`https://nuke-kohl.vercel.app/streaming`) for production deployments

This ensures that:
- The Twitch OAuth flow redirects back to a consistent URL that's registered with Twitch
- The application can properly handle the OAuth callback without domain issues
- Users can successfully complete the Twitch authentication

## Testing
1. In local development, the behavior remains the same
2. In production, the Twitch authentication now directs to Twitch instead of lovable.ai
3. After authentication, users are redirected back to the Vercel app

## Related Issues
Resolves the issue where Twitch connect button redirects to lovable.ai instead of initiating the Twitch OAuth flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the authentication redirection process to differentiate between local development and production environments.
  - Production users now experience a stable sign-in process with a consistent authentication path, reducing potential login issues.
  - Local users continue to enjoy dynamic redirection tailored for development.
  - This improvement helps maintain a smooth sign-in workflow and minimizes disruptions for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->