### PR TITLE
Fix oauth redirect to vercel

### DIFF
--- a/nuke_frontend/src/components/auth/Login.tsx
+++ b/nuke_frontend/src/components/auth/Login.tsx
@@ -133,12 +133,9 @@ const Login = () => {
       setError(null);
       setLoading(true);
       
-      // For remote Supabase, let it handle the redirect automatically
-      // For local development, specify the local callback
-      const isLocalSupabase = import.meta.env.VITE_SUPABASE_URL?.includes('localhost');
-      const options = isLocalSupabase 
-        ? { redirectTo: `${window.location.origin}/auth/callback` }
-        : {}; // Let Supabase handle the redirect for remote instances
+      // Always specify an explicit redirect so production deployments on Vercel
+      // return to the correct origin regardless of Supabase Site URL
+      const options = { redirectTo: `${window.location.origin}/auth/callback` };
       
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'github',

--- a/nuke_frontend/src/pages/DataDiagnostic.tsx
+++ b/nuke_frontend/src/pages/DataDiagnostic.tsx
@@ -50,7 +50,8 @@ const DataDiagnostic: React.FC = () => {
 
   const forceLogin = async () => {
     const { error } = await supabase.auth.signInWithOAuth({
-      provider: 'google'
+      provider: 'google',
+      options: { redirectTo: `${window.location.origin}/auth/callback` }
     });
     if (error) console.error('Login error:', error);
   };


### PR DESCRIPTION
Update OAuth redirect URLs to always use the current origin, fixing Vercel deployments redirecting to localhost.

Previously, the OAuth flow for GitHub login conditionally set `redirectTo` only for local Supabase, relying on Supabase's "Site URL" for remote instances. This caused Vercel deployments to redirect to `localhost:5174` after login. By explicitly setting `redirectTo` to `window.location.origin` for both GitHub and Google logins, users are now correctly returned to the deployed domain.

---
<a href="https://cursor.com/background-agent?bcId=bc-29f31ea4-ebb0-46d1-bb9b-27db51994ad7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29f31ea4-ebb0-46d1-bb9b-27db51994ad7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

