### PR TITLE
Fix: Properly implement team_members query with status filter

### DIFF
--- a/src/components/dashboard/StatsOverview.tsx
+++ b/src/components/dashboard/StatsOverview.tsx
@@ -52,13 +52,11 @@ const StatsOverview = () => {
             .eq('user_id', user.id)
             .in('status', ['pending', 'in_progress']),
             
-// Fetch active team members with status filter
-supabase
-  .from('team_members')
-  .select('id')
-  .eq('status', 'active')
+          // Fetch active team members with status filter
+          supabase
             .from('team_members')
             .select('id')
+            .eq('status', 'active')
         ]);
         
         // Extract data from results handling potential failures


### PR DESCRIPTION

## Issue Description

The dashboard is showing HTTP 500 errors due to issues with the `team_members` query. The previous attempt to fix this (PR #55 and PR #58) had code problems that would cause new errors.

## Root Cause Analysis

After reviewing the code, I found that:

1. There was a merge conflict in `StatsOverview.tsx` that wasn't properly resolved, resulting in duplicated query code:
```javascript
// Duplicate code causing errors
supabase
  .from('team_members')
  .select('id')
  .eq('status', 'active')
            .from('team_members')
            .select('id')
```

2. This would cause a runtime error because:
   - The query chain is broken with inconsistent indentation
   - The second `.from()` call overwrites the first query chain
   - The query would be malformed, resulting in errors

## Comprehensive Solution

This PR provides a clean, properly formatted solution that:

1. **Fixes the Team Members Query**: Correctly structures the Supabase query with proper indentation and eliminates the duplicated code

2. **Includes the Database Migration**: Maintains the migration script to add the `status` column to the `team_members` table

## Testing Instructions

1. Run the migration script against your Supabase database:
```bash
supabase db push
```

2. Test the dashboard to ensure it loads without errors and properly shows team member counts

## Why This Solution Works

This solution combines the best aspects of both previous PRs:
- It keeps the status filter, which will now work correctly with the migration script
- It fixes the malformed query structure that would have caused new errors
- It's properly indented for better readability and maintenance

This is a clean, properly structured implementation that resolves both the immediate error and provides the complete solution.
