### PR TITLE
Check vehicle entry status

### DIFF
--- a/supabase/functions/simple-scraper/index.ts
+++ b/supabase/functions/simple-scraper/index.ts
@@ -53,44 +53,153 @@ serve(async (req) => {
       const priceString = priceMatch ? priceMatch[0] : ''
       const price = priceString ? parseFloat(priceString.replace(/[\$,]/g, '')) : null
 
-      // Extract images - BaT and Craigslist
+      // Extract images - comprehensive multi-pattern extraction
       let images: string[] = []
+      const seen = new Set<string>()
       
-      // BaT images: wp-content/uploads URLs
+      // Helper to add image URL with deduplication and validation
+      const addImage = (imgUrl: string) => {
+        if (!imgUrl || typeof imgUrl !== 'string') return
+        
+        // Clean the URL
+        let cleanUrl = imgUrl
+          .replace(/&#038;/g, '&')
+          .replace(/&amp;/g, '&')
+          .replace(/\\/g, '')
+          .trim()
+        
+        // Skip invalid URLs
+        if (!cleanUrl.startsWith('http')) return
+        if (cleanUrl.includes('data:')) return
+        
+        // Skip icons/logos/small images
+        const lower = cleanUrl.toLowerCase()
+        if (lower.includes('logo') || lower.includes('icon') || lower.includes('avatar')) return
+        if (lower.includes('themes/') || lower.includes('assets/') || lower.includes('.svg')) return
+        if (lower.includes('placeholder') || lower.includes('spinner') || lower.includes('loading')) return
+        if (lower.includes('150x150') || lower.includes('50x50') || lower.includes('32x32')) return
+        if (lower.includes('youtube.com') || lower.includes('vimeo.com')) return
+        
+        // Remove resize parameters for full-size images
+        cleanUrl = cleanUrl
+          .replace(/[?&]w=\d+/g, '')
+          .replace(/[?&]h=\d+/g, '')
+          .replace(/[?&]resize=[^&]*/g, '')
+          .replace(/[?&]fit=[^&]*/g, '')
+          .replace(/[?&]quality=[^&]*/g, '')
+          .replace(/[?&]$/, '')
+          .replace(/-scaled\./g, '.')
+          .replace(/-\d+x\d+\./, '.')  // Remove WordPress thumbnail suffix
+        
+        if (!seen.has(cleanUrl)) {
+          seen.add(cleanUrl)
+          images.push(cleanUrl)
+        }
+      }
+      
+      // PATTERN 1: Standard <img> tags - most common
+      const imgTagRegex = /<img[^>]+src=["']([^"']+)["'][^>]*>/gi
+      let match
+      while ((match = imgTagRegex.exec(html)) !== null) {
+        addImage(match[1])
+      }
+      
+      // PATTERN 2: Data attributes for lazy-loaded images
+      const dataAttrPatterns = [
+        /<[^>]+data-src=["']([^"']+)["'][^>]*>/gi,
+        /<[^>]+data-lazy-src=["']([^"']+)["'][^>]*>/gi,
+        /<[^>]+data-original=["']([^"']+)["'][^>]*>/gi,
+        /<[^>]+data-image=["']([^"']+)["'][^>]*>/gi,
+        /<[^>]+data-srcset=["']([^"'\s]+)/gi,
+      ]
+      for (const pattern of dataAttrPatterns) {
+        while ((match = pattern.exec(html)) !== null) {
+          addImage(match[1])
+        }
+      }
+      
+      // PATTERN 3: Background images in style attributes
+      const bgImageRegex = /background(?:-image)?:\s*url\(["']?([^"')]+)["']?\)/gi
+      while ((match = bgImageRegex.exec(html)) !== null) {
+        addImage(match[1])
+      }
+      
+      // PATTERN 4: JSON data in scripts (galleries, React/Vue data)
+      const jsonPatterns = [
+        /"(?:image|img|src|url|imageUrl|image_url|photo|thumbnail)":\s*"([^"]+\.(?:jpg|jpeg|png|webp))"/gi,
+        /"(?:full|large|original|highres)":\s*"([^"]+\.(?:jpg|jpeg|png|webp))"/gi,
+      ]
+      for (const pattern of jsonPatterns) {
+        while ((match = pattern.exec(html)) !== null) {
+          addImage(match[1])
+        }
+      }
+      
+      // PATTERN 5: BaT-specific - gallery images and wp-content
       if (url.includes('bringatrailer.com')) {
-        const batImageMatches = html.match(/https:\/\/bringatrailer\.com\/wp-content\/uploads\/[^"'\s>]+\.(jpg|jpeg|png)/gi)
-        if (batImageMatches) {
-          images = batImageMatches
-            .map(img => {
-              // Clean HTML entities and resize parameters
-              return img
-                .replace(/&#038;/g, '&')
-                .replace(/&amp;/g, '&')
-                .replace(/[?&]w=\d+/g, '')
-                .replace(/[?&]resize=[^&]*/g, '')
-                .replace(/[?&]fit=[^&]*/g, '')
-                .replace(/[?&]$/, '')
-                .replace(/-scaled\./g, '.')
-            })
-            .filter((url: string) => {
-              const lower = url.toLowerCase()
-              return !lower.includes('themes/') && 
-                     !lower.includes('assets/') && 
-                     !lower.includes('.svg')
-            })
+        // Gallery carousel images
+        const batGalleryRegex = /https?:\/\/(?:bringatrailer\.com|cdn\.bringatrailer\.com)\/wp-content\/uploads\/[^"'\s<>\\]+\.(?:jpg|jpeg|png|webp)/gi
+        while ((match = batGalleryRegex.exec(html)) !== null) {
+          addImage(match[0])
+        }
+        
+        // BaT image CDN patterns
+        const batCdnRegex = /https?:\/\/(?:i\.)?bringatrailer\.com\/[^"'\s<>\\]+\.(?:jpg|jpeg|png|webp)/gi
+        while ((match = batCdnRegex.exec(html)) !== null) {
+          addImage(match[0])
         }
       }
       
-      // Craigslist images
-      if (url.includes('craigslist.org') || images.length === 0) {
-        const craigslistMatches = html.match(/https:\/\/images\.craigslist\.org\/[^"'\s>]+/g)
-        if (craigslistMatches) {
-          images = [...images, ...craigslistMatches]
+      // PATTERN 6: Craigslist-specific - high-res images
+      if (url.includes('craigslist.org')) {
+        const clImageRegex = /https?:\/\/images\.craigslist\.org\/[^"'\s<>\\]+/gi
+        while ((match = clImageRegex.exec(html)) !== null) {
+          let imgUrl = match[0]
+          // Upgrade to high-res if thumbnail
+          imgUrl = imgUrl.replace('_600x450.jpg', '_1200x900.jpg')
+          imgUrl = imgUrl.replace('_300x300.jpg', '_1200x900.jpg')
+          addImage(imgUrl)
         }
       }
       
-      // Remove duplicates and filter
-      images = [...new Set(images)].filter((url: string) => url && typeof url === 'string' && url.trim().length > 0)
+      // PATTERN 7: KSL Cars specific
+      if (url.includes('ksl.com')) {
+        const kslImageRegex = /https?:\/\/(?:img|images)\.ksl\.com\/[^"'\s<>\\]+\.(?:jpg|jpeg|png|webp)/gi
+        while ((match = kslImageRegex.exec(html)) !== null) {
+          addImage(match[0])
+        }
+      }
+      
+      // PATTERN 8: Facebook Marketplace specific
+      if (url.includes('facebook.com')) {
+        const fbImageRegex = /https?:\/\/(?:scontent|external)[^"'\s<>\\]+\.(?:jpg|jpeg|png|webp)[^"'\s<>\\]*/gi
+        while ((match = fbImageRegex.exec(html)) !== null) {
+          addImage(match[0])
+        }
+      }
+      
+      // PATTERN 9: Generic CDN patterns
+      const cdnPatterns = [
+        /https?:\/\/[^"'\s<>]+\.cloudfront\.net\/[^"'\s<>]+\.(?:jpg|jpeg|png|webp)/gi,
+        /https?:\/\/[^"'\s<>]+\.amazonaws\.com\/[^"'\s<>]+\.(?:jpg|jpeg|png|webp)/gi,
+        /https?:\/\/cdn\.[^"'\s<>]+\/[^"'\s<>]+\.(?:jpg|jpeg|png|webp)/gi,
+      ]
+      for (const pattern of cdnPatterns) {
+        while ((match = pattern.exec(html)) !== null) {
+          addImage(match[0])
+        }
+      }
+      
+      // Filter to keep only likely vehicle images (prioritize larger images)
+      images = images.filter(img => {
+        const lower = img.toLowerCase()
+        // Remove tiny thumbnails
+        if (lower.match(/\/thumb\/|_thumb\.|_t\.|\/s\/|\/xs\/|\/xxs\//)) return false
+        // Remove common non-vehicle images
+        if (lower.includes('profile') && lower.includes('user')) return false
+        if (lower.includes('banner') || lower.includes('header')) return false
+        return true
+      })
 
       // Extract basic vehicle info from title
       let year, make, model
@@ -159,6 +268,25 @@ serve(async (req) => {
         }
       }
 
+      // Log image extraction results
+      console.log(`[simple-scraper] Extracted ${images.length} images from ${url.substring(0, 60)}...`)
+      if (images.length > 0) {
+        console.log(`[simple-scraper] First image: ${images[0].substring(0, 80)}...`)
+      } else {
+        console.log(`[simple-scraper] WARNING: No images found! HTML length: ${html.length}`)
+      }
+
+      // Determine source
+      let source = 'Unknown'
+      if (url.includes('bringatrailer.com')) source = 'Bring a Trailer'
+      else if (url.includes('craigslist.org')) source = 'Craigslist'
+      else if (url.includes('ksl.com')) source = 'KSL Cars'
+      else if (url.includes('facebook.com')) source = 'Facebook Marketplace'
+      else if (url.includes('cargurus.com')) source = 'CarGurus'
+      else if (url.includes('autotrader.com')) source = 'AutoTrader'
+      else if (url.includes('cars.com')) source = 'Cars.com'
+      else if (url.includes('classiccars.com')) source = 'ClassicCars.com'
+
       return {
         title,
         price,
@@ -166,9 +294,8 @@ serve(async (req) => {
         make,
         model: model || 'Unknown',  // Database requires non-empty string
         images,
-        source: url.includes('bringatrailer.com') ? 'Bring a Trailer' : 
-                url.includes('craigslist.org') ? 'Craigslist' : 
-                'Unknown',
+        image_count: images.length, // Explicit count for debugging
+        source,
         listing_url: url,
         html: html.substring(0, 50000), // Store first 50k chars for further processing
         text: html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().substring(0, 10000), // Plain text for AI extraction
@@ -177,6 +304,9 @@ serve(async (req) => {
     }
 
     const extractedData = extractBasicData(html, url)
+    
+    // Log final result summary
+    console.log(`[simple-scraper] Result: ${extractedData.year || '?'} ${extractedData.make || '?'} ${extractedData.model || '?'} - ${extractedData.images?.length || 0} images`)
 
     return new Response(
       JSON.stringify({


### PR DESCRIPTION
Enhance `simple-scraper` image extraction to fix missing photos from target pages.

The previous `simple-scraper` only used limited regex patterns for BaT and Craigslist, failing to capture images from other sources, lazy-loaded images, or images embedded in JSON. This update implements 9 comprehensive patterns, including `<img>` tags, data attributes, background images, JSON data, and CDN-specific patterns, to ensure more reliable image ingestion. Improved logging and an `image_count` return field have also been added for better debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-b987d727-5d92-4dbb-a8ce-b6a929a53422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b987d727-5d92-4dbb-a8ce-b6a929a53422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

