### PR TITLE
feat: Professional wiring workspace with 7 features

### DIFF
--- a/nuke_frontend/src/components/wiring/BulkEditPanel.tsx
+++ b/nuke_frontend/src/components/wiring/BulkEditPanel.tsx
@@ -1,0 +1,267 @@
+// BulkEditPanel.tsx — Bulk property editor for multi-selected devices
+// Shows shared/mixed attributes and allows batch updates.
+
+import React, { useCallback, useMemo, useState } from 'react';
+import type { ManifestDevice } from './overlayCompute';
+import { supabase } from '../../lib/supabase';
+import { LOCATION_ZONES } from './harnessConstants';
+
+interface Props {
+  devices: ManifestDevice[];
+  selectedIds: Set<string>;
+  onClose: () => void;
+  onUpdate: (ids: string[], updates: Partial<ManifestDevice>) => void;
+}
+
+const label: React.CSSProperties = {
+  fontSize: '8px', textTransform: 'uppercase', letterSpacing: '0.5px',
+  color: '#8888aa', fontWeight: 700, fontFamily: 'Arial',
+};
+const val: React.CSSProperties = {
+  fontSize: '10px', fontFamily: '"Courier New", monospace', fontWeight: 700,
+  color: '#e0e0e8',
+};
+const row: React.CSSProperties = {
+  display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+  padding: '4px 0', borderBottom: '1px solid #2a2a5e', gap: 8,
+};
+
+const STATUS_OPTIONS = ['planned', 'ordered', 'received', 'installed', 'wired', 'tested'];
+
+export function BulkEditPanel({ devices, selectedIds, onClose, onUpdate }: Props) {
+  const selected = useMemo(() => devices.filter(d => selectedIds.has(d.id)), [devices, selectedIds]);
+
+  const [saving, setSaving] = useState(false);
+  const [edits, setEdits] = useState<Record<string, string | boolean | null>>({});
+
+  // Compute shared/mixed attributes
+  const attributes = useMemo(() => {
+    const attrs: { key: string; label: string; value: string; isMixed: boolean; options?: string[] }[] = [];
+
+    // Location zone
+    const zones = [...new Set(selected.map(d => d.location_zone || ''))];
+    attrs.push({
+      key: 'location_zone', label: 'ZONE',
+      value: zones.length === 1 ? (zones[0] || '—') : '(MIXED)',
+      isMixed: zones.length > 1,
+      options: LOCATION_ZONES.map(z => z.value),
+    });
+
+    // Status
+    const statuses = [...new Set(selected.map(d => d.status || ''))];
+    attrs.push({
+      key: 'status', label: 'STATUS',
+      value: statuses.length === 1 ? (statuses[0] || '—') : '(MIXED)',
+      isMixed: statuses.length > 1,
+      options: STATUS_OPTIONS,
+    });
+
+    // Purchased
+    const purchased = [...new Set(selected.map(d => d.purchased))];
+    attrs.push({
+      key: 'purchased', label: 'PURCHASED',
+      value: purchased.length === 1 ? (purchased[0] ? 'YES' : 'NO') : '(MIXED)',
+      isMixed: purchased.length > 1,
+      options: ['true', 'false'],
+    });
+
+    // PDM channel group
+    const groups = [...new Set(selected.map(d => d.pdm_channel_group || ''))];
+    attrs.push({
+      key: 'pdm_channel_group', label: 'PDM GROUP',
+      value: groups.length === 1 ? (groups[0] || '—') : '(MIXED)',
+      isMixed: groups.length > 1,
+    });
+
+    return attrs;
+  }, [selected]);
+
+  // Shared category summary
+  const categories = useMemo(() => [...new Set(selected.map(d => d.device_category))], [selected]);
+  const zones = useMemo(() => [...new Set(selected.map(d => d.location_zone))], [selected]);
+
+  const handleApply = useCallback(async () => {
+    if (Object.keys(edits).length === 0) return;
+    setSaving(true);
+
+    const ids = [...selectedIds];
+    const updates: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(edits)) {
+      if (key === 'purchased') {
+        updates[key] = value === 'true' || value === true;
+      } else {
+        updates[key] = value || null;
+      }
+    }
+
+    // Save to DB
+    await supabase
+      .from('vehicle_build_manifest')
+      .update(updates)
+      .in('id', ids);
+
+    // Update local state
+    onUpdate(ids, updates as Partial<ManifestDevice>);
+    setSaving(false);
+    setEdits({});
+  }, [edits, selectedIds, onUpdate]);
+
+  return (
+    <div style={{
+      position: 'absolute', right: 0, top: 0, width: 320, height: '100%', zIndex: 10,
+      background: '#1e1e32', borderLeft: '2px solid #2a2a5e',
+      overflowY: 'auto', fontFamily: 'Arial, sans-serif',
+    }}>
+      {/* Header */}
+      <div style={{
+        padding: '10px 14px', borderBottom: '2px solid #2a2a5e',
+        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+      }}>
+        <div>
+          <div style={{ fontSize: '11px', fontWeight: 700, color: '#00ddff' }}>
+            BULK EDIT
+          </div>
+          <div style={{ fontSize: '8px', color: '#8888aa', fontWeight: 700, letterSpacing: '0.5px', marginTop: 2 }}>
+            {selected.length} DEVICES SELECTED
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          style={{
+            width: 24, height: 24, border: '2px solid #2a2a5e',
+            background: 'transparent', cursor: 'pointer', fontSize: '12px',
+            fontWeight: 700, color: '#8888aa', lineHeight: '20px', textAlign: 'center',
+          }}
+        >×</button>
+      </div>
+
+      <div style={{ padding: '10px 14px' }}>
+        {/* Summary */}
+        <div style={{ marginBottom: 12 }}>
+          <div style={{ ...label, fontSize: '7px', letterSpacing: '1px', marginBottom: 4, paddingBottom: 3, borderBottom: '2px solid #e0e0e8' }}>
+            SELECTION SUMMARY
+          </div>
+          <div style={row}>
+            <span style={label}>CATEGORIES</span>
+            <span style={{ ...val, fontSize: '8px' }}>
+              {categories.length === 1 ? categories[0] : `${categories.length} MIXED`}
+            </span>
+          </div>
+          <div style={row}>
+            <span style={label}>ZONES</span>
+            <span style={{ ...val, fontSize: '8px' }}>
+              {zones.length === 1 ? (zones[0] || '—').replace(/_/g, ' ') : `${zones.length} MIXED`}
+            </span>
+          </div>
+          <div style={row}>
+            <span style={label}>TOTAL AMPS</span>
+            <span style={val}>{selected.reduce((s, d) => s + (d.power_draw_amps || 0), 0).toFixed(1)}A</span>
+          </div>
+          <div style={row}>
+            <span style={label}>TOTAL COST</span>
+            <span style={val}>${selected.reduce((s, d) => s + (d.price || 0), 0).toLocaleString()}</span>
+          </div>
+        </div>
+
+        {/* Editable attributes */}
+        <div style={{ marginBottom: 12 }}>
+          <div style={{ ...label, fontSize: '7px', letterSpacing: '1px', marginBottom: 4, paddingBottom: 3, borderBottom: '2px solid #e0e0e8' }}>
+            EDIT PROPERTIES
+          </div>
+          {attributes.map(attr => (
+            <div key={attr.key} style={{ ...row, flexDirection: 'column', alignItems: 'stretch', gap: 4 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <span style={label}>{attr.label}</span>
+                <span style={{
+                  ...val, fontSize: '8px',
+                  color: attr.isMixed ? '#ccaa00' : '#e0e0e8',
+                }}>
+                  {edits[attr.key] != null ? String(edits[attr.key]) : attr.value}
+                </span>
+              </div>
+              {attr.options ? (
+                <select
+                  value={edits[attr.key] as string ?? ''}
+                  onChange={e => {
+                    if (e.target.value) {
+                      setEdits(prev => ({ ...prev, [attr.key]: e.target.value }));
+                    } else {
+                      setEdits(prev => {
+                        const next = { ...prev };
+                        delete next[attr.key];
+                        return next;
+                      });
+                    }
+                  }}
+                  style={{
+                    fontSize: '8px', fontFamily: '"Courier New"', fontWeight: 700,
+                    padding: '3px 4px', border: '2px solid #2a2a5e',
+                    background: '#1a1a2e', color: '#e0e0e8', cursor: 'pointer',
+                    textTransform: 'uppercase',
+                  }}
+                >
+                  <option value="">— SET ALL —</option>
+                  {attr.options.map(o => (
+                    <option key={o} value={o}>
+                      {attr.key === 'purchased' ? (o === 'true' ? 'YES' : 'NO') : o.replace(/_/g, ' ')}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  type="text"
+                  placeholder={`SET ${attr.label} FOR ALL`}
+                  value={edits[attr.key] as string ?? ''}
+                  onChange={e => setEdits(prev => ({ ...prev, [attr.key]: e.target.value }))}
+                  style={{
+                    fontSize: '8px', fontFamily: '"Courier New"', fontWeight: 700,
+                    padding: '3px 6px', border: '2px solid #2a2a5e',
+                    background: '#1a1a2e', color: '#e0e0e8', outline: 'none',
+                    textTransform: 'uppercase',
+                  }}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Apply button */}
+        {Object.keys(edits).length > 0 && (
+          <button
+            onClick={handleApply}
+            disabled={saving}
+            style={{
+              width: '100%', padding: '8px',
+              fontSize: '9px', fontWeight: 700, fontFamily: 'Arial',
+              textTransform: 'uppercase', letterSpacing: '0.5px',
+              border: '2px solid #00ddff',
+              background: saving ? '#2a2a5e' : '#00ddff',
+              color: saving ? '#8888aa' : '#1a1a2e',
+              cursor: saving ? 'default' : 'pointer',
+            }}
+          >
+            {saving ? 'SAVING...' : `APPLY TO ${selected.length} DEVICES`}
+          </button>
+        )}
+
+        {/* Selected device list */}
+        <div style={{ marginTop: 12 }}>
+          <div style={{ ...label, fontSize: '7px', letterSpacing: '1px', marginBottom: 4, paddingBottom: 3, borderBottom: '2px solid #e0e0e8' }}>
+            SELECTED DEVICES
+          </div>
+          {selected.map(d => (
+            <div key={d.id} style={{
+              padding: '3px 0', borderBottom: '1px solid #252540',
+              fontSize: '8px', color: '#e0e0e8', fontWeight: 700,
+            }}>
+              {d.device_name}
+              <span style={{ color: '#555577', fontWeight: 400, marginLeft: 6, fontFamily: '"Courier New"', fontSize: '7px' }}>
+                {d.device_category}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/nuke_frontend/src/components/wiring/CommandPalette.tsx
+++ b/nuke_frontend/src/components/wiring/CommandPalette.tsx
@@ -1,0 +1,339 @@
+// CommandPalette.tsx — Cmd+K search-everything overlay
+// Fuzzy searches devices, wires, zones, and actions.
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ManifestDevice, WireSpec } from './overlayCompute';
+
+type ResultCategory = 'DEVICES' | 'WIRES' | 'ZONES' | 'ACTIONS';
+
+interface SearchResult {
+  id: string;
+  category: ResultCategory;
+  label: string;
+  description: string;
+  imageUrl?: string;
+  data?: { deviceId?: string; wireNumber?: number; zone?: string; action?: string };
+}
+
+interface Props {
+  devices: ManifestDevice[];
+  wires: WireSpec[];
+  isOpen: boolean;
+  onClose: () => void;
+  onSelectDevice: (deviceId: string) => void;
+  onSelectWire: (wireNumber: number) => void;
+  onFilterZone: (zone: string) => void;
+  onAction: (action: string) => void;
+}
+
+// Simple fuzzy match — checks if all query chars appear in order in the target
+function fuzzyMatch(query: string, target: string): number {
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  if (t.includes(q)) return 100 - q.length; // Exact substring match scores highest
+  let qi = 0;
+  let score = 0;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      qi++;
+      score += 10;
+      // Bonus for matching at start or after separator
+      if (ti === 0 || t[ti - 1] === ' ' || t[ti - 1] === '_') score += 5;
+    }
+  }
+  return qi === q.length ? score : -1;
+}
+
+const ACTIONS: { id: string; label: string; description: string }[] = [
+  { id: 'export-bom', label: 'Export BOM', description: 'Generate Bill of Materials spreadsheet' },
+  { id: 'export-cutlist', label: 'Export Cut List', description: 'Generate wire cutting list' },
+  { id: 'print-formboard', label: 'Print Formboard', description: 'Print 1:1 formboard layout' },
+  { id: 'reset-view', label: 'Reset View', description: 'Reset zoom and pan to default' },
+];
+
+export function CommandPalette({
+  devices, wires, isOpen, onClose, onSelectDevice, onSelectWire, onFilterZone, onAction,
+}: Props) {
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus input when opened
+  useEffect(() => {
+    if (isOpen) {
+      setQuery('');
+      setSelectedIndex(0);
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [isOpen]);
+
+  // Build search results
+  const results = useMemo((): SearchResult[] => {
+    if (!query.trim()) {
+      // Show recent/popular items when empty
+      const items: SearchResult[] = [];
+      // Show first few devices
+      devices.slice(0, 5).forEach(d => {
+        items.push({
+          id: `device-${d.id}`,
+          category: 'DEVICES',
+          label: d.device_name,
+          description: `${d.device_category} | ${d.location_zone?.replace(/_/g, ' ') || '—'}`,
+          imageUrl: d.product_image_url || undefined,
+          data: { deviceId: d.id },
+        });
+      });
+      // Show zones
+      const zones = [...new Set(devices.map(d => d.location_zone).filter(Boolean))] as string[];
+      zones.forEach(z => {
+        const count = devices.filter(d => d.location_zone === z).length;
+        items.push({
+          id: `zone-${z}`,
+          category: 'ZONES',
+          label: z.replace(/_/g, ' '),
+          description: `${count} devices`,
+          data: { zone: z },
+        });
+      });
+      // Show actions
+      ACTIONS.forEach(a => {
+        items.push({
+          id: `action-${a.id}`,
+          category: 'ACTIONS',
+          label: a.label,
+          description: a.description,
+          data: { action: a.id },
+        });
+      });
+      return items;
+    }
+
+    const items: SearchResult[] = [];
+
+    // Search devices
+    devices.forEach(d => {
+      const fields = [d.device_name, d.manufacturer || '', d.part_number || '', d.device_category || ''];
+      const bestScore = Math.max(...fields.map(f => fuzzyMatch(query, f)));
+      if (bestScore >= 0) {
+        items.push({
+          id: `device-${d.id}`,
+          category: 'DEVICES',
+          label: d.device_name,
+          description: `${d.device_category} | ${d.location_zone?.replace(/_/g, ' ') || '—'} | ${d.manufacturer || ''}`,
+          imageUrl: d.product_image_url || undefined,
+          data: { deviceId: d.id },
+        });
+      }
+    });
+
+    // Search wires
+    wires.forEach(w => {
+      const fields = [w.label, w.from, w.to, w.color, `W${w.wireNumber}`];
+      const bestScore = Math.max(...fields.map(f => fuzzyMatch(query, f)));
+      if (bestScore >= 0) {
+        items.push({
+          id: `wire-${w.wireNumber}`,
+          category: 'WIRES',
+          label: `W${w.wireNumber}: ${w.label}`,
+          description: `${w.from} → ${w.to} | ${w.gauge}AWG ${w.color}`,
+          data: { wireNumber: w.wireNumber },
+        });
+      }
+    });
+
+    // Search zones
+    const zones = [...new Set(devices.map(d => d.location_zone).filter(Boolean))] as string[];
+    zones.forEach(z => {
+      if (fuzzyMatch(query, z.replace(/_/g, ' ')) >= 0) {
+        const count = devices.filter(d => d.location_zone === z).length;
+        items.push({
+          id: `zone-${z}`,
+          category: 'ZONES',
+          label: z.replace(/_/g, ' '),
+          description: `${count} devices`,
+          data: { zone: z },
+        });
+      }
+    });
+
+    // Search actions
+    ACTIONS.forEach(a => {
+      if (fuzzyMatch(query, a.label) >= 0 || fuzzyMatch(query, a.description) >= 0) {
+        items.push({
+          id: `action-${a.id}`,
+          category: 'ACTIONS',
+          label: a.label,
+          description: a.description,
+          data: { action: a.id },
+        });
+      }
+    });
+
+    // Also check for special queries
+    if (fuzzyMatch(query, 'unpurchased') >= 0) {
+      const count = devices.filter(d => !d.purchased).length;
+      items.unshift({
+        id: 'filter-unpurchased',
+        category: 'ACTIONS',
+        label: 'Filter: Unpurchased',
+        description: `Show ${count} unpurchased devices`,
+        data: { action: 'filter-unpurchased' },
+      });
+    }
+
+    return items.slice(0, 30); // Cap results
+  }, [query, devices, wires]);
+
+  // Keyboard navigation
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex(i => Math.min(i + 1, results.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex(i => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const result = results[selectedIndex];
+      if (result) handleSelect(result);
+    } else if (e.key === 'Escape') {
+      onClose();
+    }
+  }, [results, selectedIndex, onClose]);
+
+  const handleSelect = useCallback((result: SearchResult) => {
+    onClose();
+    if (result.data?.deviceId) onSelectDevice(result.data.deviceId);
+    else if (result.data?.wireNumber) onSelectWire(result.data.wireNumber);
+    else if (result.data?.zone) onFilterZone(result.data.zone);
+    else if (result.data?.action) onAction(result.data.action);
+  }, [onClose, onSelectDevice, onSelectWire, onFilterZone, onAction]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, zIndex: 100,
+        background: 'rgba(0, 0, 0, 0.7)', display: 'flex', justifyContent: 'center',
+        paddingTop: '15vh', fontFamily: 'Arial, sans-serif',
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          width: 440, maxHeight: '60vh', display: 'flex', flexDirection: 'column',
+          background: '#1e1e32', border: '2px solid #2a2a5e',
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Search input */}
+        <div style={{ padding: '10px 12px', borderBottom: '2px solid #2a2a5e' }}>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={e => { setQuery(e.target.value); setSelectedIndex(0); }}
+            onKeyDown={handleKeyDown}
+            placeholder="SEARCH DEVICES, WIRES, ZONES, ACTIONS..."
+            style={{
+              width: '100%', fontSize: '11px', fontWeight: 700, fontFamily: 'Arial',
+              textTransform: 'uppercase', letterSpacing: '0.5px',
+              padding: '8px 10px', border: '2px solid #2a2a5e',
+              background: '#1a1a2e', color: '#e0e0e8', outline: 'none',
+            }}
+          />
+        </div>
+
+        {/* Results */}
+        <div style={{ flex: 1, overflowY: 'auto' }}>
+          {results.length === 0 && query && (
+            <div style={{
+              padding: '20px 12px', textAlign: 'center',
+              fontSize: '9px', color: '#555577', fontWeight: 700,
+              textTransform: 'uppercase', letterSpacing: '0.5px',
+            }}>
+              NO RESULTS
+            </div>
+          )}
+
+          {/* Group by category */}
+          {(['DEVICES', 'WIRES', 'ZONES', 'ACTIONS'] as ResultCategory[]).map(cat => {
+            const catResults = results.filter(r => r.category === cat);
+            if (catResults.length === 0) return null;
+            return (
+              <div key={cat}>
+                <div style={{
+                  padding: '6px 12px', fontSize: '7px', fontWeight: 700,
+                  color: '#555577', letterSpacing: '1px',
+                  borderBottom: '1px solid #2a2a5e', background: '#1a1a2e',
+                }}>
+                  {cat}
+                </div>
+                {catResults.map(result => {
+                  const globalIdx = results.indexOf(result);
+                  const isSelected = globalIdx === selectedIndex;
+                  return (
+                    <div
+                      key={result.id}
+                      onClick={() => handleSelect(result)}
+                      onMouseEnter={() => setSelectedIndex(globalIdx)}
+                      style={{
+                        display: 'flex', alignItems: 'center', gap: 8,
+                        padding: '6px 12px', cursor: 'pointer',
+                        background: isSelected ? '#2a2a5e' : 'transparent',
+                        borderBottom: '1px solid #252540',
+                      }}
+                    >
+                      {result.imageUrl && (
+                        <img
+                          src={result.imageUrl}
+                          alt=""
+                          style={{ width: 28, height: 28, objectFit: 'contain', flexShrink: 0, background: '#ffffff' }}
+                          onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                        />
+                      )}
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{
+                          fontSize: '9px', fontWeight: 700, color: '#e0e0e8',
+                          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                        }}>
+                          {result.label}
+                        </div>
+                        <div style={{
+                          fontSize: '7px', color: '#8888aa', fontFamily: '"Courier New"',
+                          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                        }}>
+                          {result.description}
+                        </div>
+                      </div>
+                      {isSelected && (
+                        <span style={{
+                          fontSize: '7px', color: '#00ddff', fontWeight: 700,
+                          fontFamily: '"Courier New"', flexShrink: 0,
+                        }}>
+                          ENTER
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          padding: '6px 12px', borderTop: '2px solid #2a2a5e',
+          display: 'flex', gap: 12, fontSize: '7px', color: '#555577',
+          fontFamily: '"Courier New"', fontWeight: 700,
+        }}>
+          <span>↑↓ NAVIGATE</span>
+          <span>ENTER SELECT</span>
+          <span>ESC CLOSE</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/nuke_frontend/src/components/wiring/FormboardCanvas.tsx
+++ b/nuke_frontend/src/components/wiring/FormboardCanvas.tsx
@@ -1,0 +1,785 @@
+// FormboardCanvas.tsx — Canvas 2D pegboard formboard with connector blocks,
+// wire routing, pin tables (zoom > 4x), DRC indicators, and print enhancement.
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ManifestDevice, WireSpec, PDMChannel } from './overlayCompute';
+import type { DRCDeviceResult } from './useDRC';
+import { supabase } from '../../lib/supabase';
+
+// ── Constants ────────────────────────────────────────────────────────
+const BOARD_W = 200; // inches
+const BOARD_H = 96;  // inches
+const PX_PER_INCH = 10; // base pixels per inch at zoom=1
+const GRID = 1; // 1-inch grid snap
+const CANVAS_W = BOARD_W * PX_PER_INCH;
+const CANVAS_H = BOARD_H * PX_PER_INCH;
+
+const ZONE_COLORS: Record<string, string> = {
+  engine_bay: '#cc2222', firewall: '#cc6600', dash: '#2266cc',
+  doors: '#8822cc', rear: '#22aa44', underbody: '#cc8833',
+};
+
+const DRC_COLORS: Record<string, string> = {
+  pass: '#22aa44', warn: '#ccaa00', fail: '#cc2222',
+};
+
+// ── Pin Cache ────────────────────────────────────────────────────────
+interface PinData {
+  pin_number: string;
+  pin_function: string;
+  default_wire_gauge_awg: number | null;
+  default_wire_color: string | null;
+  connected_to_device: string | null;
+}
+
+// ── Props ────────────────────────────────────────────────────────────
+interface Props {
+  devices: ManifestDevice[];
+  wires: WireSpec[];
+  pdmChannels: PDMChannel[];
+  drcMap: Map<string, DRCDeviceResult>;
+  selectedDeviceId: string | null;
+  selectedDeviceIds: Set<string>;
+  selectedWireId: number | null;
+  onDeviceClick: (id: string, e: React.MouseEvent) => void;
+  onWireClick: (wireNumber: number) => void;
+  vehicleId?: string;
+}
+
+export function FormboardCanvas({
+  devices, wires, pdmChannels, drcMap,
+  selectedDeviceId, selectedDeviceIds, selectedWireId,
+  onDeviceClick, onWireClick, vehicleId,
+}: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Viewport
+  const [zoom, setZoom] = useState(0.6);
+  const [panX, setPanX] = useState(0);
+  const [panY, setPanY] = useState(0);
+  const [isPanning, setIsPanning] = useState(false);
+  const panStart = useRef({ x: 0, y: 0, px: 0, py: 0 });
+
+  // Pin data cache: model → pins
+  const [pinCache, setPinCache] = useState<Map<string, PinData[]>>(new Map());
+  const pendingModels = useRef<Set<string>>(new Set());
+
+  // Loom tab filter
+  const [activeLoom, setActiveLoom] = useState<string | null>(null);
+  const looms = useMemo(() => {
+    const zones = [...new Set(devices.map(d => d.location_zone).filter(Boolean))] as string[];
+    return zones.sort();
+  }, [devices]);
+
+  // Device positions (grid-snapped formboard coordinates)
+  const devicePositions = useMemo(() => {
+    const positions = new Map<string, { x: number; y: number }>();
+    // Group by zone for layout
+    const byZone = new Map<string, ManifestDevice[]>();
+    for (const d of devices) {
+      const zone = d.location_zone || 'dash';
+      const list = byZone.get(zone) || [];
+      list.push(d);
+      byZone.set(zone, list);
+    }
+
+    // Zone X regions on 200" board
+    const zoneRegions: Record<string, { xStart: number; yStart: number }> = {
+      engine_bay: { xStart: 10, yStart: 10 },
+      firewall: { xStart: 45, yStart: 10 },
+      dash: { xStart: 70, yStart: 10 },
+      doors: { xStart: 110, yStart: 10 },
+      rear: { xStart: 145, yStart: 10 },
+      underbody: { xStart: 10, yStart: 55 },
+    };
+
+    byZone.forEach((devs, zone) => {
+      const region = zoneRegions[zone] || { xStart: 100, yStart: 45 };
+      const cols = Math.ceil(Math.sqrt(devs.length));
+      devs.forEach((d, i) => {
+        // Use saved positions if available, otherwise auto-layout
+        if (d.pos_x_pct != null && d.pos_y_pct != null) {
+          const x = Math.round((d.pos_x_pct / 100) * BOARD_W / GRID) * GRID;
+          const y = Math.round((d.pos_y_pct / 100) * BOARD_H / GRID) * GRID;
+          positions.set(d.id, { x, y });
+        } else {
+          const col = i % cols;
+          const row = Math.floor(i / cols);
+          const x = Math.round((region.xStart + col * 4) / GRID) * GRID;
+          const y = Math.round((region.yStart + row * 4) / GRID) * GRID;
+          positions.set(d.id, { x, y });
+        }
+      });
+    });
+    return positions;
+  }, [devices]);
+
+  // Fetch pin data for a device model on demand
+  const fetchPins = useCallback(async (model: string) => {
+    if (pinCache.has(model) || pendingModels.current.has(model)) return;
+    pendingModels.current.add(model);
+    const { data } = await supabase
+      .from('device_pin_maps')
+      .select('pin_number, pin_function, default_wire_gauge_awg, default_wire_color, connected_to_device')
+      .eq('device_model', model)
+      .order('pin_number');
+    if (data) {
+      setPinCache(prev => {
+        const next = new Map(prev);
+        next.set(model, data as PinData[]);
+        return next;
+      });
+    }
+    pendingModels.current.delete(model);
+  }, [pinCache]);
+
+  // Load pins for all visible device models when zoom > 4
+  useEffect(() => {
+    if (zoom < 4) return;
+    const models = [...new Set(devices.map(d => d.model_number).filter(Boolean))] as string[];
+    for (const m of models) {
+      if (!pinCache.has(m)) fetchPins(m);
+    }
+  }, [zoom, devices, pinCache, fetchPins]);
+
+  // ── Drawing ────────────────────────────────────────────────────────
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    // Clear
+    ctx.fillStyle = '#1a1a2e';
+    ctx.fillRect(0, 0, rect.width, rect.height);
+
+    ctx.save();
+    ctx.translate(panX, panY);
+    ctx.scale(zoom, zoom);
+
+    // ── Grid ──
+    ctx.strokeStyle = '#2a2a3e';
+    ctx.lineWidth = 0.5 / zoom;
+    for (let x = 0; x <= CANVAS_W; x += PX_PER_INCH) {
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, CANVAS_H);
+      ctx.stroke();
+    }
+    for (let y = 0; y <= CANVAS_H; y += PX_PER_INCH) {
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(CANVAS_W, y);
+      ctx.stroke();
+    }
+
+    // ── Ruler marks ──
+    ctx.fillStyle = '#555577';
+    ctx.font = `${7 / zoom}px Arial`;
+    ctx.textAlign = 'center';
+    for (let x = 0; x <= BOARD_W; x += 10) {
+      ctx.fillText(`${x}"`, x * PX_PER_INCH, -3);
+    }
+    ctx.textAlign = 'right';
+    for (let y = 0; y <= BOARD_H; y += 10) {
+      ctx.fillText(`${y}"`, -3, y * PX_PER_INCH + 3);
+    }
+
+    // ── Zone boundaries ──
+    const zoneRegions: Record<string, { x: number; y: number; w: number; h: number }> = {
+      engine_bay: { x: 5, y: 5, w: 35, h: 45 },
+      firewall: { x: 42, y: 5, w: 25, h: 45 },
+      dash: { x: 69, y: 5, w: 38, h: 45 },
+      doors: { x: 109, y: 5, w: 33, h: 45 },
+      rear: { x: 144, y: 5, w: 50, h: 45 },
+      underbody: { x: 5, y: 52, w: 189, h: 40 },
+    };
+    for (const [zone, r] of Object.entries(zoneRegions)) {
+      if (activeLoom && activeLoom !== zone) continue;
+      const color = ZONE_COLORS[zone] || '#555577';
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 1.5 / zoom;
+      ctx.setLineDash([4 / zoom, 4 / zoom]);
+      ctx.strokeRect(r.x * PX_PER_INCH, r.y * PX_PER_INCH, r.w * PX_PER_INCH, r.h * PX_PER_INCH);
+      ctx.setLineDash([]);
+      // Zone label
+      ctx.fillStyle = color;
+      ctx.font = `bold ${9 / zoom}px Arial`;
+      ctx.textAlign = 'left';
+      ctx.fillText(zone.replace(/_/g, ' ').toUpperCase(), (r.x + 0.5) * PX_PER_INCH, (r.y + 1.5) * PX_PER_INCH);
+    }
+
+    // ── Wire routing (quadratic bezier) ──
+    const deviceByName = new Map<string, ManifestDevice>();
+    for (const d of devices) deviceByName.set(d.device_name, d);
+
+    for (const wire of wires) {
+      if (activeLoom) {
+        const toDevice = deviceByName.get(wire.to);
+        if (toDevice && toDevice.location_zone !== activeLoom) continue;
+      }
+
+      const toDevice = deviceByName.get(wire.to);
+      if (!toDevice) continue;
+      const toPos = devicePositions.get(toDevice.id);
+      if (!toPos) continue;
+
+      // Source position (PDM or ECU — center-top of board for now)
+      const fromX = wire.from.startsWith('PDM') ? 55 * PX_PER_INCH : 75 * PX_PER_INCH;
+      const fromY = 2 * PX_PER_INCH;
+      const toX = toPos.x * PX_PER_INCH;
+      const toY = toPos.y * PX_PER_INCH;
+
+      const isHighlighted = selectedWireId === wire.wireNumber;
+      const isDimmed = selectedWireId != null && !isHighlighted;
+
+      ctx.beginPath();
+      ctx.moveTo(fromX, fromY);
+      const cpX = (fromX + toX) / 2;
+      const cpY = Math.min(fromY, toY) - 30;
+      ctx.quadraticCurveTo(cpX, cpY, toX, toY);
+
+      if (isHighlighted) {
+        ctx.shadowBlur = 8;
+        ctx.shadowColor = '#00ddff';
+        ctx.strokeStyle = '#00ddff';
+        ctx.lineWidth = 3 / zoom;
+      } else {
+        ctx.shadowBlur = 0;
+        const wireColor = wire.color.includes('RED') ? '#cc4444' :
+          wire.color.includes('GRN') ? '#44aa44' :
+          wire.color.includes('BLU') ? '#4488cc' :
+          wire.color.includes('WHT') ? '#aaaaaa' :
+          wire.color.includes('BLK') ? '#888888' :
+          wire.color.includes('VIO') ? '#9966cc' :
+          wire.color.includes('ORG') ? '#cc8833' :
+          wire.color.includes('YEL') ? '#ccaa33' :
+          wire.color.includes('TAN') ? '#aa8866' :
+          wire.color.includes('PNK') ? '#cc6688' :
+          '#777777';
+        ctx.strokeStyle = wireColor;
+        ctx.lineWidth = 1.5 / zoom;
+        ctx.globalAlpha = isDimmed ? 0.15 : 0.6;
+      }
+      ctx.stroke();
+      ctx.globalAlpha = 1;
+      ctx.shadowBlur = 0;
+    }
+
+    // ── Connector blocks ──
+    const blockW = 3 * PX_PER_INCH;
+    const blockH = 2 * PX_PER_INCH;
+
+    for (const device of devices) {
+      if (activeLoom && device.location_zone !== activeLoom) continue;
+      const pos = devicePositions.get(device.id);
+      if (!pos) continue;
+
+      const px = pos.x * PX_PER_INCH;
+      const py = pos.y * PX_PER_INCH;
+      const isSelected = device.id === selectedDeviceId || selectedDeviceIds.has(device.id);
+      const isDimmed = (selectedDeviceId != null || selectedDeviceIds.size > 0) && !isSelected;
+      const isWireHighlighted = selectedWireId != null && wires.some(w => w.wireNumber === selectedWireId && w.to === device.device_name);
+
+      ctx.globalAlpha = isDimmed && !isWireHighlighted ? 0.25 : 1;
+
+      // Block background
+      const zoneColor = ZONE_COLORS[device.location_zone || ''] || '#444466';
+      ctx.fillStyle = '#252540';
+      ctx.fillRect(px, py, blockW, blockH);
+
+      // Block border
+      if (isSelected) {
+        ctx.strokeStyle = '#00ddff';
+        ctx.lineWidth = 2 / zoom;
+        ctx.setLineDash(selectedDeviceIds.has(device.id) ? [4 / zoom, 2 / zoom] : []);
+      } else if (isWireHighlighted) {
+        ctx.strokeStyle = '#00ddff';
+        ctx.lineWidth = 2 / zoom;
+        ctx.setLineDash([]);
+      } else {
+        ctx.strokeStyle = zoneColor;
+        ctx.lineWidth = 1.5 / zoom;
+        ctx.setLineDash([]);
+      }
+      ctx.strokeRect(px, py, blockW, blockH);
+      ctx.setLineDash([]);
+
+      // Device name
+      ctx.fillStyle = '#e0e0e8';
+      ctx.font = `bold ${7 / zoom}px Arial`;
+      ctx.textAlign = 'left';
+      const name = device.device_name.length > 18 ? device.device_name.slice(0, 17) + '...' : device.device_name;
+      ctx.fillText(name.toUpperCase(), px + 3, py + 8 / zoom);
+
+      // Connector type + pin count
+      ctx.fillStyle = '#8888aa';
+      ctx.font = `${6 / zoom}px "Courier New"`;
+      ctx.fillText(
+        `${device.connector_type || '—'} | ${device.pin_count || 0}p`,
+        px + 3, py + blockH - 5 / zoom,
+      );
+
+      // DRC indicator dot (top-right)
+      const drc = drcMap.get(device.id);
+      if (drc) {
+        const dotR = 3 / zoom;
+        ctx.beginPath();
+        ctx.arc(px + blockW - 5 / zoom, py + 5 / zoom, dotR, 0, Math.PI * 2);
+        ctx.fillStyle = DRC_COLORS[drc.severity];
+        ctx.fill();
+      }
+
+      // Pin count badge (zoom < 4) or pin table (zoom >= 4)
+      if (zoom < 4) {
+        // Small pin count badge
+        if (device.pin_count) {
+          ctx.fillStyle = '#333355';
+          const badgeW = 20 / zoom;
+          const badgeH = 10 / zoom;
+          ctx.fillRect(px + blockW + 2, py, badgeW, badgeH);
+          ctx.strokeStyle = '#555577';
+          ctx.lineWidth = 0.5 / zoom;
+          ctx.strokeRect(px + blockW + 2, py, badgeW, badgeH);
+          ctx.fillStyle = '#8888aa';
+          ctx.font = `bold ${7 / zoom}px "Courier New"`;
+          ctx.textAlign = 'center';
+          ctx.fillText(`${device.pin_count}p`, px + blockW + 2 + badgeW / 2, py + badgeH / 2 + 2.5 / zoom);
+          ctx.textAlign = 'left';
+        }
+      } else {
+        // Full pin table at zoom >= 4
+        const pins = device.model_number ? pinCache.get(device.model_number) : undefined;
+        if (pins && pins.length > 0) {
+          const tableX = px + blockW + 4;
+          const tableY = py;
+          const rowH = 8 / zoom;
+          const colWidths = [18, 50, 16, 22, 40]; // PIN FUNC AWG COLOR TO
+          const tableW = colWidths.reduce((a, b) => a + b, 0) / zoom;
+          const tableH = (pins.length + 1) * rowH;
+
+          // Table background
+          ctx.fillStyle = '#ffffff';
+          ctx.fillRect(tableX, tableY, tableW, tableH);
+          ctx.strokeStyle = isSelected ? '#00ddff' : '#000000';
+          ctx.lineWidth = (isSelected ? 2 : 1) / zoom;
+          ctx.strokeRect(tableX, tableY, tableW, tableH);
+
+          // Header row
+          ctx.fillStyle = '#333333';
+          ctx.font = `bold ${5.5 / zoom}px "Courier New"`;
+          let cx = tableX + 2 / zoom;
+          for (const [i, hdr] of ['PIN', 'FUNC', 'AWG', 'COLOR', 'TO'].entries()) {
+            ctx.fillText(hdr, cx, tableY + rowH - 2 / zoom);
+            cx += colWidths[i] / zoom;
+          }
+
+          // Data rows
+          ctx.font = `${5 / zoom}px "Courier New"`;
+          for (let r = 0; r < pins.length; r++) {
+            const pin = pins[r];
+            const ry = tableY + (r + 1) * rowH;
+            // Alternating row background
+            if (r % 2 === 1) {
+              ctx.fillStyle = '#f8f8f8';
+              ctx.fillRect(tableX, ry, tableW, rowH);
+            }
+            ctx.fillStyle = '#333333';
+            cx = tableX + 2 / zoom;
+            const fields = [
+              pin.pin_number,
+              (pin.pin_function || '—').slice(0, 12),
+              pin.default_wire_gauge_awg != null ? String(pin.default_wire_gauge_awg) : '—',
+              pin.default_wire_color || '—',
+              (pin.connected_to_device || '—').slice(0, 10),
+            ];
+            for (let i = 0; i < fields.length; i++) {
+              ctx.fillText(fields[i], cx, ry + rowH - 2 / zoom);
+              cx += colWidths[i] / zoom;
+            }
+          }
+        }
+      }
+
+      ctx.globalAlpha = 1;
+    }
+
+    // ── Net badge (when wire is selected) ──
+    if (selectedWireId != null) {
+      const wire = wires.find(w => w.wireNumber === selectedWireId);
+      if (wire) {
+        // Count wires in same net (same PDM channel group or signal type)
+        const netWires = wires.filter(w =>
+          (wire.pdmChannel && w.pdmChannel === wire.pdmChannel) ||
+          (wire.signalType === 'can_bus' && w.signalType === 'can_bus')
+        );
+        const netLabel = wire.pdmChannel ? `PDM CH${wire.pdmChannel}` : wire.to;
+        const badgeText = `NET: ${netLabel} — ${netWires.length > 1 ? netWires.length + ' WIRES' : '1 WIRE'}`;
+
+        ctx.fillStyle = 'rgba(0, 221, 255, 0.9)';
+        const bw = ctx.measureText(badgeText).width + 12 / zoom;
+        ctx.fillRect(20, CANVAS_H - 30 / zoom, bw, 20 / zoom);
+        ctx.fillStyle = '#1a1a2e';
+        ctx.font = `bold ${8 / zoom}px Arial`;
+        ctx.textAlign = 'left';
+        ctx.fillText(badgeText, 20 + 6 / zoom, CANVAS_H - 30 / zoom + 14 / zoom);
+      }
+    }
+
+    ctx.restore();
+  }, [
+    devices, wires, zoom, panX, panY, devicePositions, drcMap, pinCache,
+    selectedDeviceId, selectedDeviceIds, selectedWireId, activeLoom,
+  ]);
+
+  useEffect(() => {
+    draw();
+  }, [draw]);
+
+  // Redraw on resize
+  useEffect(() => {
+    const observer = new ResizeObserver(() => draw());
+    if (containerRef.current) observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [draw]);
+
+  // ── Event Handlers ──
+  const toBoard = useCallback((clientX: number, clientY: number) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: (clientX - rect.left - panX) / zoom / PX_PER_INCH,
+      y: (clientY - rect.top - panY) / zoom / PX_PER_INCH,
+    };
+  }, [panX, panY, zoom]);
+
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    const factor = e.deltaY < 0 ? 1.12 : 0.89;
+    setZoom(z => Math.max(0.1, Math.min(20, z * factor)));
+  }, []);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if (e.button === 1 || (e.button === 0 && e.altKey)) {
+      // Middle click or alt+click = pan
+      setIsPanning(true);
+      panStart.current = { x: e.clientX, y: e.clientY, px: panX, py: panY };
+      e.preventDefault();
+      return;
+    }
+    if (e.button !== 0) return;
+
+    // Check if clicking on a device
+    const pt = toBoard(e.clientX, e.clientY);
+    for (const device of devices) {
+      if (activeLoom && device.location_zone !== activeLoom) continue;
+      const pos = devicePositions.get(device.id);
+      if (!pos) continue;
+      if (pt.x >= pos.x && pt.x <= pos.x + 3 && pt.y >= pos.y && pt.y <= pos.y + 2) {
+        onDeviceClick(device.id, e);
+        return;
+      }
+    }
+
+    // Check if clicking on a wire (rough hit test)
+    // For now, start panning if no hit
+    setIsPanning(true);
+    panStart.current = { x: e.clientX, y: e.clientY, px: panX, py: panY };
+  }, [devices, devicePositions, panX, panY, toBoard, onDeviceClick, activeLoom]);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!isPanning) return;
+    setPanX(panStart.current.px + (e.clientX - panStart.current.x));
+    setPanY(panStart.current.py + (e.clientY - panStart.current.y));
+  }, [isPanning]);
+
+  const handleMouseUp = useCallback(() => setIsPanning(false), []);
+
+  // ── Print Handler ──
+  const handlePrint = useCallback(() => {
+    const printCanvas = document.createElement('canvas');
+    const scale = 4; // High-res print
+    printCanvas.width = CANVAS_W * scale;
+    printCanvas.height = CANVAS_H * scale;
+    const ctx = printCanvas.getContext('2d');
+    if (!ctx) return;
+
+    ctx.scale(scale, scale);
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+
+    // Grid
+    ctx.strokeStyle = '#e0e0e0';
+    ctx.lineWidth = 0.3;
+    for (let x = 0; x <= CANVAS_W; x += PX_PER_INCH) {
+      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, CANVAS_H); ctx.stroke();
+    }
+    for (let y = 0; y <= CANVAS_H; y += PX_PER_INCH) {
+      ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(CANVAS_W, y); ctx.stroke();
+    }
+
+    // Grid coordinates: A-H rows, 1-17 columns
+    const rowLabels = 'ABCDEFGH'.split('');
+    const rowH = CANVAS_H / 8;
+    ctx.fillStyle = '#333333';
+    ctx.font = 'bold 8px Arial';
+    ctx.textAlign = 'center';
+    for (let i = 0; i < rowLabels.length; i++) {
+      ctx.fillText(rowLabels[i], 8, i * rowH + rowH / 2 + 3);
+      ctx.fillText(rowLabels[i], CANVAS_W - 8, i * rowH + rowH / 2 + 3);
+    }
+    for (let c = 1; c <= 17; c++) {
+      const cx = (c / 18) * CANVAS_W;
+      ctx.fillText(String(c), cx, 10);
+      ctx.fillText(String(c), cx, CANVAS_H - 4);
+    }
+
+    // Zone labels
+    const zoneRegionsPrint: Record<string, { x: number; y: number }> = {
+      engine_bay: { x: 20, y: 20 },
+      firewall: { x: 45, y: 20 },
+      dash: { x: 70, y: 20 },
+      doors: { x: 110, y: 20 },
+      rear: { x: 145, y: 20 },
+      underbody: { x: 20, y: 60 },
+    };
+    ctx.font = 'bold 12px Arial';
+    for (const [zone, pos] of Object.entries(zoneRegionsPrint)) {
+      ctx.fillStyle = ZONE_COLORS[zone] || '#333';
+      ctx.textAlign = 'left';
+      ctx.fillText(zone.replace(/_/g, ' ').toUpperCase(), pos.x * PX_PER_INCH, pos.y * PX_PER_INCH);
+    }
+
+    // Connector blocks (simplified for print)
+    ctx.font = 'bold 6px Arial';
+    for (const device of devices) {
+      const pos = devicePositions.get(device.id);
+      if (!pos) continue;
+      const px = pos.x * PX_PER_INCH;
+      const py = pos.y * PX_PER_INCH;
+      ctx.fillStyle = '#f5f5f5';
+      ctx.fillRect(px, py, 30, 20);
+      ctx.strokeStyle = '#333333';
+      ctx.lineWidth = 1;
+      ctx.strokeRect(px, py, 30, 20);
+      ctx.fillStyle = '#333333';
+      ctx.textAlign = 'left';
+      const nm = device.device_name.length > 18 ? device.device_name.slice(0, 17) + '...' : device.device_name;
+      ctx.fillText(nm.toUpperCase(), px + 2, py + 8);
+      ctx.font = '5px "Courier New"';
+      ctx.fillText(`${device.connector_type || ''} ${device.pin_count || 0}p`, px + 2, py + 16);
+      ctx.font = 'bold 6px Arial';
+
+      // Print pin tables adjacent to connectors
+      const pins = device.model_number ? pinCache.get(device.model_number) : undefined;
+      if (pins && pins.length > 0) {
+        const tableX = px + 34;
+        const tRowH = 6;
+        ctx.font = '4.5px "Courier New"';
+        ctx.fillStyle = '#ffffff';
+        const tH = (pins.length + 1) * tRowH;
+        ctx.fillRect(tableX, py, 110, tH);
+        ctx.strokeStyle = '#999';
+        ctx.lineWidth = 0.5;
+        ctx.strokeRect(tableX, py, 110, tH);
+
+        ctx.fillStyle = '#333';
+        ctx.font = 'bold 4.5px "Courier New"';
+        ctx.fillText('PIN  FUNC          AWG  COLOR  TO', tableX + 2, py + tRowH - 1);
+        ctx.font = '4px "Courier New"';
+        for (let r = 0; r < Math.min(pins.length, 20); r++) {
+          const pin = pins[r];
+          const ry = py + (r + 1) * tRowH;
+          if (r % 2 === 1) {
+            ctx.fillStyle = '#f8f8f8';
+            ctx.fillRect(tableX, ry, 110, tRowH);
+          }
+          ctx.fillStyle = '#333';
+          const line = `${(pin.pin_number + '    ').slice(0, 5)}${((pin.pin_function || '—') + '              ').slice(0, 14)}${((pin.default_wire_gauge_awg ?? '—') + '   ').toString().slice(0, 4)}${((pin.default_wire_color || '—') + '      ').slice(0, 7)}${(pin.connected_to_device || '—').slice(0, 10)}`;
+          ctx.fillText(line, tableX + 2, ry + tRowH - 1);
+        }
+        ctx.font = 'bold 6px Arial';
+      }
+    }
+
+    // Wire color legend (bottom-left)
+    const usedColors = [...new Set(wires.map(w => w.color))].sort();
+    const legendX = 10;
+    const legendY = CANVAS_H - 20 - usedColors.length * 10;
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(legendX * PX_PER_INCH, legendY, 120, usedColors.length * 10 + 16);
+    ctx.strokeStyle = '#333';
+    ctx.lineWidth = 1;
+    ctx.strokeRect(legendX * PX_PER_INCH, legendY, 120, usedColors.length * 10 + 16);
+    ctx.fillStyle = '#333';
+    ctx.font = 'bold 6px Arial';
+    ctx.fillText('WIRE COLOR LEGEND', legendX * PX_PER_INCH + 4, legendY + 10);
+    ctx.font = '5px "Courier New"';
+    usedColors.forEach((color, i) => {
+      const ly = legendY + 16 + i * 10;
+      // Color swatch
+      const swatchColor = color.includes('RED') ? '#cc4444' :
+        color.includes('GRN') ? '#44aa44' :
+        color.includes('BLU') ? '#4488cc' :
+        color.includes('WHT') ? '#cccccc' :
+        color.includes('BLK') ? '#333333' :
+        color.includes('VIO') ? '#9966cc' :
+        color.includes('ORG') ? '#cc8833' :
+        '#777777';
+      ctx.fillStyle = swatchColor;
+      ctx.fillRect(legendX * PX_PER_INCH + 4, ly, 8, 6);
+      ctx.strokeStyle = '#999';
+      ctx.lineWidth = 0.3;
+      ctx.strokeRect(legendX * PX_PER_INCH + 4, ly, 8, 6);
+      ctx.fillStyle = '#333';
+      ctx.fillText(color, legendX * PX_PER_INCH + 16, ly + 5);
+    });
+
+    // Scale bar (bottom-center)
+    const sbX = CANVAS_W / 2 - 30;
+    const sbY = CANVAS_H - 20;
+    ctx.fillStyle = '#333';
+    ctx.font = 'bold 7px Arial';
+    ctx.textAlign = 'center';
+    ctx.fillText('SCALE 1:1', sbX + 30, sbY - 4);
+    ctx.strokeStyle = '#333';
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(sbX, sbY);
+    ctx.lineTo(sbX + 60, sbY);
+    ctx.stroke();
+    // 6" tick marks
+    for (let i = 0; i <= 6; i++) {
+      const tx = sbX + i * 10;
+      ctx.beginPath();
+      ctx.moveTo(tx, sbY - 3);
+      ctx.lineTo(tx, sbY + 3);
+      ctx.stroke();
+      ctx.fillText(`${i}"`, tx, sbY + 10);
+    }
+
+    // Title block (bottom-right)
+    const tbW = 200;
+    const tbH = 60;
+    const tbX = CANVAS_W - tbW - 10;
+    const tbY = CANVAS_H - tbH - 10;
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(tbX, tbY, tbW, tbH);
+    ctx.strokeStyle = '#333';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(tbX, tbY, tbW, tbH);
+    ctx.fillStyle = '#333';
+    ctx.textAlign = 'left';
+    ctx.font = 'bold 8px Arial';
+    ctx.fillText('NUKE VEHICLE PLATFORM', tbX + 6, tbY + 14);
+    ctx.font = 'bold 7px Arial';
+    ctx.fillText('1977 K5 BLAZER — WIRING FORMBOARD', tbX + 6, tbY + 26);
+    ctx.font = '6px "Courier New"';
+    ctx.fillText(`DWG: NUKE-K5-FB-001    REV: A`, tbX + 6, tbY + 38);
+    ctx.fillText(`DATE: ${new Date().toISOString().split('T')[0]}    SCALE: 1:1`, tbX + 6, tbY + 48);
+
+    // Open print dialog
+    const printWindow = window.open('', '_blank');
+    if (printWindow) {
+      const imgData = printCanvas.toDataURL('image/png');
+      printWindow.document.write(`
+        <html><head><title>Formboard Print</title>
+        <style>@media print { body { margin: 0; } img { width: 100%; } }</style>
+        </head><body>
+        <img src="${imgData}" style="width:100%;" />
+        </body></html>
+      `);
+      printWindow.document.close();
+      printWindow.focus();
+      setTimeout(() => printWindow.print(), 500);
+    }
+  }, [devices, wires, devicePositions, pinCache]);
+
+  // Listen for Ctrl+P
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'p') {
+        e.preventDefault();
+        handlePrint();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [handlePrint]);
+
+  return (
+    <div ref={containerRef} style={{ display: 'flex', flexDirection: 'column', height: '100%', background: '#1a1a2e' }}>
+      {/* Toolbar */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 4, padding: '4px 8px',
+        borderBottom: '2px solid #2a2a5e', background: '#1e1e32', flexShrink: 0,
+      }}>
+        {/* Loom tabs */}
+        <button
+          onClick={() => setActiveLoom(null)}
+          style={{
+            fontSize: '7px', fontWeight: 700, fontFamily: 'Arial', textTransform: 'uppercase',
+            letterSpacing: '0.5px', padding: '3px 8px', border: '2px solid #2a2a5e',
+            background: activeLoom === null ? '#00ddff' : 'transparent',
+            color: activeLoom === null ? '#1a1a2e' : '#8888aa', cursor: 'pointer',
+          }}
+        >ALL</button>
+        {looms.map(zone => (
+          <button
+            key={zone}
+            onClick={() => setActiveLoom(zone === activeLoom ? null : zone)}
+            style={{
+              fontSize: '7px', fontWeight: 700, fontFamily: 'Arial', textTransform: 'uppercase',
+              letterSpacing: '0.5px', padding: '3px 8px', border: `2px solid ${ZONE_COLORS[zone] || '#2a2a5e'}`,
+              background: activeLoom === zone ? (ZONE_COLORS[zone] || '#2a2a5e') : 'transparent',
+              color: activeLoom === zone ? '#ffffff' : (ZONE_COLORS[zone] || '#8888aa'), cursor: 'pointer',
+            }}
+          >{zone.replace(/_/g, ' ')}</button>
+        ))}
+
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span style={{ fontSize: '7px', fontFamily: '"Courier New"', fontWeight: 700, color: '#8888aa' }}>
+            {Math.round(zoom * 100)}%
+          </span>
+          <button
+            onClick={() => { setZoom(0.6); setPanX(0); setPanY(0); }}
+            style={{
+              fontSize: '7px', fontWeight: 700, fontFamily: 'Arial', padding: '3px 8px',
+              border: '2px solid #2a2a5e', background: 'transparent', color: '#8888aa', cursor: 'pointer',
+              textTransform: 'uppercase',
+            }}
+          >RESET</button>
+          <button
+            onClick={handlePrint}
+            style={{
+              fontSize: '7px', fontWeight: 700, fontFamily: 'Arial', padding: '3px 8px',
+              border: '2px solid #2a2a5e', background: 'transparent', color: '#8888aa', cursor: 'pointer',
+              textTransform: 'uppercase',
+            }}
+          >PRINT</button>
+        </div>
+      </div>
+
+      {/* Canvas */}
+      <canvas
+        ref={canvasRef}
+        onWheel={handleWheel}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+        style={{
+          flex: 1, cursor: isPanning ? 'grabbing' : 'crosshair', display: 'block',
+        }}
+      />
+    </div>
+  );
+}

--- a/nuke_frontend/src/components/wiring/LoomTopologyView.tsx
+++ b/nuke_frontend/src/components/wiring/LoomTopologyView.tsx
@@ -1,0 +1,251 @@
+// LoomTopologyView.tsx — Node-based loom routing topology graph
+// Shows how wire looms connect zones through junction nodes.
+
+import React, { useMemo, useState } from 'react';
+import type { ManifestDevice, WireSpec } from './overlayCompute';
+import type { DRCDeviceResult } from './useDRC';
+
+const ZONE_COLORS: Record<string, string> = {
+  engine_bay: '#cc2222', firewall: '#cc6600', dash: '#2266cc',
+  doors: '#8822cc', rear: '#22aa44', underbody: '#cc8833',
+};
+
+const DRC_COLORS: Record<string, string> = {
+  pass: '#22aa44', warn: '#ccaa00', fail: '#cc2222',
+};
+
+// Topology positions for zone nodes (SVG coordinates)
+const ZONE_POSITIONS: Record<string, { x: number; y: number }> = {
+  engine_bay: { x: 120, y: 200 },
+  firewall: { x: 300, y: 200 },
+  dash: { x: 480, y: 200 },
+  doors: { x: 480, y: 380 },
+  rear: { x: 680, y: 200 },
+  underbody: { x: 300, y: 380 },
+};
+
+// Junction nodes (where looms split/merge)
+const JUNCTIONS = [
+  { id: 'J1', label: 'FIREWALL GROMMET', x: 210, y: 200 },
+  { id: 'J2', label: 'DASH JUNCTION', x: 390, y: 200 },
+  { id: 'J3', label: 'REAR CROSSOVER', x: 580, y: 200 },
+  { id: 'J4', label: 'UNDERBODY SPLIT', x: 300, y: 290 },
+];
+
+// Loom connections between zones through junctions
+const LOOM_LINKS = [
+  { from: 'engine_bay', to: 'J1' },
+  { from: 'J1', to: 'firewall' },
+  { from: 'firewall', to: 'J2' },
+  { from: 'J2', to: 'dash' },
+  { from: 'dash', to: 'J3' },
+  { from: 'J3', to: 'rear' },
+  { from: 'J2', to: 'J4' },
+  { from: 'J4', to: 'underbody' },
+  { from: 'J4', to: 'doors' },
+];
+
+interface Props {
+  devices: ManifestDevice[];
+  wires: WireSpec[];
+  drcMap: Map<string, DRCDeviceResult>;
+  selectedDeviceId: string | null;
+  onDeviceClick: (id: string, e: React.MouseEvent) => void;
+}
+
+export function LoomTopologyView({
+  devices, wires, drcMap, selectedDeviceId, onDeviceClick,
+}: Props) {
+  const [hoveredZone, setHoveredZone] = useState<string | null>(null);
+
+  // Compute wire counts per zone
+  const zoneStats = useMemo(() => {
+    const stats = new Map<string, { deviceCount: number; wireCount: number; totalAmps: number; drcFail: number; drcWarn: number }>();
+    for (const zone of Object.keys(ZONE_POSITIONS)) {
+      const zoneDevices = devices.filter(d => d.location_zone === zone);
+      const zoneWires = wires.filter(w => {
+        const toDevice = devices.find(d => d.device_name === w.to);
+        return toDevice?.location_zone === zone;
+      });
+      const drcFail = zoneDevices.filter(d => drcMap.get(d.id)?.severity === 'fail').length;
+      const drcWarn = zoneDevices.filter(d => drcMap.get(d.id)?.severity === 'warn').length;
+      stats.set(zone, {
+        deviceCount: zoneDevices.length,
+        wireCount: zoneWires.length,
+        totalAmps: zoneDevices.reduce((s, d) => s + (d.power_draw_amps || 0), 0),
+        drcFail,
+        drcWarn,
+      });
+    }
+    return stats;
+  }, [devices, wires, drcMap]);
+
+  // Compute loom bundle wire counts
+  const loomWireCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const link of LOOM_LINKS) {
+      // Count wires that traverse this link
+      const fromZone = link.from.startsWith('J') ? null : link.from;
+      const toZone = link.to.startsWith('J') ? null : link.to;
+      let count = 0;
+      if (toZone) {
+        count = wires.filter(w => {
+          const toDevice = devices.find(d => d.device_name === w.to);
+          return toDevice?.location_zone === toZone;
+        }).length;
+      } else if (fromZone) {
+        count = wires.filter(w => {
+          const toDevice = devices.find(d => d.device_name === w.to);
+          return toDevice?.location_zone === fromZone;
+        }).length;
+      }
+      counts.set(`${link.from}-${link.to}`, count);
+    }
+    return counts;
+  }, [wires, devices]);
+
+  const getPos = (id: string) => {
+    if (ZONE_POSITIONS[id]) return ZONE_POSITIONS[id];
+    const j = JUNCTIONS.find(j => j.id === id);
+    return j ? { x: j.x, y: j.y } : { x: 400, y: 300 };
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: '#1a1a2e' }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', padding: '4px 8px',
+        borderBottom: '2px solid #2a2a5e', background: '#1e1e32', flexShrink: 0,
+      }}>
+        <span style={{ fontSize: '8px', fontWeight: 700, fontFamily: 'Arial', color: '#8888aa',
+          textTransform: 'uppercase', letterSpacing: '1px' }}>
+          LOOM TOPOLOGY — {devices.length} DEVICES — {wires.length} WIRES
+        </span>
+      </div>
+
+      {/* SVG Canvas */}
+      <div style={{ flex: 1, overflow: 'auto', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <svg width={850} height={500} viewBox="0 0 850 500" style={{ display: 'block' }}>
+          {/* Background grid */}
+          {Array.from({ length: 22 }).map((_, i) => (
+            <line key={`gx${i}`} x1={i * 40} y1={0} x2={i * 40} y2={500} stroke="#2a2a3e" strokeWidth={0.3} />
+          ))}
+          {Array.from({ length: 13 }).map((_, i) => (
+            <line key={`gy${i}`} x1={0} y1={i * 40} x2={850} y2={i * 40} stroke="#2a2a3e" strokeWidth={0.3} />
+          ))}
+
+          {/* Loom connections */}
+          {LOOM_LINKS.map(link => {
+            const from = getPos(link.from);
+            const to = getPos(link.to);
+            const wireCount = loomWireCounts.get(`${link.from}-${link.to}`) || 0;
+            const thickness = Math.max(2, Math.min(8, wireCount / 3));
+            return (
+              <g key={`${link.from}-${link.to}`}>
+                <line
+                  x1={from.x} y1={from.y} x2={to.x} y2={to.y}
+                  stroke="#444466" strokeWidth={thickness} strokeLinecap="round"
+                />
+                {wireCount > 0 && (
+                  <text
+                    x={(from.x + to.x) / 2} y={(from.y + to.y) / 2 - 8}
+                    fill="#8888aa" textAnchor="middle"
+                    style={{ fontSize: '7px', fontFamily: '"Courier New"', fontWeight: 700 }}
+                  >
+                    {wireCount}W
+                  </text>
+                )}
+              </g>
+            );
+          })}
+
+          {/* Junction nodes */}
+          {JUNCTIONS.map(j => (
+            <g key={j.id}>
+              <circle cx={j.x} cy={j.y} r={8} fill="#333355" stroke="#555577" strokeWidth={1.5} />
+              <text x={j.x} y={j.y - 14} fill="#8888aa" textAnchor="middle"
+                style={{ fontSize: '6px', fontFamily: 'Arial', fontWeight: 700, letterSpacing: '0.3px' }}>
+                {j.label}
+              </text>
+            </g>
+          ))}
+
+          {/* Zone nodes */}
+          {Object.entries(ZONE_POSITIONS).map(([zone, pos]) => {
+            const stats = zoneStats.get(zone);
+            const color = ZONE_COLORS[zone] || '#555577';
+            const isHovered = hoveredZone === zone;
+            const hasSelection = selectedDeviceId != null;
+            const selectedInZone = hasSelection && devices.find(d => d.id === selectedDeviceId)?.location_zone === zone;
+            const isDimmed = hasSelection && !selectedInZone;
+
+            return (
+              <g
+                key={zone}
+                onMouseEnter={() => setHoveredZone(zone)}
+                onMouseLeave={() => setHoveredZone(null)}
+                style={{ cursor: 'pointer', opacity: isDimmed ? 0.3 : 1, transition: 'opacity 200ms' }}
+              >
+                {/* Zone box */}
+                <rect
+                  x={pos.x - 55} y={pos.y - 35} width={110} height={70}
+                  fill="#252540"
+                  stroke={isHovered || selectedInZone ? '#00ddff' : color}
+                  strokeWidth={isHovered || selectedInZone ? 2.5 : 1.5}
+                />
+                {/* Color accent */}
+                <rect x={pos.x - 55} y={pos.y - 35} width={4} height={70} fill={color} />
+
+                {/* Zone name */}
+                <text x={pos.x} y={pos.y - 18} fill="#e0e0e8" textAnchor="middle"
+                  style={{ fontSize: '8px', fontFamily: 'Arial', fontWeight: 700, letterSpacing: '0.5px' }}>
+                  {zone.replace(/_/g, ' ').toUpperCase()}
+                </text>
+
+                {/* Stats */}
+                <text x={pos.x} y={pos.y - 2} fill="#8888aa" textAnchor="middle"
+                  style={{ fontSize: '7px', fontFamily: '"Courier New"', fontWeight: 700 }}>
+                  {stats?.deviceCount || 0} DEV | {stats?.wireCount || 0} WIRES
+                </text>
+                <text x={pos.x} y={pos.y + 12} fill="#8888aa" textAnchor="middle"
+                  style={{ fontSize: '7px', fontFamily: '"Courier New"' }}>
+                  {(stats?.totalAmps || 0).toFixed(1)}A TOTAL
+                </text>
+
+                {/* DRC summary for zone */}
+                {stats && (stats.drcFail > 0 || stats.drcWarn > 0) && (
+                  <g>
+                    {stats.drcFail > 0 && (
+                      <>
+                        <circle cx={pos.x + 40} cy={pos.y - 28} r={4} fill={DRC_COLORS.fail} />
+                        <text x={pos.x + 40} y={pos.y - 26} fill="#fff" textAnchor="middle"
+                          style={{ fontSize: '5px', fontFamily: '"Courier New"', fontWeight: 700 }}>
+                          {stats.drcFail}
+                        </text>
+                      </>
+                    )}
+                    {stats.drcWarn > 0 && (
+                      <>
+                        <circle cx={pos.x + 30} cy={pos.y - 28} r={4} fill={DRC_COLORS.warn} />
+                        <text x={pos.x + 30} y={pos.y - 26} fill="#1a1a2e" textAnchor="middle"
+                          style={{ fontSize: '5px', fontFamily: '"Courier New"', fontWeight: 700 }}>
+                          {stats.drcWarn}
+                        </text>
+                      </>
+                    )}
+                  </g>
+                )}
+              </g>
+            );
+          })}
+
+          {/* Title */}
+          <text x={425} y={480} fill="#555577" textAnchor="middle"
+            style={{ fontSize: '8px', fontFamily: 'Arial', fontWeight: 700, letterSpacing: '1px' }}>
+            1977 K5 BLAZER — HARNESS LOOM TOPOLOGY
+          </text>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/nuke_frontend/src/components/wiring/SchematicViewer.tsx
+++ b/nuke_frontend/src/components/wiring/SchematicViewer.tsx
@@ -1,0 +1,453 @@
+// SchematicViewer.tsx — SVG schematics with 5 sub-sheets
+// Power, Engine, Lighting, Body, Audio. Click device → detail. DRC dots. Dark/light toggle.
+
+import React, { useCallback, useMemo, useState } from 'react';
+import type { ManifestDevice, WireSpec, PDMChannel } from './overlayCompute';
+import type { DRCDeviceResult } from './useDRC';
+
+// ── Sheet Definitions ────────────────────────────────────────────────
+const SHEETS = [
+  { id: 'power', label: 'POWER', categories: ['power_distribution', 'starting', 'charging'] },
+  { id: 'engine', label: 'ENGINE', categories: ['engine_management', 'engine_mgmt', 'fuel', 'cooling'] },
+  { id: 'lighting', label: 'LIGHTING', categories: ['lighting'] },
+  { id: 'body', label: 'BODY', categories: ['body', 'safety', 'controls', 'gauges', 'comfort'] },
+  { id: 'audio', label: 'AUDIO', categories: ['audio', 'entertainment'] },
+] as const;
+
+type SheetId = typeof SHEETS[number]['id'];
+
+// ── Color Maps ──────────────────────────────────────────────────────
+const CATEGORY_COLORS: Record<string, string> = {
+  power_distribution: '#cc4444', starting: '#cc6644', charging: '#cc8844',
+  engine_management: '#44aa44', engine_mgmt: '#44aa44', fuel: '#cc44aa', cooling: '#4488cc',
+  lighting: '#ccaa33', sensors: '#9966cc', safety: '#cc4444',
+  body: '#6688cc', controls: '#6688cc', gauges: '#888888',
+  audio: '#cc8833', entertainment: '#cc8833', comfort: '#6688cc',
+};
+
+const DRC_COLORS: Record<string, string> = {
+  pass: '#22aa44', warn: '#ccaa00', fail: '#cc2222',
+};
+
+interface LightTheme {
+  bg: string; deviceFill: string; deviceStroke: string; wireColor: string;
+  gridColor: string; textColor: string; textDim: string; groundColor: string;
+}
+
+const DARK_THEME: LightTheme = {
+  bg: '#1a1a2e', deviceFill: '#252540', deviceStroke: '#e0e0e8',
+  wireColor: '#e0e0e8', gridColor: '#2a2a3e', textColor: '#e0e0e8',
+  textDim: '#8888aa', groundColor: '#888888',
+};
+
+const LIGHT_THEME: LightTheme = {
+  bg: '#ffffff', deviceFill: '#f5f5f5', deviceStroke: '#333333',
+  wireColor: '#333333', gridColor: '#e8e8e8', textColor: '#333333',
+  textDim: '#888888', groundColor: '#666666',
+};
+
+// ── Props ────────────────────────────────────────────────────────────
+interface Props {
+  devices: ManifestDevice[];
+  wires: WireSpec[];
+  pdmChannels: PDMChannel[];
+  drcMap: Map<string, DRCDeviceResult>;
+  selectedDeviceId: string | null;
+  selectedDeviceIds: Set<string>;
+  selectedWireId: number | null;
+  onDeviceClick: (id: string, e: React.MouseEvent) => void;
+  onWireClick: (wireNumber: number) => void;
+}
+
+export function SchematicViewer({
+  devices, wires, pdmChannels, drcMap,
+  selectedDeviceId, selectedDeviceIds, selectedWireId,
+  onDeviceClick, onWireClick,
+}: Props) {
+  const [activeSheet, setActiveSheet] = useState<SheetId>('engine');
+  const [isDark, setIsDark] = useState(() => {
+    try { return localStorage.getItem('schematic-dark') !== 'false'; } catch { return true; }
+  });
+  const [hoveredDevice, setHoveredDevice] = useState<string | null>(null);
+  const [drcPopover, setDrcPopover] = useState<{ deviceId: string; x: number; y: number } | null>(null);
+
+  const theme = isDark ? DARK_THEME : LIGHT_THEME;
+
+  const toggleDark = useCallback(() => {
+    setIsDark(prev => {
+      const next = !prev;
+      try { localStorage.setItem('schematic-dark', String(next)); } catch {}
+      return next;
+    });
+  }, []);
+
+  // Filter devices for current sheet
+  const sheetDef = SHEETS.find(s => s.id === activeSheet)!;
+  const sheetDevices = useMemo(() => {
+    const cats = new Set(sheetDef.categories);
+    // Also include sensors on the engine sheet
+    return devices.filter(d => {
+      const cat = d.device_category || '';
+      if (cats.has(cat)) return true;
+      if (activeSheet === 'engine' && cat === 'sensors') return true;
+      // Catch-all: unmatched devices go to body sheet
+      if (activeSheet === 'body') {
+        return !SHEETS.some(s => s.id !== 'body' && s.categories.some(c => c === cat));
+      }
+      return false;
+    });
+  }, [devices, sheetDef, activeSheet]);
+
+  // Sheet wire connections
+  const sheetWires = useMemo(() => {
+    const deviceNames = new Set(sheetDevices.map(d => d.device_name));
+    return wires.filter(w => deviceNames.has(w.to));
+  }, [wires, sheetDevices]);
+
+  // Layout devices in a schematic grid
+  const deviceLayout = useMemo(() => {
+    const layout = new Map<string, { x: number; y: number; w: number; h: number }>();
+    const cols = Math.ceil(Math.sqrt(sheetDevices.length * 1.5));
+    const cellW = 160;
+    const cellH = 80;
+    const padding = 40;
+
+    sheetDevices.forEach((d, i) => {
+      const col = i % cols;
+      const row = Math.floor(i / cols);
+      layout.set(d.id, {
+        x: padding + col * (cellW + 30),
+        y: padding + 50 + row * (cellH + 40),
+        w: cellW,
+        h: cellH,
+      });
+    });
+    return layout;
+  }, [sheetDevices]);
+
+  const svgW = useMemo(() => {
+    let maxX = 800;
+    deviceLayout.forEach(v => { maxX = Math.max(maxX, v.x + v.w + 60); });
+    return maxX;
+  }, [deviceLayout]);
+  const svgH = useMemo(() => {
+    let maxY = 600;
+    deviceLayout.forEach(v => { maxY = Math.max(maxY, v.y + v.h + 60); });
+    return maxY;
+  }, [deviceLayout]);
+
+  // Wire color mapper
+  const wireDisplayColor = useCallback((wire: WireSpec) => {
+    if (isDark && wire.color.includes('BLK')) return theme.groundColor;
+    const c = wire.color;
+    if (c.includes('RED')) return '#cc4444';
+    if (c.includes('GRN')) return '#44aa44';
+    if (c.includes('BLU')) return '#4488cc';
+    if (c.includes('WHT')) return isDark ? '#aaaaaa' : '#999999';
+    if (c.includes('VIO')) return '#9966cc';
+    if (c.includes('ORG')) return '#cc8833';
+    if (c.includes('YEL')) return '#ccaa33';
+    if (c.includes('TAN')) return '#aa8866';
+    if (c.includes('PNK')) return '#cc6688';
+    if (c.includes('BRN')) return '#886644';
+    return isDark ? '#aaaaaa' : '#666666';
+  }, [isDark, theme.groundColor]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: theme.bg }}>
+      {/* Tab Bar */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 2, padding: '4px 8px',
+        borderBottom: `2px solid ${isDark ? '#2a2a5e' : '#cccccc'}`,
+        background: isDark ? '#1e1e32' : '#f0f0f0', flexShrink: 0,
+      }}>
+        {SHEETS.map(sheet => {
+          const count = devices.filter(d => {
+            const cats = new Set(sheet.categories);
+            if (cats.has(d.device_category || '')) return true;
+            if (sheet.id === 'engine' && d.device_category === 'sensors') return true;
+            return false;
+          }).length;
+          return (
+            <button
+              key={sheet.id}
+              onClick={() => setActiveSheet(sheet.id)}
+              style={{
+                fontSize: '7px', fontWeight: 700, fontFamily: 'Arial', textTransform: 'uppercase',
+                letterSpacing: '0.5px', padding: '3px 10px', border: `2px solid ${isDark ? '#2a2a5e' : '#cccccc'}`,
+                background: activeSheet === sheet.id ? (isDark ? '#00ddff' : '#333333') : 'transparent',
+                color: activeSheet === sheet.id ? (isDark ? '#1a1a2e' : '#ffffff') : theme.textDim,
+                cursor: 'pointer',
+              }}
+            >
+              {sheet.label} ({count})
+            </button>
+          );
+        })}
+
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 6 }}>
+          <button
+            onClick={toggleDark}
+            style={{
+              fontSize: '7px', fontWeight: 700, fontFamily: 'Arial', padding: '3px 10px',
+              border: `2px solid ${isDark ? '#2a2a5e' : '#cccccc'}`,
+              background: isDark ? '#252540' : '#ffffff',
+              color: theme.textDim, cursor: 'pointer', textTransform: 'uppercase',
+            }}
+          >
+            {isDark ? 'LIGHT' : 'DARK'}
+          </button>
+        </div>
+      </div>
+
+      {/* SVG Canvas */}
+      <div style={{ flex: 1, overflow: 'auto', position: 'relative' }}>
+        <svg
+          width={svgW}
+          height={svgH}
+          viewBox={`0 0 ${svgW} ${svgH}`}
+          style={{ display: 'block' }}
+        >
+          {/* Grid */}
+          {Array.from({ length: Math.ceil(svgW / 40) + 1 }).map((_, i) => (
+            <line key={`gx${i}`} x1={i * 40} y1={0} x2={i * 40} y2={svgH}
+              stroke={theme.gridColor} strokeWidth={0.5} />
+          ))}
+          {Array.from({ length: Math.ceil(svgH / 40) + 1 }).map((_, i) => (
+            <line key={`gy${i}`} x1={0} y1={i * 40} x2={svgW} y2={i * 40}
+              stroke={theme.gridColor} strokeWidth={0.5} />
+          ))}
+
+          {/* Sheet title */}
+          <text x={20} y={30} fill={theme.textDim}
+            style={{ fontSize: '10px', fontFamily: 'Arial', fontWeight: 700, letterSpacing: '1px' }}>
+            {sheetDef.label} SCHEMATIC — {sheetDevices.length} DEVICES — {sheetWires.length} WIRES
+          </text>
+
+          {/* Wire paths */}
+          {sheetWires.map(wire => {
+            const toDevice = sheetDevices.find(d => d.device_name === wire.to);
+            if (!toDevice) return null;
+            const toLayout = deviceLayout.get(toDevice.id);
+            if (!toLayout) return null;
+
+            // Source from top-center as bus bar
+            const srcX = svgW / 2;
+            const srcY = 20;
+            const dstX = toLayout.x + toLayout.w / 2;
+            const dstY = toLayout.y;
+
+            const isHighlighted = selectedWireId === wire.wireNumber;
+            const isDimmed = selectedWireId != null && !isHighlighted;
+            const color = wireDisplayColor(wire);
+
+            return (
+              <g key={wire.wireNumber} onClick={(e) => { e.stopPropagation(); onWireClick(wire.wireNumber); }}
+                style={{ cursor: 'pointer' }}>
+                <path
+                  d={`M ${srcX} ${srcY} C ${srcX} ${(srcY + dstY) / 2}, ${dstX} ${(srcY + dstY) / 2}, ${dstX} ${dstY}`}
+                  fill="none"
+                  stroke={isHighlighted ? '#00ddff' : color}
+                  strokeWidth={isHighlighted ? 3 : 1.5}
+                  opacity={isDimmed ? 0.15 : 1}
+                  filter={isHighlighted ? 'url(#glowFilter)' : undefined}
+                  style={{ transition: 'opacity 200ms' }}
+                />
+                {/* Wire label on hover area */}
+                <path
+                  d={`M ${srcX} ${srcY} C ${srcX} ${(srcY + dstY) / 2}, ${dstX} ${(srcY + dstY) / 2}, ${dstX} ${dstY}`}
+                  fill="none" stroke="transparent" strokeWidth={8}
+                />
+              </g>
+            );
+          })}
+
+          {/* Device boxes */}
+          {sheetDevices.map(device => {
+            const layout = deviceLayout.get(device.id);
+            if (!layout) return null;
+
+            const isSelected = device.id === selectedDeviceId || selectedDeviceIds.has(device.id);
+            const isDimmed = (selectedDeviceId != null || selectedDeviceIds.size > 0 || selectedWireId != null)
+              && !isSelected
+              && !wires.some(w => w.wireNumber === selectedWireId && w.to === device.device_name);
+            const isHovered = hoveredDevice === device.id;
+            const drc = drcMap.get(device.id);
+            const catColor = CATEGORY_COLORS[device.device_category || ''] || theme.textDim;
+
+            return (
+              <g
+                key={device.id}
+                onClick={(e) => onDeviceClick(device.id, e)}
+                onMouseEnter={() => setHoveredDevice(device.id)}
+                onMouseLeave={() => setHoveredDevice(null)}
+                style={{
+                  cursor: 'pointer',
+                  opacity: isDimmed ? 0.25 : 1,
+                  transition: 'opacity 200ms',
+                }}
+              >
+                {/* Device rect */}
+                <rect
+                  x={layout.x} y={layout.y} width={layout.w} height={layout.h}
+                  fill={theme.deviceFill}
+                  stroke={isSelected ? '#00ddff' : isHovered ? catColor : theme.deviceStroke}
+                  strokeWidth={isSelected ? 2.5 : 1.5}
+                  strokeDasharray={selectedDeviceIds.has(device.id) ? '4,2' : undefined}
+                />
+                {/* Category color accent bar */}
+                <rect x={layout.x} y={layout.y} width={4} height={layout.h} fill={catColor} />
+
+                {/* Device name */}
+                <text x={layout.x + 10} y={layout.y + 16} fill={theme.textColor}
+                  style={{ fontSize: '9px', fontFamily: 'Arial', fontWeight: 700, letterSpacing: '0.5px' }}>
+                  {device.device_name.length > 22 ? device.device_name.slice(0, 21) + '...' : device.device_name}
+                </text>
+
+                {/* Details line */}
+                <text x={layout.x + 10} y={layout.y + 28} fill={theme.textDim}
+                  style={{ fontSize: '7px', fontFamily: '"Courier New"', fontWeight: 700 }}>
+                  {device.connector_type || '—'} | {device.pin_count || 0}P | {device.power_draw_amps != null ? `${device.power_draw_amps}A` : '—'}
+                </text>
+
+                {/* Wire info */}
+                {(() => {
+                  const wire = wires.find(w => w.to === device.device_name);
+                  if (!wire) return null;
+                  return (
+                    <text x={layout.x + 10} y={layout.y + 40} fill={theme.textDim}
+                      style={{ fontSize: '7px', fontFamily: '"Courier New"' }}>
+                      W{wire.wireNumber} | {wire.gauge}AWG {wire.color} | {wire.from}
+                    </text>
+                  );
+                })()}
+
+                {/* Zone badge */}
+                {device.location_zone && (
+                  <g>
+                    <rect
+                      x={layout.x + 10} y={layout.y + layout.h - 20}
+                      width={60} height={14}
+                      fill={CATEGORY_COLORS[device.device_category || ''] || '#555577'}
+                      opacity={0.3}
+                    />
+                    <text
+                      x={layout.x + 14} y={layout.y + layout.h - 10}
+                      fill={theme.textColor}
+                      style={{ fontSize: '7px', fontFamily: 'Arial', fontWeight: 700, letterSpacing: '0.3px' }}
+                    >
+                      {device.location_zone.replace(/_/g, ' ').toUpperCase()}
+                    </text>
+                  </g>
+                )}
+
+                {/* Part number */}
+                {device.part_number && (
+                  <text
+                    x={layout.x + layout.w - 6} y={layout.y + layout.h - 10}
+                    fill={theme.textDim} textAnchor="end"
+                    style={{ fontSize: '6px', fontFamily: '"Courier New"' }}
+                  >
+                    {device.part_number}
+                  </text>
+                )}
+
+                {/* DRC indicator dot */}
+                {drc && (
+                  <circle
+                    cx={layout.x + layout.w - 8}
+                    cy={layout.y + 8}
+                    r={4}
+                    fill={DRC_COLORS[drc.severity]}
+                    stroke={theme.deviceFill}
+                    strokeWidth={1}
+                    style={{ cursor: 'pointer' }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      const svgRect = (e.target as SVGElement).closest('svg')?.getBoundingClientRect();
+                      if (svgRect) {
+                        setDrcPopover({ deviceId: device.id, x: e.clientX - svgRect.left, y: e.clientY - svgRect.top });
+                      }
+                    }}
+                  />
+                )}
+              </g>
+            );
+          })}
+
+          {/* Glow filter for highlighted wires */}
+          <defs>
+            <filter id="glowFilter" x="-50%" y="-50%" width="200%" height="200%">
+              <feGaussianBlur stdDeviation="3" result="blur" />
+              <feFlood floodColor="#00ddff" floodOpacity="0.6" result="color" />
+              <feComposite in="color" in2="blur" operator="in" result="glow" />
+              <feMerge>
+                <feMergeNode in="glow" />
+                <feMergeNode in="SourceGraphic" />
+              </feMerge>
+            </filter>
+          </defs>
+
+          {/* Net badge */}
+          {selectedWireId != null && (() => {
+            const wire = wires.find(w => w.wireNumber === selectedWireId);
+            if (!wire) return null;
+            const netWires = wires.filter(w =>
+              (wire.pdmChannel && w.pdmChannel === wire.pdmChannel) ||
+              (wire.signalType === 'can_bus' && w.signalType === 'can_bus') ||
+              w.wireNumber === wire.wireNumber
+            );
+            const netLabel = wire.pdmChannel ? `PDM CH${wire.pdmChannel}` : wire.to;
+            return (
+              <g>
+                <rect x={20} y={svgH - 30} width={220} height={22} fill="rgba(0,221,255,0.9)" />
+                <text x={30} y={svgH - 14} fill="#1a1a2e"
+                  style={{ fontSize: '9px', fontFamily: 'Arial', fontWeight: 700 }}>
+                  NET: {netLabel} — {netWires.length} WIRE{netWires.length !== 1 ? 'S' : ''}
+                </text>
+              </g>
+            );
+          })()}
+        </svg>
+
+        {/* DRC Popover */}
+        {drcPopover && (() => {
+          const drc = drcMap.get(drcPopover.deviceId);
+          const device = devices.find(d => d.id === drcPopover.deviceId);
+          if (!drc || !device) return null;
+          return (
+            <div
+              style={{
+                position: 'absolute', left: drcPopover.x + 10, top: drcPopover.y - 10,
+                background: '#1e1e32', border: '2px solid #2a2a5e', padding: '8px 10px',
+                zIndex: 20, minWidth: 200, fontFamily: 'Arial',
+              }}
+              onClick={() => setDrcPopover(null)}
+            >
+              <div style={{ fontSize: '8px', fontWeight: 700, color: '#e0e0e8', marginBottom: 6, letterSpacing: '0.5px' }}>
+                DRC: {device.device_name}
+              </div>
+              {drc.rules.map(rule => (
+                <div key={rule.ruleId} style={{
+                  display: 'flex', alignItems: 'center', gap: 6, padding: '2px 0',
+                  borderBottom: '1px solid #2a2a5e',
+                }}>
+                  <span style={{
+                    width: 6, height: 6, display: 'inline-block', flexShrink: 0,
+                    background: DRC_COLORS[rule.severity],
+                  }} />
+                  <span style={{ fontSize: '7px', fontWeight: 700, color: '#8888aa', width: 80, letterSpacing: '0.3px' }}>
+                    {rule.label}
+                  </span>
+                  <span style={{ fontSize: '7px', color: '#e0e0e8', fontFamily: '"Courier New"' }}>
+                    {rule.message}
+                  </span>
+                </div>
+              ))}
+            </div>
+          );
+        })()}
+      </div>
+    </div>
+  );
+}

--- a/nuke_frontend/src/components/wiring/WiringWorkspace.tsx
+++ b/nuke_frontend/src/components/wiring/WiringWorkspace.tsx
@@ -1,14 +1,11 @@
-// WiringWorkspace.tsx — Two-panel data view: reference image + device table
-// Left: zoomable reference images (harness plan, GM diagrams)
-// Right: sortable/filterable device table from vehicle_build_manifest
+// WiringWorkspace.tsx — DATA tab: reference image viewer + sortable device table
+// Now accepts cross-view selection state from WiringPlan parent.
 
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useOverlayCompute } from './useOverlayCompute';
 import type { ManifestDevice, WireSpec } from './overlayCompute';
-import { WiringDetailPanel } from './WiringDetailPanel';
-import { useWireCatalog, type WireTier } from './useWireCatalog';
-import { useComponentLibrary } from './useComponentLibrary';
 import { WIRE_TIERS } from './harnessConstants';
+import type { DRCDeviceResult } from './useDRC';
 
 // ── Colors ───────────────────────────────────────────────────────────
 const C = {
@@ -38,6 +35,10 @@ const ZONE_ACCENT: Record<string, string> = {
   underbody: C.underbody, firewall: C.firewall, interior: C.interior, roof: C.roof,
 };
 
+const DRC_COLORS: Record<string, string> = {
+  pass: '#22aa44', warn: '#ccaa00', fail: '#cc2222',
+};
+
 // ── Reference Images ─────────────────────────────────────────────────
 const REFERENCE_IMAGES: { label: string; file: string }[] = [
   { label: 'Harness Routing Plan', file: 'K5_harness_routing_plan_view.png' },
@@ -57,15 +58,22 @@ const REFERENCE_IMAGES: { label: string; file: string }[] = [
 interface Props {
   initialDevices: ManifestDevice[];
   vehicleId?: string;
+  // Cross-view state from WiringPlan
+  selectedDeviceId: string | null;
+  selectedDeviceIds: Set<string>;
+  selectedWireId: number | null;
+  drcMap: Map<string, DRCDeviceResult>;
+  onDeviceClick: (id: string, e: React.MouseEvent) => void;
+  onWireClick: (wireNumber: number) => void;
 }
 
-export function WiringWorkspace({ initialDevices, vehicleId }: Props) {
-  const { devices, result, terminations } = useOverlayCompute(initialDevices);
-  const [tier, setTier] = useState<WireTier>('professional');
-  const { products, gaugeConversions } = useWireCatalog(tier);
-  const { findComponent } = useComponentLibrary();
+export function WiringWorkspace({
+  initialDevices, vehicleId,
+  selectedDeviceId, selectedDeviceIds, selectedWireId, drcMap,
+  onDeviceClick, onWireClick,
+}: Props) {
+  const { devices, result } = useOverlayCompute(initialDevices);
 
-  const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
   const [filter, setFilter] = useState('');
   const [activeImage, setActiveImage] = useState(0);
 
@@ -74,15 +82,6 @@ export function WiringWorkspace({ initialDevices, vehicleId }: Props) {
   const [offset, setOffset] = useState({ x: 0, y: 0 });
   const [isPanning, setIsPanning] = useState(false);
   const panStart = useRef({ x: 0, y: 0, ox: 0, oy: 0 });
-
-  // Selected device data
-  const selectedDevice = useMemo(() => selectedDeviceId ? devices.find(d => d.id === selectedDeviceId) : null, [devices, selectedDeviceId]);
-  const selectedWire = useMemo(() => selectedDevice ? result.wires.find(w => w.to === selectedDevice.device_name) : undefined, [selectedDevice, result.wires]);
-  const selectedPdmChannel = useMemo(() => selectedDevice ? result.pdmChannels.find(ch => ch.devices.includes(selectedDevice.device_name)) : undefined, [selectedDevice, result.pdmChannels]);
-  const selectedTermination = useMemo(() => selectedDevice ? terminations.find(t => t.deviceName === selectedDevice.device_name) : undefined, [selectedDevice, terminations]);
-  const selectedLibraryComponent = useMemo(() => selectedDevice ? findComponent(selectedDevice.manufacturer || '', selectedDevice.part_number || '') : undefined, [selectedDevice, findComponent]);
-  const selectedWireProduct = useMemo(() => selectedWire ? products.find(p => p.gauge_awg === selectedWire.gauge) : undefined, [selectedWire, products]);
-  const selectedGaugeInfo = useMemo(() => selectedWire ? gaugeConversions.find(g => g.awg === selectedWire.gauge) : undefined, [selectedWire, gaugeConversions]);
 
   // Pan/zoom handlers
   const handleWheel = useCallback((e: React.WheelEvent) => {
@@ -101,10 +100,6 @@ export function WiringWorkspace({ initialDevices, vehicleId }: Props) {
   }, [isPanning]);
   const handleMouseUp = useCallback(() => setIsPanning(false), []);
   const resetView = useCallback(() => { setScale(1); setOffset({ x: 0, y: 0 }); }, []);
-
-  // Stats
-  const totalCost = result.partsCost + result.recommendedConfig.totalCost;
-  const totalLength = result.wires.reduce((s, w) => s + w.lengthFt, 0);
 
   // Table sort
   const [sortKey, setSortKey] = useState<string>('device_name');
@@ -134,26 +129,6 @@ export function WiringWorkspace({ initialDevices, vehicleId }: Props) {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', fontFamily: 'Arial, sans-serif', background: C.bg, color: C.text }}>
-      {/* ── Status Bar ────────────────────────────────────────────── */}
-      <div style={{ display: 'flex', alignItems: 'center', padding: '0 12px', height: 36, background: C.surface, borderBottom: `1px solid ${C.border}`, gap: 2, flexShrink: 0 }}>
-        <Stat label="DEVICES" value={String(devices.length)} />
-        <Stat label="WIRES" value={String(result.wireCount)} />
-        <Stat label="LENGTH" value={`${Math.round(totalLength)}ft`} />
-        <Stat label="ECU" value={result.recommendedConfig.ecu.model} />
-        <Stat label="PDM" value={result.recommendedConfig.pdm.config} />
-        <Stat label="COST" value={`$${Math.round(totalCost).toLocaleString()}`} />
-
-        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 6 }}>
-          <span style={{ fontSize: '8px', color: C.textDim, fontWeight: 700, letterSpacing: '0.5px' }}>TIER</span>
-          <select value={tier} onChange={e => setTier(e.target.value as WireTier)} style={{
-            fontSize: '8px', fontFamily: '"Courier New", monospace', fontWeight: 700,
-            padding: '2px 4px', border: `1px solid ${C.border}`, background: C.bg, color: C.text, cursor: 'pointer',
-          }}>
-            {WIRE_TIERS.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
-          </select>
-        </div>
-      </div>
-
       {/* ── Two-Panel Layout ──────────────────────────────────────── */}
       <div style={{ flex: 1, display: 'flex', overflow: 'hidden', position: 'relative' }}>
 
@@ -231,6 +206,13 @@ export function WiringWorkspace({ initialDevices, vehicleId }: Props) {
             <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '9px', fontFamily: 'Arial' }}>
               <thead>
                 <tr style={{ position: 'sticky', top: 0, zIndex: 2, background: C.surface, borderBottom: `2px solid ${C.accent}` }}>
+                  {/* DRC column */}
+                  <th style={{
+                    padding: '6px 4px', textAlign: 'center', fontSize: '7px',
+                    fontWeight: 700, color: C.textDim, letterSpacing: '0.5px', width: 28,
+                  }}>
+                    DRC
+                  </th>
                   {[
                     ['NAME', 'device_name'],
                     ['ZONE', 'location_zone'],
@@ -257,20 +239,39 @@ export function WiringWorkspace({ initialDevices, vehicleId }: Props) {
               <tbody>
                 {sortedDevices.map(d => {
                   const wire = result.wires.find(w => w.to === d.device_name);
-                  const isSelected = d.id === selectedDeviceId;
+                  const isSelected = d.id === selectedDeviceId || selectedDeviceIds.has(d.id);
+                  const isDimmed = (selectedWireId != null) && !wire?.wireNumber;
+                  const isWireHighlighted = selectedWireId != null && wire?.wireNumber === selectedWireId;
+                  const drc = drcMap.get(d.id);
                   return (
                     <tr
                       key={d.id}
-                      onClick={() => setSelectedDeviceId(isSelected ? null : d.id)}
+                      onClick={(e) => onDeviceClick(d.id, e)}
                       style={{
                         cursor: 'pointer',
                         background: isSelected ? C.surfaceSelected : undefined,
                         borderBottom: `1px solid ${C.border}`,
+                        opacity: isDimmed && !isWireHighlighted ? 0.3 : 1,
+                        transition: 'opacity 200ms',
                       }}
                       onMouseEnter={e => { if (!isSelected) e.currentTarget.style.background = C.surfaceHover; }}
                       onMouseLeave={e => { if (!isSelected) e.currentTarget.style.background = ''; }}
                     >
-                      <td style={{ padding: '5px 8px', fontWeight: 700 }}>{d.device_name}</td>
+                      {/* DRC dot */}
+                      <td style={{ padding: '5px 4px', textAlign: 'center' }}>
+                        {drc && (
+                          <span style={{
+                            display: 'inline-block', width: 6, height: 6,
+                            background: DRC_COLORS[drc.severity],
+                          }} title={drc.rules.filter(r => r.severity !== 'pass').map(r => r.message).join('\n') || 'All checks pass'} />
+                        )}
+                      </td>
+                      <td style={{ padding: '5px 8px', fontWeight: 700 }}>
+                        {d.device_name}
+                        {isWireHighlighted && (
+                          <span style={{ marginLeft: 6, fontSize: '7px', color: '#00ddff', fontWeight: 700 }}>NET</span>
+                        )}
+                      </td>
                       <td style={{ padding: '5px 8px' }}>
                         <span style={{
                           fontSize: '7px', fontWeight: 700, padding: '1px 5px',
@@ -302,38 +303,7 @@ export function WiringWorkspace({ initialDevices, vehicleId }: Props) {
             </table>
           </div>
         </div>
-
-        {/* ── Detail Panel (overlay on right) ──────────────────────── */}
-        {selectedDevice && (
-          <div style={{ position: 'absolute', right: 0, top: 0, height: '100%', zIndex: 10 }}>
-            <WiringDetailPanel
-              device={selectedDevice}
-              wire={selectedWire}
-              pdmChannel={selectedPdmChannel}
-              ecuModel={result.recommendedConfig.ecu.model}
-              termination={selectedTermination}
-              onClose={() => setSelectedDeviceId(null)}
-              onSavePosition={() => {}}
-              positionDirty={false}
-              libraryComponent={selectedLibraryComponent}
-              wireProduct={selectedWireProduct}
-              gaugeInfo={selectedGaugeInfo}
-              tierLabel={WIRE_TIERS.find(t => t.value === tier)?.label}
-              allWires={result.wires}
-            />
-          </div>
-        )}
       </div>
-    </div>
-  );
-}
-
-// ── Stat chip ────────────────────────────────────────────────────────
-function Stat({ label, value }: { label: string; value: string }) {
-  return (
-    <div style={{ display: 'flex', alignItems: 'baseline', gap: 3, marginRight: 6 }}>
-      <span style={{ fontSize: '7px', fontWeight: 700, letterSpacing: '0.5px', color: C.textMuted }}>{label}</span>
-      <span style={{ fontSize: '10px', fontFamily: '"Courier New", monospace', fontWeight: 700, color: C.text }}>{value}</span>
     </div>
   );
 }

--- a/nuke_frontend/src/components/wiring/useDRC.ts
+++ b/nuke_frontend/src/components/wiring/useDRC.ts
@@ -1,0 +1,245 @@
+// useDRC.ts — Design Rule Check hook
+// Runs 8 design checks against manifest + pin maps + overlay.
+// Returns severity map per device and summary counts.
+
+import { useMemo, useEffect, useState } from 'react';
+import type { ManifestDevice, WireSpec, PDMChannel, OverlayResult } from './overlayCompute';
+import { AWG_TABLE } from './harnessConstants';
+import { supabase } from '../../lib/supabase';
+
+export interface DRCRule {
+  ruleId: string;
+  label: string;
+  message: string;
+  severity: 'pass' | 'warn' | 'fail';
+}
+
+export interface DRCDeviceResult {
+  severity: 'pass' | 'warn' | 'fail';
+  rules: DRCRule[];
+}
+
+export interface DRCSummary {
+  pass: number;
+  warn: number;
+  fail: number;
+  total: number;
+}
+
+// AWG ampacity lookup from the constants table
+function getMaxAmps(gauge: number): number {
+  const entry = AWG_TABLE.find(e => parseInt(e.gauge) === gauge);
+  return entry?.maxAmps ?? 999;
+}
+
+const CRITICAL_CATEGORIES = ['engine_management', 'engine_mgmt', 'sensors', 'safety', 'starting'];
+
+export function useDRC(
+  devices: ManifestDevice[],
+  result: OverlayResult,
+): { drcMap: Map<string, DRCDeviceResult>; summary: DRCSummary } {
+  // Fetch pin maps for all device models
+  const [pinMaps, setPinMaps] = useState<Map<string, { pin_number: string; connected_to_device: string | null }[]>>(new Map());
+
+  useEffect(() => {
+    async function loadPinMaps() {
+      const models = [...new Set(devices.map(d => d.model_number).filter(Boolean))] as string[];
+      if (models.length === 0) return;
+      const { data } = await supabase
+        .from('device_pin_maps')
+        .select('device_model, pin_number, connected_to_device')
+        .in('device_model', models);
+      if (!data) return;
+      const map = new Map<string, { pin_number: string; connected_to_device: string | null }[]>();
+      for (const row of data) {
+        const list = map.get(row.device_model) || [];
+        list.push({ pin_number: row.pin_number, connected_to_device: row.connected_to_device });
+        map.set(row.device_model, list);
+      }
+      setPinMaps(map);
+    }
+    loadPinMaps();
+  }, [devices]);
+
+  const drcMap = useMemo(() => {
+    const map = new Map<string, DRCDeviceResult>();
+
+    // Build wire lookup by device name
+    const wiresByDevice = new Map<string, WireSpec[]>();
+    for (const w of result.wires) {
+      const list = wiresByDevice.get(w.to) || [];
+      list.push(w);
+      wiresByDevice.set(w.to, list);
+    }
+
+    // Build PDM channel lookup
+    const pdmByDevice = new Map<string, PDMChannel>();
+    for (const ch of result.pdmChannels) {
+      for (const dName of ch.devices) {
+        pdmByDevice.set(dName, ch);
+      }
+    }
+
+    for (const device of devices) {
+      const rules: DRCRule[] = [];
+
+      // Rule 1: Pin conflict — same pin assigned to two different wires
+      if (device.model_number && pinMaps.has(device.model_number)) {
+        const pins = pinMaps.get(device.model_number)!;
+        const pinAssignments = new Map<string, string[]>();
+        for (const p of pins) {
+          if (p.connected_to_device) {
+            const list = pinAssignments.get(p.pin_number) || [];
+            list.push(p.connected_to_device);
+            pinAssignments.set(p.pin_number, list);
+          }
+        }
+        const conflicts = [...pinAssignments.entries()].filter(([, devs]) => devs.length > 1);
+        if (conflicts.length > 0) {
+          rules.push({
+            ruleId: 'pin_conflict',
+            label: 'PIN CONFLICT',
+            message: `Pin${conflicts.length > 1 ? 's' : ''} ${conflicts.map(([p]) => p).join(', ')} assigned to multiple wires`,
+            severity: 'fail',
+          });
+        } else {
+          rules.push({ ruleId: 'pin_conflict', label: 'PIN CONFLICT', message: 'No conflicts', severity: 'pass' });
+        }
+      } else {
+        rules.push({ ruleId: 'pin_conflict', label: 'PIN CONFLICT', message: 'No pin data', severity: 'pass' });
+      }
+
+      // Rule 2: Gauge vs ampacity
+      const wires = wiresByDevice.get(device.device_name) || [];
+      if (wires.length > 0 && device.power_draw_amps) {
+        const wire = wires[0];
+        const maxAmps = getMaxAmps(wire.gauge);
+        if (device.power_draw_amps > maxAmps) {
+          rules.push({
+            ruleId: 'gauge_ampacity',
+            label: 'GAUGE AMPACITY',
+            message: `${device.power_draw_amps}A exceeds ${wire.gauge}AWG rating of ${maxAmps}A`,
+            severity: 'fail',
+          });
+        } else if (device.power_draw_amps > maxAmps * 0.8) {
+          rules.push({
+            ruleId: 'gauge_ampacity',
+            label: 'GAUGE AMPACITY',
+            message: `${device.power_draw_amps}A is >${Math.round(maxAmps * 0.8)}A (80% of ${maxAmps}A limit)`,
+            severity: 'warn',
+          });
+        } else {
+          rules.push({ ruleId: 'gauge_ampacity', label: 'GAUGE AMPACITY', message: `${wire.gauge}AWG OK for ${device.power_draw_amps}A`, severity: 'pass' });
+        }
+      } else {
+        rules.push({ ruleId: 'gauge_ampacity', label: 'GAUGE AMPACITY', message: 'No wire data', severity: 'pass' });
+      }
+
+      // Rule 3: Voltage drop > 3%
+      if (wires.length > 0) {
+        const maxDrop = Math.max(...wires.map(w => w.voltageDropPct));
+        if (maxDrop > 3) {
+          rules.push({
+            ruleId: 'voltage_drop',
+            label: 'VOLTAGE DROP',
+            message: `${maxDrop.toFixed(1)}% exceeds 3% limit`,
+            severity: 'fail',
+          });
+        } else if (maxDrop > 2) {
+          rules.push({
+            ruleId: 'voltage_drop',
+            label: 'VOLTAGE DROP',
+            message: `${maxDrop.toFixed(1)}% approaching 3% limit`,
+            severity: 'warn',
+          });
+        } else {
+          rules.push({ ruleId: 'voltage_drop', label: 'VOLTAGE DROP', message: `${maxDrop.toFixed(1)}% OK`, severity: 'pass' });
+        }
+      } else {
+        rules.push({ ruleId: 'voltage_drop', label: 'VOLTAGE DROP', message: 'No wire data', severity: 'pass' });
+      }
+
+      // Rule 4: Missing pin map
+      if (device.model_number && !pinMaps.has(device.model_number) && (device.pin_count || 0) > 0) {
+        rules.push({
+          ruleId: 'missing_pin_map',
+          label: 'PIN MAP',
+          message: `No pin map found for ${device.model_number}`,
+          severity: 'warn',
+        });
+      } else {
+        rules.push({ ruleId: 'missing_pin_map', label: 'PIN MAP', message: 'Pin map available', severity: 'pass' });
+      }
+
+      // Rule 5: Missing connector type
+      if (!device.connector_type) {
+        rules.push({
+          ruleId: 'missing_connector',
+          label: 'CONNECTOR TYPE',
+          message: 'No connector type specified',
+          severity: 'warn',
+        });
+      } else {
+        rules.push({ ruleId: 'missing_connector', label: 'CONNECTOR TYPE', message: device.connector_type, severity: 'pass' });
+      }
+
+      // Rule 6: Missing location zone
+      if (!device.location_zone) {
+        rules.push({
+          ruleId: 'missing_zone',
+          label: 'LOCATION ZONE',
+          message: 'No location zone specified',
+          severity: 'warn',
+        });
+      } else {
+        rules.push({ ruleId: 'missing_zone', label: 'LOCATION ZONE', message: device.location_zone.replace(/_/g, ' '), severity: 'pass' });
+      }
+
+      // Rule 7: PDM overload
+      const pdmCh = pdmByDevice.get(device.device_name);
+      if (pdmCh && pdmCh.totalAmps > pdmCh.maxAmps) {
+        rules.push({
+          ruleId: 'pdm_overload',
+          label: 'PDM OVERLOAD',
+          message: `OUT${pdmCh.channel}: ${pdmCh.totalAmps.toFixed(1)}A exceeds ${pdmCh.maxAmps}A`,
+          severity: 'fail',
+        });
+      } else {
+        rules.push({ ruleId: 'pdm_overload', label: 'PDM OVERLOAD', message: pdmCh ? `OUT${pdmCh.channel}: ${pdmCh.totalAmps.toFixed(1)}A / ${pdmCh.maxAmps}A` : 'N/A', severity: 'pass' });
+      }
+
+      // Rule 8: Unpurchased critical
+      if (!device.purchased && CRITICAL_CATEGORIES.includes(device.device_category || '')) {
+        rules.push({
+          ruleId: 'unpurchased_critical',
+          label: 'PROCUREMENT',
+          message: `Critical ${device.device_category} device not purchased`,
+          severity: 'warn',
+        });
+      } else {
+        rules.push({ ruleId: 'unpurchased_critical', label: 'PROCUREMENT', message: device.purchased ? 'Purchased' : 'Non-critical', severity: 'pass' });
+      }
+
+      // Compute worst severity
+      const hasFail = rules.some(r => r.severity === 'fail');
+      const hasWarn = rules.some(r => r.severity === 'warn');
+      const severity: 'pass' | 'warn' | 'fail' = hasFail ? 'fail' : hasWarn ? 'warn' : 'pass';
+
+      map.set(device.id, { severity, rules });
+    }
+
+    return map;
+  }, [devices, result, pinMaps]);
+
+  const summary = useMemo((): DRCSummary => {
+    let pass = 0, warn = 0, fail = 0;
+    drcMap.forEach(v => {
+      if (v.severity === 'pass') pass++;
+      else if (v.severity === 'warn') warn++;
+      else fail++;
+    });
+    return { pass, warn, fail, total: pass + warn + fail };
+  }, [drcMap]);
+
+  return { drcMap, summary };
+}

--- a/nuke_frontend/src/pages/WiringPlan.tsx
+++ b/nuke_frontend/src/pages/WiringPlan.tsx
@@ -1,36 +1,81 @@
-// WiringPlan.tsx — Entry point for /vehicle/:vehicleId/wiring
-// Loads vehicle_build_manifest → WiringWorkspace (data view + reference images).
+// WiringPlan.tsx — Parent component for /vehicle/:vehicleId/wiring
+// Manages tab switching, cross-view selection state, DRC, and command palette.
 
-import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
-import { WiringWorkspace } from '../components/wiring/WiringWorkspace';
+import { useOverlayCompute } from '../components/wiring/useOverlayCompute';
 import type { ManifestDevice } from '../components/wiring/overlayCompute';
+import { useDRC } from '../components/wiring/useDRC';
+import { WiringWorkspace } from '../components/wiring/WiringWorkspace';
+import { FormboardCanvas } from '../components/wiring/FormboardCanvas';
+import { SchematicViewer } from '../components/wiring/SchematicViewer';
+import { LoomTopologyView } from '../components/wiring/LoomTopologyView';
+import { CommandPalette } from '../components/wiring/CommandPalette';
+import { BulkEditPanel } from '../components/wiring/BulkEditPanel';
+import { WiringDetailPanel } from '../components/wiring/WiringDetailPanel';
+import { useWireCatalog } from '../components/wiring/useWireCatalog';
+import { useComponentLibrary } from '../components/wiring/useComponentLibrary';
+import { WIRE_TIERS } from '../components/wiring/harnessConstants';
+import type { WireTier } from '../components/wiring/harnessConstants';
+
+type TabId = 'formboard' | 'schematics' | 'topology' | 'data';
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: 'formboard', label: 'FORMBOARD' },
+  { id: 'schematics', label: 'SCHEMATICS' },
+  { id: 'topology', label: 'TOPOLOGY' },
+  { id: 'data', label: 'DATA' },
+];
+
+const C = {
+  bg: '#1a1a2e',
+  surface: '#1e1e32',
+  border: '#2a2a5e',
+  text: '#e0e0e8',
+  textDim: '#8888aa',
+  textMuted: '#555577',
+  accent: '#00ddff',
+};
+
+const DRC_COLORS: Record<string, string> = {
+  pass: '#22aa44', warn: '#ccaa00', fail: '#cc2222',
+};
 
 export default function WiringPlan() {
-  const navigate = useNavigate();
   const { vehicleId } = useParams();
 
-  const [vehicleInfo, setVehicleInfo] = useState<{ year?: number; make?: string; model?: string } | null>(null);
   const [manifestDevices, setManifestDevices] = useState<ManifestDevice[]>([]);
   const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState<TabId>('data');
 
+  // Cross-view selection state
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
+  const [selectedDeviceIds, setSelectedDeviceIds] = useState<Set<string>>(new Set());
+  const [selectedWireId, setSelectedWireId] = useState<number | null>(null);
+
+  // Command palette
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  // DRC filter
+  const [drcFilterSeverity, setDrcFilterSeverity] = useState<string | null>(null);
+
+  // Wire tier
+  const [tier, setTier] = useState<WireTier>('professional');
+
+  // Load manifest
   useEffect(() => {
     async function init() {
       if (!vehicleId) return;
       setLoading(true);
       try {
-        const [vehicleRes, manifestRes] = await Promise.all([
-          supabase.from('vehicles').select('year, make, model').eq('id', vehicleId).maybeSingle(),
-          supabase.from('vehicle_build_manifest')
-            .select('*')
-            .eq('vehicle_id', vehicleId)
-            .order('device_category')
-            .order('device_name'),
-        ]);
-
-        if (vehicleRes.data) setVehicleInfo(vehicleRes.data);
-        if (manifestRes.data) setManifestDevices(manifestRes.data as ManifestDevice[]);
+        const { data } = await supabase
+          .from('vehicle_build_manifest')
+          .select('*')
+          .eq('vehicle_id', vehicleId)
+          .order('device_category')
+          .order('device_name');
+        if (data) setManifestDevices(data as ManifestDevice[]);
       } finally {
         setLoading(false);
       }
@@ -38,11 +83,352 @@ export default function WiringPlan() {
     init();
   }, [vehicleId]);
 
+  // Computation hooks
+  const { devices, result, terminations, updateDevice: overlayUpdateDevice } = useOverlayCompute(manifestDevices);
+  const { drcMap, summary: drcSummary } = useDRC(devices, result);
+  const { products, gaugeConversions } = useWireCatalog(tier);
+  const { findComponent } = useComponentLibrary();
+
+  // Selected device data
+  const selectedDevice = useMemo(
+    () => selectedDeviceId ? devices.find(d => d.id === selectedDeviceId) ?? null : null,
+    [devices, selectedDeviceId],
+  );
+  const selectedWire = useMemo(
+    () => selectedDevice ? result.wires.find(w => w.to === selectedDevice.device_name) : undefined,
+    [selectedDevice, result.wires],
+  );
+  const selectedPdmChannel = useMemo(
+    () => selectedDevice ? result.pdmChannels.find(ch => ch.devices.includes(selectedDevice.device_name)) : undefined,
+    [selectedDevice, result.pdmChannels],
+  );
+  const selectedTermination = useMemo(
+    () => selectedDevice ? terminations.find(t => t.deviceName === selectedDevice.device_name) : undefined,
+    [selectedDevice, terminations],
+  );
+  const selectedLibraryComponent = useMemo(
+    () => selectedDevice ? findComponent(selectedDevice.manufacturer || '', selectedDevice.part_number || '') : undefined,
+    [selectedDevice, findComponent],
+  );
+  const selectedWireProduct = useMemo(
+    () => selectedWire ? products.find(p => p.gauge_awg === selectedWire.gauge) : undefined,
+    [selectedWire, products],
+  );
+  const selectedGaugeInfo = useMemo(
+    () => selectedWire ? gaugeConversions.find(g => g.awg === selectedWire.gauge) : undefined,
+    [selectedWire, gaugeConversions],
+  );
+
+  // Device click handler (supports multi-select with shift/ctrl)
+  const handleDeviceClick = useCallback((id: string, e: React.MouseEvent) => {
+    if (e.shiftKey) {
+      // Add to multi-select
+      setSelectedDeviceIds(prev => {
+        const next = new Set(prev);
+        next.add(id);
+        return next;
+      });
+      setSelectedDeviceId(null);
+    } else if (e.ctrlKey || e.metaKey) {
+      // Toggle in multi-select
+      setSelectedDeviceIds(prev => {
+        const next = new Set(prev);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      });
+      setSelectedDeviceId(null);
+    } else {
+      // Single select
+      setSelectedDeviceIds(new Set());
+      setSelectedDeviceId(prev => prev === id ? null : id);
+    }
+    setSelectedWireId(null);
+  }, []);
+
+  // Wire click handler
+  const handleWireClick = useCallback((wireNumber: number) => {
+    setSelectedWireId(prev => prev === wireNumber ? null : wireNumber);
+    setSelectedDeviceId(null);
+    setSelectedDeviceIds(new Set());
+  }, []);
+
+  // Clear selection on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (paletteOpen) { setPaletteOpen(false); return; }
+        setSelectedDeviceId(null);
+        setSelectedDeviceIds(new Set());
+        setSelectedWireId(null);
+        setDrcFilterSeverity(null);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [paletteOpen]);
+
+  // Cmd+K handler
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        setPaletteOpen(prev => !prev);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  // Bulk edit update handler
+  const handleBulkUpdate = useCallback((ids: string[], updates: Partial<ManifestDevice>) => {
+    for (const id of ids) {
+      overlayUpdateDevice(id, updates);
+    }
+    setSelectedDeviceIds(new Set());
+  }, [overlayUpdateDevice]);
+
+  // Command palette handlers
+  const handlePaletteSelectDevice = useCallback((deviceId: string) => {
+    setSelectedDeviceId(deviceId);
+    setSelectedDeviceIds(new Set());
+    setSelectedWireId(null);
+  }, []);
+
+  const handlePaletteSelectWire = useCallback((wireNumber: number) => {
+    setSelectedWireId(wireNumber);
+    setSelectedDeviceId(null);
+    setSelectedDeviceIds(new Set());
+  }, []);
+
+  const handlePaletteFilterZone = useCallback((_zone: string) => {
+    // Navigate to data tab for zone filtering
+    setActiveTab('data');
+  }, []);
+
+  const handlePaletteAction = useCallback((action: string) => {
+    if (action === 'print-formboard') setActiveTab('formboard');
+    else if (action === 'reset-view') {
+      setSelectedDeviceId(null);
+      setSelectedDeviceIds(new Set());
+      setSelectedWireId(null);
+    }
+  }, []);
+
+  // Stats
+  const totalCost = result.partsCost + result.recommendedConfig.totalCost;
+  const totalLength = result.wires.reduce((s, w) => s + w.lengthFt, 0);
+
   if (loading) return null;
 
+  // Filter devices by DRC severity if active
+  const filteredDevices = drcFilterSeverity
+    ? devices.filter(d => drcMap.get(d.id)?.severity === drcFilterSeverity)
+    : devices;
+
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 42px)' }}>
-      <WiringWorkspace initialDevices={manifestDevices} vehicleId={vehicleId} />
+    <div style={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 42px)', fontFamily: 'Arial, sans-serif', background: C.bg, color: C.text }}>
+      {/* ── Tab Bar + Status ────────────────────────────────────────── */}
+      <div style={{
+        display: 'flex', alignItems: 'center', padding: '0 8px', height: 32,
+        background: C.surface, borderBottom: `2px solid ${C.border}`, flexShrink: 0,
+      }}>
+        {/* Tabs */}
+        {TABS.map(tab => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            style={{
+              fontSize: '8px', fontWeight: 700, fontFamily: 'Arial', textTransform: 'uppercase',
+              letterSpacing: '0.5px', padding: '6px 14px', border: 'none',
+              borderBottom: activeTab === tab.id ? `2px solid ${C.accent}` : '2px solid transparent',
+              background: 'transparent',
+              color: activeTab === tab.id ? C.accent : C.textDim,
+              cursor: 'pointer', marginBottom: -2,
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
+
+        {/* Separator */}
+        <div style={{ width: 1, height: 16, background: C.border, margin: '0 8px' }} />
+
+        {/* Status chips */}
+        <StatChip label="DEVICES" value={String(devices.length)} />
+        <StatChip label="WIRES" value={String(result.wireCount)} />
+        <StatChip label="LENGTH" value={`${Math.round(totalLength)}ft`} />
+        <StatChip label="ECU" value={result.recommendedConfig.ecu.model} />
+        <StatChip label="PDM" value={result.recommendedConfig.pdm.config} />
+        <StatChip label="COST" value={`$${Math.round(totalCost).toLocaleString()}`} />
+
+        {/* DRC Summary */}
+        <div style={{ marginLeft: 8, display: 'flex', alignItems: 'center', gap: 2 }}>
+          <span style={{ fontSize: '7px', fontWeight: 700, color: C.textMuted, letterSpacing: '0.5px', marginRight: 4 }}>DRC</span>
+          <DrcChip count={drcSummary.pass} severity="pass" active={drcFilterSeverity === 'pass'}
+            onClick={() => setDrcFilterSeverity(prev => prev === 'pass' ? null : 'pass')} />
+          <DrcChip count={drcSummary.warn} severity="warn" active={drcFilterSeverity === 'warn'}
+            onClick={() => setDrcFilterSeverity(prev => prev === 'warn' ? null : 'warn')} />
+          <DrcChip count={drcSummary.fail} severity="fail" active={drcFilterSeverity === 'fail'}
+            onClick={() => setDrcFilterSeverity(prev => prev === 'fail' ? null : 'fail')} />
+        </div>
+
+        {/* Tier selector + Cmd+K hint */}
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+          <select
+            value={tier}
+            onChange={e => setTier(e.target.value as WireTier)}
+            style={{
+              fontSize: '7px', fontFamily: '"Courier New"', fontWeight: 700,
+              padding: '2px 4px', border: `1px solid ${C.border}`, background: C.bg, color: C.text, cursor: 'pointer',
+            }}
+          >
+            {WIRE_TIERS.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
+          </select>
+          <button
+            onClick={() => setPaletteOpen(true)}
+            style={{
+              fontSize: '7px', fontWeight: 700, fontFamily: '"Courier New"',
+              padding: '2px 8px', border: `1px solid ${C.border}`,
+              background: 'transparent', color: C.textDim, cursor: 'pointer',
+            }}
+          >
+            CMD+K
+          </button>
+        </div>
+      </div>
+
+      {/* ── View Content ────────────────────────────────────────────── */}
+      <div style={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
+        {activeTab === 'formboard' && (
+          <FormboardCanvas
+            devices={filteredDevices}
+            wires={result.wires}
+            pdmChannels={result.pdmChannels}
+            drcMap={drcMap}
+            selectedDeviceId={selectedDeviceId}
+            selectedDeviceIds={selectedDeviceIds}
+            selectedWireId={selectedWireId}
+            onDeviceClick={handleDeviceClick}
+            onWireClick={handleWireClick}
+            vehicleId={vehicleId}
+          />
+        )}
+
+        {activeTab === 'schematics' && (
+          <SchematicViewer
+            devices={filteredDevices}
+            wires={result.wires}
+            pdmChannels={result.pdmChannels}
+            drcMap={drcMap}
+            selectedDeviceId={selectedDeviceId}
+            selectedDeviceIds={selectedDeviceIds}
+            selectedWireId={selectedWireId}
+            onDeviceClick={handleDeviceClick}
+            onWireClick={handleWireClick}
+          />
+        )}
+
+        {activeTab === 'topology' && (
+          <LoomTopologyView
+            devices={filteredDevices}
+            wires={result.wires}
+            drcMap={drcMap}
+            selectedDeviceId={selectedDeviceId}
+            onDeviceClick={handleDeviceClick}
+          />
+        )}
+
+        {activeTab === 'data' && (
+          <WiringWorkspace
+            initialDevices={manifestDevices}
+            vehicleId={vehicleId}
+            selectedDeviceId={selectedDeviceId}
+            selectedDeviceIds={selectedDeviceIds}
+            selectedWireId={selectedWireId}
+            drcMap={drcMap}
+            onDeviceClick={handleDeviceClick}
+            onWireClick={handleWireClick}
+          />
+        )}
+
+        {/* ── Detail Panel (single device selected) ──────────────── */}
+        {selectedDevice && selectedDeviceIds.size === 0 && (
+          <div style={{ position: 'absolute', right: 0, top: 0, height: '100%', zIndex: 10 }}>
+            <WiringDetailPanel
+              device={selectedDevice}
+              wire={selectedWire}
+              pdmChannel={selectedPdmChannel}
+              ecuModel={result.recommendedConfig.ecu.model}
+              termination={selectedTermination}
+              onClose={() => setSelectedDeviceId(null)}
+              onSavePosition={() => {}}
+              positionDirty={false}
+              libraryComponent={selectedLibraryComponent}
+              wireProduct={selectedWireProduct}
+              gaugeInfo={selectedGaugeInfo}
+              tierLabel={WIRE_TIERS.find(t => t.value === tier)?.label}
+              allWires={result.wires}
+            />
+          </div>
+        )}
+
+        {/* ── Bulk Edit Panel (multi-select) ─────────────────────── */}
+        {selectedDeviceIds.size > 1 && (
+          <BulkEditPanel
+            devices={devices}
+            selectedIds={selectedDeviceIds}
+            onClose={() => setSelectedDeviceIds(new Set())}
+            onUpdate={handleBulkUpdate}
+          />
+        )}
+      </div>
+
+      {/* ── Command Palette ──────────────────────────────────────── */}
+      <CommandPalette
+        devices={devices}
+        wires={result.wires}
+        isOpen={paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+        onSelectDevice={handlePaletteSelectDevice}
+        onSelectWire={handlePaletteSelectWire}
+        onFilterZone={handlePaletteFilterZone}
+        onAction={handlePaletteAction}
+      />
     </div>
+  );
+}
+
+// ── Stat chip ────────────────────────────────────────────────────────
+function StatChip({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: 3, marginRight: 6 }}>
+      <span style={{ fontSize: '7px', fontWeight: 700, letterSpacing: '0.5px', color: '#555577' }}>{label}</span>
+      <span style={{ fontSize: '9px', fontFamily: '"Courier New"', fontWeight: 700, color: '#e0e0e8' }}>{value}</span>
+    </div>
+  );
+}
+
+// ── DRC Summary chip ─────────────────────────────────────────────────
+function DrcChip({ count, severity, active, onClick }: {
+  count: number; severity: string; active: boolean; onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: 'flex', alignItems: 'center', gap: 3,
+        padding: '2px 6px', border: `1px solid ${active ? DRC_COLORS[severity] : '#2a2a5e'}`,
+        background: active ? DRC_COLORS[severity] : 'transparent',
+        cursor: 'pointer', fontSize: '8px', fontFamily: '"Courier New"', fontWeight: 700,
+        color: active ? '#1a1a2e' : DRC_COLORS[severity],
+      }}
+    >
+      <span style={{
+        width: 5, height: 5, display: 'inline-block',
+        background: active ? '#1a1a2e' : DRC_COLORS[severity],
+      }} />
+      {count} {severity.toUpperCase()}
+    </button>
   );
 }


### PR DESCRIPTION
## Summary

Transforms the wiring workspace from a single data tab into a 4-tab professional harness design tool (FORMBOARD / SCHEMATICS / TOPOLOGY / DATA) with unified cross-view state management.

**7 features implemented:**

1. **Dynamic Connector Pin Tables** (FormboardCanvas.tsx) — Canvas 2D pegboard with 200"x96" board, zone boundaries, wire routing beziers, and dynamic pin tables that appear when zoom > 4x. Pin data fetched from `device_pin_maps` and cached.

2. **Traffic-Light DRC Overlay** (useDRC.ts) — 8 design rule checks: pin conflict, gauge vs ampacity, voltage drop >3%, missing pin map, missing connector type, missing location zone, PDM channel overload, unpurchased critical. DRC indicator dots on every device in every view. Summary bar: "N PASS | N WARN | N FAIL" with click-to-filter.

3. **Net Highlighting** — Click any wire on any view → all wires in the same net (PDM channel group or CAN bus) highlight with cyan glow, everything else dims to 25% opacity. Net badge shows wire count. Works across all 4 views simultaneously via `selectedWireId` state.

4. **Multi-Select + Bulk Property Edit** (BulkEditPanel.tsx) — Shift-click to add, Ctrl-click to toggle. Bulk edit panel shows shared/mixed attributes with dropdowns to set location_zone, status, purchased, pdm_channel_group on all selected devices. Saves to Supabase via `.update().in('id', ids)`.

5. **Command Palette Cmd+K** (CommandPalette.tsx) — Full-screen search overlay with fuzzy matching across devices (name/manufacturer/part#), wires (label/color/from-to), zones (with device counts), and actions (Export BOM, Print Formboard, etc.). Arrow keys + Enter navigation.

6. **Dark Schematic Toggle** — Light/Dark button on schematic tab bar. Dark: `#1a1a2e` background, `#252540` device fill. Light: white engineering drawing standard. Ground wires render as `#888` on dark. Preference saved to localStorage.

7. **Formboard Print Enhancement** — Ctrl+P generates high-res 1:1 printout with: title block (bottom-right), scale bar (6" reference ruler), connector pin tables adjacent to each device, wire color legend with swatches, zone labels, and grid coordinates (A-H rows, 1-17 columns).

**Architecture:**
- `WiringPlan.tsx` promoted to multi-tab parent managing all cross-view state (`selectedDeviceId`, `selectedDeviceIds`, `selectedWireId`, DRC, command palette)
- `WiringWorkspace.tsx` updated to accept cross-view state props
- New views: `FormboardCanvas.tsx`, `SchematicViewer.tsx`, `LoomTopologyView.tsx`
- New hooks: `useDRC.ts`
- New components: `CommandPalette.tsx`, `BulkEditPanel.tsx`
- Zero modifications to infrastructure (`overlayCompute.ts`, `harnessRouting.ts`, `terminationCompute.ts`)

## Test plan

- [ ] TypeScript compiles with zero errors (`tsc --noEmit` verified)
- [ ] Vite build succeeds (verified)
- [ ] FORMBOARD tab renders connector blocks with zone coloring and wire routing
- [ ] Zoom past 4x on formboard shows pin tables with data from `device_pin_maps`
- [ ] SCHEMATICS tab shows 5 sub-sheets with device boxes and wire paths
- [ ] Dark/Light toggle works on schematics, persists to localStorage
- [ ] TOPOLOGY tab shows zone nodes with wire counts and DRC indicators
- [ ] DATA tab device table includes DRC column with colored indicator dots
- [ ] DRC summary bar shows pass/warn/fail counts, click to filter
- [ ] Click wire on any view → net highlight with cyan glow + dimming
- [ ] Shift-click multiple devices → bulk edit panel appears
- [ ] Bulk edit: change zone/status/purchased → saves to Supabase
- [ ] Cmd+K opens command palette, fuzzy search works across all categories
- [ ] Escape clears selection on all views
- [ ] Ctrl+P on formboard generates print-ready output with title block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multiple visualization tabs for wiring plans: interactive formboard with zoom/pan, multi-sheet schematic viewer, and loom topology graph.
  * Introduced command palette (Cmd/Ctrl+K) for quick device and action search.
  * Added bulk editing panel for simultaneously modifying multiple selected devices.
  * Integrated design rule checking with visual severity indicators and filtering.
  * Added print functionality for formboard canvas with high-resolution output.
  * Enabled multi-device selection with Shift and Ctrl/Cmd modifier support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->