### PR TITLE
fix: capture-phase wheel listener + log-scale histogram (v5)

### DIFF
--- a/nuke_frontend/src/components/map/UnifiedMap.tsx
+++ b/nuke_frontend/src/components/map/UnifiedMap.tsx
@@ -909,7 +909,9 @@ export default function UnifiedMap() {
       bins[idx]++;
     }
     const maxBin = Math.max(...bins, 1);
-    return bins.map(n => n / maxBin);
+    // Log-scale normalization: prevents one dominant bin from flattening all others
+    const logMax = Math.log1p(maxBin);
+    return bins.map(n => logMax > 0 ? Math.log1p(n) / logMax : 0);
   }, [vehicles, timelineRange, visibleRange]);
 
   // --- Date ticks for timeline ---
@@ -943,19 +945,26 @@ export default function UnifiedMap() {
     return ticks;
   }, [timelineRange, visibleRange, timelineZoom, timelineEnabled]);
 
-  // --- Timeline scroll wheel zoom handler (native listener to intercept before deck.gl) ---
+  // --- Timeline scroll wheel zoom handler ---
+  // Must use capture-phase native listener on the timeline CONTAINER (not just histogram)
+  // because deck.gl registers its own capture-phase wheel listener on the canvas.
+  // We attach to the entire bottom timeline bar so any scroll over it is intercepted.
+  const timelineBarRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
-    const el = histogramRef.current;
+    const el = timelineBarRef.current;
     if (!el) return;
     const handler = (e: WheelEvent) => {
+      // Only zoom timeline when timeline is enabled and histogram is showing
+      if (!histogramRef.current) return;
       e.preventDefault();
       e.stopPropagation();
       e.stopImmediatePropagation();
       const delta = e.deltaY > 0 ? -1 : 1;
       setTimelineZoom(z => Math.max(1, Math.min(20, z + delta * 0.5)));
     };
-    el.addEventListener('wheel', handler, { passive: false });
-    return () => el.removeEventListener('wheel', handler);
+    // Capture phase = fires BEFORE deck.gl's bubble-phase handler
+    el.addEventListener('wheel', handler, { capture: true, passive: false });
+    return () => el.removeEventListener('wheel', handler, { capture: true } as any);
   });
 
   const filteredVehicles = useMemo(() => {
@@ -1964,7 +1973,7 @@ export default function UnifiedMap() {
         </div>
 
         {/* Timeline slider — bottom center */}
-        <div style={{
+        <div ref={timelineBarRef} style={{
           position: 'absolute', bottom: 10, left: 10, right: 10, zIndex: 1000,
           display: 'flex', alignItems: 'center', gap: 10,
           background: 'var(--surface-glass)', border: '1px solid var(--border)',


### PR DESCRIPTION
## What

Two production bugs in the UnifiedMap timeline:

### 1. Scrolling over histogram zooms the map instead of the timeline
**Root cause:** deck.gl v9 registers its own wheel listener in the **capture phase**. Our previous fix used `addEventListener('wheel', handler)` (bubble phase), which fires AFTER deck.gl already processes the event — so `stopImmediatePropagation()` has no effect.

**Fix:** Added `timelineBarRef` on the timeline bar container and registered a capture-phase listener: `el.addEventListener('wheel', handler, { capture: true, passive: false })`. This fires BEFORE deck.gl's handler, letting us intercept and block the event.

### 2. Histogram bars are flat/invisible
**Root cause:** Vehicle dates span Sep 1970 – Mar 2026 (56 years) but most vehicles cluster in 2020-2026. With linear normalization (`n / maxBin`), one dominant bin gets ~1.0 and everything else rounds to ~0.

**Fix:** Replaced with log-scale normalization: `Math.log1p(n) / Math.log1p(maxBin)`. This preserves visibility of smaller bins while still showing relative magnitude.

## Testing
- Scroll wheel over timeline histogram → should zoom timeline range, NOT move the map
- Histogram bars should be visibly tall for bins with data, not flattened to invisible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeline histogram visualization with adjusted bin scaling for better data representation
  * Enhanced wheel zoom responsiveness on the timeline
  * Refined event detection for timeline bar wheel interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->