### PR TITLE
Fix broken image links on mobile

### DIFF
--- a/nuke_frontend/src/App.tsx
+++ b/nuke_frontend/src/App.tsx
@@ -233,6 +233,7 @@ function App() {
             
             {/* Vehicle Management */}
             <Route path="/vehicle/:vehicleId" element={<VehicleProfile />} />
+            {/* Alias route to ensure legacy /vehicles/:id works */}
             <Route path="/vehicle/:vehicleId/edit" element={<EditVehicle />} />
             {/* <Route path="/vehicle/:vehicleId/date-images" element={<VehicleDateImages />} /> */}
             <Route path="/vehicle-approval/:extractionId" element={<VehicleApproval />} />
@@ -259,7 +260,8 @@ function App() {
             <Route path="/vehicle/:vehicleId/moderate" element={<VehicleModerationDashboard />} />
             <Route path="/vehicle/:vehicleId/contribute" element={<VehicleContributionForm />} />
             <Route path="/vehicle-tasks/:vehicleId" element={<VehicleTasks />} />
-            <Route path="/vehicles/:id" element={<VehicleProfile />} />
+            {/* Additional alias: /vehicles/:id should resolve to VehicleProfile */}
+            <Route path="/vehicles/:vehicleId" element={<VehicleProfile />} />
             {/* <Route path="/public/:slug" element={<PublicVehicleProfile />} /> */}
             
             {/* Legacy redirects */}

--- a/nuke_frontend/src/components/feed/ContentCard.tsx
+++ b/nuke_frontend/src/components/feed/ContentCard.tsx
@@ -75,7 +75,27 @@ const ContentCard = ({ item, viewMode = 'gallery', denseMode = false }: ContentC
   };
 
   const handleImageClick = (e: React.MouseEvent) => {
-    e.stopPropagation(); // Prevent card click
+    e.stopPropagation();
+    // Prefer navigating to the vehicle profile when possible
+    if (item.type === 'vehicle') {
+      window.location.href = `/vehicle/${item.id}`;
+      return;
+    }
+    if (item.type === 'image') {
+      const vid = (item as any)?.metadata?.vehicle_id;
+      if (vid) {
+        window.location.href = `/vehicle/${vid}`;
+        return;
+      }
+    }
+    if (item.type === 'timeline_event') {
+      const vid = (item as any)?.metadata?.vehicle_id;
+      if (vid) {
+        window.location.href = `/vehicle/${vid}?t=timeline&event=${item.id}`;
+        return;
+      }
+    }
+    // Fallback to lightbox if we can't infer a vehicle
     setLightboxOpen(true);
   };
 
@@ -88,23 +108,31 @@ const ContentCard = ({ item, viewMode = 'gallery', denseMode = false }: ContentC
     });
 
     // Navigate to detailed view based on content type
-    const baseUrl = '/';
     switch (item.type) {
       case 'vehicle':
-        window.location.href = `${baseUrl}vehicle/${item.id}`;
+        window.location.href = `/vehicle/${item.id}`;
         break;
       case 'image':
-        window.location.href = `${baseUrl}images/${item.id}`;
+        {
+          const vid = (item as any)?.metadata?.vehicle_id;
+          if (vid) {
+            window.location.href = `/vehicle/${vid}`;
+          } else {
+            // If no vehicle association, open the image lightbox instead of 404
+            setLightboxOpen(true);
+          }
+        }
         break;
       case 'shop':
-        window.location.href = `${baseUrl}shops/${item.id}`;
+        window.location.href = `/shops/${item.id}`;
         break;
       case 'timeline_event': {
         const vid = (item as any)?.metadata?.vehicle_id;
         if (vid) {
-          window.location.href = `${baseUrl}vehicle/${vid}?t=timeline&event=${item.id}`;
+          window.location.href = `/vehicle/${vid}?t=timeline&event=${item.id}`;
         } else {
-          window.location.href = `${baseUrl}events/${item.id}`;
+          // No dedicated timeline event route; fall back to lightbox
+          setLightboxOpen(true);
         }
         break;
       }


### PR DESCRIPTION
Add route aliases and update image/card click handlers to fix mobile 404s and consistently navigate to vehicle profiles.

Users frequently encountered 404 errors on mobile when tapping images, expecting to go to the vehicle profile. This was due to inconsistent routing paths (e.g., `/vehicle/:id` vs `/vehicles/:id`) and image click handlers not always directing to the vehicle profile. The changes ensure that both `/vehicle/:id` and `/vehicles/:id` resolve to the `VehicleProfile` component and that tapping an image or content card prioritizes navigation to the associated vehicle profile, falling back to a lightbox only when a vehicle ID cannot be determined.

---
<a href="https://cursor.com/background-agent?bcId=bc-81120963-66fd-42ba-9434-0191ae508214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-81120963-66fd-42ba-9434-0191ae508214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

