### PR TITLE
Fix mobile profile session error

### DIFF
--- a/nuke_frontend/src/components/mobile/MobileVehicleProfile.tsx
+++ b/nuke_frontend/src/components/mobile/MobileVehicleProfile.tsx
@@ -95,7 +95,7 @@ export const MobileVehicleProfile: React.FC<MobileVehicleProfileProps> = ({ vehi
       {/* Scrollable Content */}
       <div style={styles.content}>
         {activeTab === 'overview' && (
-          <MobileOverviewTab vehicleId={vehicleId} vehicle={vehicle} onTabChange={setActiveTab} />
+          <MobileOverviewTab vehicleId={vehicleId} vehicle={vehicle} session={session} onTabChange={setActiveTab} />
         )}
         {activeTab === 'timeline' && (
           <MobileTimelineTab vehicleId={vehicleId} onEventClick={setSelectedEvent} />
@@ -119,7 +119,7 @@ export const MobileVehicleProfile: React.FC<MobileVehicleProfileProps> = ({ vehi
   );
 };
 
-const MobileOverviewTab: React.FC<{ vehicleId: string; vehicle: any; onTabChange: (tab: string) => void }> = ({ vehicleId, vehicle, onTabChange }) => {
+const MobileOverviewTab: React.FC<{ vehicleId: string; vehicle: any; session: any; onTabChange: (tab: string) => void }> = ({ vehicleId, vehicle, session, onTabChange }) => {
   const [stats, setStats] = useState<any>(null);
   const [vehicleImages, setVehicleImages] = useState<string[]>([]);
 


### PR DESCRIPTION
Pass the `session` prop to `MobileOverviewTab` to resolve the "Can't find variable: session" error on mobile profile pages.

The `MobileOverviewTab` component was attempting to access a `session` variable that was not being passed to it as a prop, leading to a runtime error when a user clicked on a profile in the mobile view. This change ensures `session` is correctly provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-815f4f65-c3ea-4951-83dd-d59c70a42a0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-815f4f65-c3ea-4951-83dd-d59c70a42a0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

