### PR TITLE
Debug rendering error with hooks

### DIFF
--- a/nuke_frontend/src/components/mobile/MobileAddVehicle.tsx
+++ b/nuke_frontend/src/components/mobile/MobileAddVehicle.tsx
@@ -9,6 +9,7 @@
 import React, { useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 // import { useAuth } from '../../contexts/AuthContext'; // Not used
+import { useAuth } from '../../hooks/useAuth';
 import { ImageUploadService } from '../../services/imageUploadService';
 import { supabase } from '../../lib/supabase';
 import '../../design-system.css';

--- a/nuke_frontend/src/pages/add-vehicle/AddVehicle.tsx
+++ b/nuke_frontend/src/pages/add-vehicle/AddVehicle.tsx
@@ -27,16 +27,6 @@ const AddVehicle: React.FC<AddVehicleProps> = ({
   onSuccess 
 }) => {
   const isMobile = useIsMobile();
-  
-  // If mobile, use mobile-optimized version
-  if (isMobile) {
-    return (
-      <MobileAddVehicle 
-        onClose={onClose}
-        onSuccess={onSuccess}
-      />
-    );
-  }
   const navigate = useNavigate();
   const [user, setUser] = useState<any>(null);
 
@@ -972,6 +962,16 @@ Redirecting to vehicle profile...`);
   );
 
   // Render based on mode
+  // IMPORTANT: Determine mobile rendering AFTER all hooks have been called
+  // to preserve consistent hook order across renders
+  if (isMobile) {
+    return (
+      <MobileAddVehicle 
+        onClose={onClose}
+        onSuccess={onSuccess}
+      />
+    );
+  }
   if (mode === 'modal') {
     return (
       <div 


### PR DESCRIPTION
Fix 'Rendered fewer hooks than expected' error by deferring mobile component rendering until after all hooks are declared, and add missing `useAuth` import.

The `AddVehicle.tsx` component had an early return for mobile users based on `useIsMobile()`. This caused a React hook error ("Rendered fewer hooks than expected") because the `isMobile` state could change after initial mount, leading to a different number of hooks being called between renders. The fix moves the conditional rendering of the mobile component to after all hooks have been declared, ensuring consistent hook order. Additionally, `MobileAddVehicle.tsx` was using `useAuth` without importing it, which has been corrected.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b17a3c8-10b1-4784-98dd-a150d54d58b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b17a3c8-10b1-4784-98dd-a150d54d58b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

