### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.156.1",
     "vaul": "^0.7.9",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "validator": "^13.12.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.0",

--- a/src/pages/AddVehicle.tsx
+++ b/src/pages/AddVehicle.tsx
@@ -12,6 +12,7 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ImageIcon, LinkIcon } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
+import { isURL } from 'validator';
 
 function AddVehicle() {
   const navigate = useNavigate();
@@ -139,9 +140,17 @@ function AddVehicle() {
   // Handle URL input
   const handleUrlInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     const url = event.target.value;
-    setImagePreview(url);
-    form.setValue('image', url);
-    setIsFormModified(true);
+    if (isURL(url)) {
+      setImagePreview(url);
+      form.setValue('image', url);
+      setIsFormModified(true);
+    } else {
+      toast({
+        title: "Invalid URL",
+        description: "Please enter a valid image URL.",
+        status: "error",
+      });
+    }
   };
 
   // Detect form changes


### PR DESCRIPTION
Potential fix for [https://github.com/sss97133/nuke/security/code-scanning/8](https://github.com/sss97133/nuke/security/code-scanning/8)

To fix the problem, we need to ensure that the `imagePreview` variable is properly sanitized before being used as the `src` attribute of the `img` tag. This can be achieved by validating that the input is a well-formed URL. We can use a library like `validator` to perform this validation.

1. Install the `validator` library.
2. Import the `isURL` function from the `validator` library.
3. Use the `isURL` function to validate the `url` before setting it to `imagePreview`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
