### PR TITLE
Investigate and fix blank mobile pages

### DIFF
--- a/nuke_frontend/src/components/util/ErrorBoundary.tsx
+++ b/nuke_frontend/src/components/util/ErrorBoundary.tsx
@@ -20,13 +20,11 @@ export default class ErrorBoundary extends React.Component<React.PropsWithChildr
   render() {
     if (this.state.hasError) {
       return (
-        <div className="container compact">
-          <div className="main">
-            <div className="card"><div className="card-body">
-              <div className="text">An error occurred rendering this section.</div>
-              {this.state.message && <div className="text text-small text-muted" style={{ marginTop: 6 }}>{this.state.message}</div>}
-            </div></div>
-          </div>
+        <div style={{ padding: 12 }}>
+          <div className="card"><div className="card-body">
+            <div className="text">An error occurred rendering this section.</div>
+            {this.state.message && <div className="text text-small text-muted" style={{ marginTop: 6 }}>{this.state.message}</div>}
+          </div></div>
         </div>
       );
     }

--- a/nuke_frontend/src/index.css
+++ b/nuke_frontend/src/index.css
@@ -1,6 +1,21 @@
 @import './design-system.css';
 @import './styles/windows95.css';
 
+/* Global safeguards to prevent blank screens on mobile */
+html, body, #root {
+  min-height: 100%;
+}
+
+#root {
+  display: block; /* ensure root always lays out children */
+}
+
+@media (max-width: 768px) {
+  body, html {
+    background: var(--grey-100, #f5f5f5);
+  }
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/nuke_frontend/src/main.tsx
+++ b/nuke_frontend/src/main.tsx
@@ -2,13 +2,16 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import ErrorBoundary from './components/util/ErrorBoundary'
 
 // Debug: verify that main.tsx is executing in the browser
 console.log('[main] starting application bootstrap');
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 )
 


### PR DESCRIPTION
Implement a global ErrorBoundary and add CSS safeguards for mobile layout.

This PR prevents blank pages on mobile by catching render errors and ensuring the root element always lays out and paints a background, reducing perceived white-out during slow or failed renders.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c0bf58e-0700-4b2d-9d03-ae71a21a4685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c0bf58e-0700-4b2d-9d03-ae71a21a4685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

