### PR TITLE
Fix: Remove incorrect status filter from team_members query

### DIFF
--- a/src/components/dashboard/StatsOverview.tsx
+++ b/src/components/dashboard/StatsOverview.tsx
@@ -52,11 +52,10 @@ const StatsOverview = () => {
             .eq('user_id', user.id)
             .in('status', ['pending', 'in_progress']),
             
-          // Fetch team members
+          // Fetch team members - removed the status filter as it doesn't exist in the schema
           supabase
             .from('team_members')
             .select('id')
-            .eq('status', 'active')
         ]);
         
         // Extract data from results handling potential failures


### PR DESCRIPTION

## Issue Description

The dashboard has been showing 500 (Internal Server Error) when trying to fetch data from the `team_members` table. 

## Root Cause Analysis

After reviewing the code and database schema, I identified that the error occurred because:

1. In `StatsOverview.tsx`, we were querying the `team_members` table with a `.eq('status', 'active')` filter
2. According to the database schema in `types.ts`, the `team_members` table doesn't have a `status` column
3. This mismatch between the query and actual schema caused Supabase to return a 500 error

## Changes Made

1. Removed the incorrect status filter from the team_members query in `StatsOverview.tsx`
2. Left the rest of the query intact to maintain functionality

## Testing

After these changes, the dashboard should load properly without throwing 500 errors. The team members count will now include all team members, not just those with a status of "active" (which wasn't possible anyway since the column doesn't exist).

## Next Steps

Consider one of these options for a more comprehensive fix:
1. Add a `status` column to the `team_members` table if filtering by status is desired
2. Update other similar queries in the codebase that might have the same issue
