### PR TITLE
Rebuild wiring harness workspace UI with 5-view tab system

### DIFF
--- a/nuke_frontend/src/components/wiring/CommandPalette.tsx
+++ b/nuke_frontend/src/components/wiring/CommandPalette.tsx
@@ -1,0 +1,227 @@
+// CommandPalette.tsx — Cmd+K fuzzy search overlay
+// Search devices, wires, zones, actions. Keyboard navigable.
+
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import type { ManifestDevice, WireSpec } from './overlayCompute';
+
+const C = {
+  bg: '#1a1a2e',
+  surface: '#1f1f35',
+  elevated: '#252540',
+  text: '#e0e0e8',
+  label: '#a0a0b0',
+  muted: '#666680',
+  border: '#333355',
+  active: '#00ddff',
+} as const;
+
+interface Props {
+  devices: ManifestDevice[];
+  wires: WireSpec[];
+  zoneColors: Record<string, string>;
+  onSelectDevice: (id: string) => void;
+  onSelectWire: (wireNumber: number) => void;
+  onSwitchTab: (tab: string) => void;
+  onClose: () => void;
+}
+
+interface SearchResult {
+  type: 'device' | 'wire' | 'zone' | 'action';
+  id: string;
+  label: string;
+  detail: string;
+  color?: string;
+}
+
+export function CommandPalette({ devices, wires, zoneColors, onSelectDevice, onSelectWire, onSwitchTab, onClose }: Props) {
+  const [query, setQuery] = useState('');
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // ── Build search index ──
+  const allResults = useMemo((): SearchResult[] => {
+    const results: SearchResult[] = [];
+
+    // Actions
+    results.push(
+      { type: 'action', id: 'formboard', label: 'Go to Formboard', detail: 'View 1', color: C.active },
+      { type: 'action', id: 'schematics', label: 'Go to Schematics', detail: 'View 2', color: C.active },
+      { type: 'action', id: '3d', label: 'Go to 3D View', detail: 'View 3', color: C.active },
+      { type: 'action', id: 'data', label: 'Go to Data', detail: 'View 4', color: C.active },
+      { type: 'action', id: 'topology', label: 'Go to Topology', detail: 'View 5', color: C.active },
+    );
+
+    // Zones
+    const zones = [...new Set(devices.map(d => d.location_zone).filter(Boolean))] as string[];
+    for (const zone of zones) {
+      const count = devices.filter(d => d.location_zone === zone).length;
+      results.push({
+        type: 'zone', id: zone, label: zone.replace(/_/g, ' ').toUpperCase(),
+        detail: `${count} devices`, color: zoneColors[zone],
+      });
+    }
+
+    // Devices
+    for (const d of devices) {
+      results.push({
+        type: 'device', id: d.id,
+        label: d.device_name,
+        detail: [d.manufacturer, d.model_number, d.location_zone?.replace(/_/g, ' ')].filter(Boolean).join(' · '),
+      });
+    }
+
+    // Wires
+    for (const w of wires) {
+      results.push({
+        type: 'wire', id: String(w.wireNumber),
+        label: `W${w.wireNumber}: ${w.label}`,
+        detail: `${w.gauge}AWG ${w.color} ${w.from} → ${w.to}`,
+      });
+    }
+
+    return results;
+  }, [devices, wires, zoneColors]);
+
+  // ── Fuzzy filter ──
+  const filtered = useMemo(() => {
+    if (!query.trim()) return allResults.slice(0, 20);
+    const q = query.toLowerCase();
+    return allResults.filter(r =>
+      r.label.toLowerCase().includes(q) ||
+      r.detail.toLowerCase().includes(q) ||
+      r.type.includes(q)
+    ).slice(0, 20);
+  }, [query, allResults]);
+
+  // Reset selection when results change
+  useEffect(() => { setSelectedIdx(0); }, [filtered]);
+
+  // ── Execute ──
+  const executeResult = useCallback((result: SearchResult) => {
+    switch (result.type) {
+      case 'device': onSelectDevice(result.id); break;
+      case 'wire': onSelectWire(parseInt(result.id)); break;
+      case 'action': onSwitchTab(result.id); break;
+      case 'zone': {
+        const first = devices.find(d => d.location_zone === result.id);
+        if (first) onSelectDevice(first.id);
+        break;
+      }
+    }
+  }, [devices, onSelectDevice, onSelectWire, onSwitchTab]);
+
+  // ── Keyboard nav ──
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIdx(i => Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIdx(i => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (filtered[selectedIdx]) executeResult(filtered[selectedIdx]);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    }
+  }, [filtered, selectedIdx, executeResult, onClose]);
+
+  // ── Scroll selected into view ──
+  useEffect(() => {
+    const el = listRef.current?.children[selectedIdx] as HTMLElement | undefined;
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIdx]);
+
+  const typeIcons: Record<string, string> = {
+    device: 'DEV', wire: 'WIR', zone: 'ZON', action: 'ACT',
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, zIndex: 1000,
+        background: 'rgba(0,0,0,0.6)',
+        display: 'flex', alignItems: 'flex-start', justifyContent: 'center',
+        paddingTop: 120,
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          width: 480, maxHeight: 400,
+          background: C.bg, border: `2px solid ${C.border}`,
+          display: 'flex', flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        {/* ── Input ── */}
+        <div style={{ padding: '8px 12px', borderBottom: `2px solid ${C.border}` }}>
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Search devices, wires, zones..."
+            style={{
+              width: '100%', background: 'transparent', border: 'none', outline: 'none',
+              color: C.text, fontFamily: "'Courier New', monospace", fontSize: 13, fontWeight: 700,
+            }}
+          />
+        </div>
+
+        {/* ── Results ── */}
+        <div ref={listRef} style={{ flex: 1, overflowY: 'auto' }}>
+          {filtered.map((r, i) => (
+            <div
+              key={`${r.type}-${r.id}`}
+              onClick={() => executeResult(r)}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 8,
+                padding: '6px 12px',
+                background: i === selectedIdx ? C.elevated : 'transparent',
+                cursor: 'pointer',
+                borderLeft: i === selectedIdx ? `2px solid ${C.active}` : '2px solid transparent',
+              }}
+            >
+              <span style={{
+                fontFamily: "'Courier New', monospace", fontSize: 7, fontWeight: 700,
+                color: r.color || C.muted, minWidth: 24,
+              }}>
+                {typeIcons[r.type]}
+              </span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{
+                  fontFamily: "'Courier New', monospace", fontSize: 11, fontWeight: 700,
+                  color: C.text, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+                }}>
+                  {r.label}
+                </div>
+                <div style={{
+                  fontFamily: 'Arial', fontSize: 8, color: C.muted,
+                  whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+                }}>
+                  {r.detail}
+                </div>
+              </div>
+            </div>
+          ))}
+          {filtered.length === 0 && (
+            <div style={{
+              padding: 16, textAlign: 'center',
+              color: C.muted, fontFamily: "'Courier New', monospace", fontSize: 10,
+            }}>
+              NO RESULTS
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/nuke_frontend/src/components/wiring/DataView.tsx
+++ b/nuke_frontend/src/components/wiring/DataView.tsx
@@ -1,0 +1,549 @@
+// DataView.tsx — HTML device table with sorting, filtering, zone chips
+// Sub-tabs: DEVICES | BOM | CUT LIST. Export buttons.
+
+import React, { useState, useMemo, useCallback } from 'react';
+import type { ManifestDevice, OverlayResult } from './overlayCompute';
+import { generateBOM, bomToText } from './generateBOM';
+import { generateCutList, cutListToText } from './generateCutList';
+import type { BOMDocument } from './generateBOM';
+import type { CutListDocument } from './generateCutList';
+
+// ── Design tokens ─────────────────────────────────────────────────────
+const C = {
+  bg: '#1a1a2e',
+  surface: '#1f1f35',
+  elevated: '#252540',
+  text: '#e0e0e8',
+  label: '#a0a0b0',
+  muted: '#666680',
+  border: '#333355',
+  active: '#00ddff',
+  pass: '#22c55e',
+  warn: '#eab308',
+  fail: '#ef4444',
+} as const;
+
+const ZONE_COLORS: Record<string, string> = {
+  engine_bay: '#cc2222',
+  firewall: '#cc6600',
+  dash: '#2266cc',
+  doors: '#8822cc',
+  rear: '#22aa44',
+  underbody: '#666666',
+};
+
+type SubTab = 'devices' | 'bom' | 'cutlist';
+type SortKey = 'device_name' | 'location_zone' | 'device_category' | 'wire_gauge_recommended' | 'power_draw_amps' | 'part_number' | 'price' | 'status';
+type SortDir = 'asc' | 'desc';
+
+interface Props {
+  devices: ManifestDevice[];
+  result: OverlayResult;
+  selectedDeviceId: string | null;
+  selectedDeviceIds: Set<string>;
+  selectedWireId: number | null;
+  onDeviceClick: (id: string, shiftKey?: boolean) => void;
+  onWireClick: (wireNumber: number) => void;
+  onDeselect: () => void;
+  fitRequested: number;
+  zoneColors: Record<string, string>;
+  overlay: {
+    devices: ManifestDevice[];
+    result: OverlayResult;
+    terminations: unknown[];
+    terminationSummary: { total: number; ready: number; notReady: number; readyPct: number };
+  };
+}
+
+export function DataView({
+  devices, result, selectedDeviceId,
+  onDeviceClick, overlay,
+}: Props) {
+  const [subTab, setSubTab] = useState<SubTab>('devices');
+  const [filter, setFilter] = useState('');
+  const [zoneFilter, setZoneFilter] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>('device_name');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+
+  // ── Filtered + sorted devices ──
+  const filteredDevices = useMemo(() => {
+    let filtered = devices;
+
+    if (zoneFilter) {
+      filtered = filtered.filter(d => d.location_zone === zoneFilter);
+    }
+
+    if (filter.trim()) {
+      const q = filter.toLowerCase();
+      filtered = filtered.filter(d =>
+        d.device_name.toLowerCase().includes(q) ||
+        (d.manufacturer || '').toLowerCase().includes(q) ||
+        (d.part_number || '').toLowerCase().includes(q) ||
+        (d.device_category || '').toLowerCase().includes(q)
+      );
+    }
+
+    filtered = [...filtered].sort((a, b) => {
+      const av = a[sortKey] ?? '';
+      const bv = b[sortKey] ?? '';
+      if (typeof av === 'number' && typeof bv === 'number') {
+        return sortDir === 'asc' ? av - bv : bv - av;
+      }
+      return sortDir === 'asc'
+        ? String(av).localeCompare(String(bv))
+        : String(bv).localeCompare(String(av));
+    });
+
+    return filtered;
+  }, [devices, filter, zoneFilter, sortKey, sortDir]);
+
+  // ── Zone counts ──
+  const zoneCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const d of devices) {
+      if (d.location_zone) counts[d.location_zone] = (counts[d.location_zone] || 0) + 1;
+    }
+    return counts;
+  }, [devices]);
+
+  // ── BOM / Cut List generation ──
+  const bomDoc = useMemo((): BOMDocument | null => {
+    if (subTab !== 'bom') return null;
+    return generateBOM(result, devices, 65, overlay.terminations as never[]);
+  }, [subTab, result, devices, overlay.terminations]);
+
+  const cutListDoc = useMemo((): CutListDocument | null => {
+    if (subTab !== 'cutlist') return null;
+    return generateCutList(result);
+  }, [subTab, result]);
+
+  // ── Column sort handler ──
+  const handleSort = useCallback((key: SortKey) => {
+    if (sortKey === key) setSortDir(d => d === 'asc' ? 'desc' : 'asc');
+    else { setSortKey(key); setSortDir('asc'); }
+  }, [sortKey]);
+
+  // ── Export handlers ──
+  const handleExportBOM = useCallback(() => {
+    if (!bomDoc) return;
+    const text = bomToText(bomDoc, '1977 K5 Blazer');
+    downloadText(text, 'K5_Blazer_BOM.txt');
+  }, [bomDoc]);
+
+  const handleExportCutList = useCallback(() => {
+    if (!cutListDoc) return;
+    const text = cutListToText(cutListDoc, '1977 K5 Blazer');
+    downloadText(text, 'K5_Blazer_CutList.txt');
+  }, [cutListDoc]);
+
+  return (
+    <div style={{
+      width: '100%', height: '100%', display: 'flex', flexDirection: 'column',
+      background: C.bg, overflow: 'hidden',
+    }}>
+      {/* ── Sub-tabs + filter ── */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 8,
+        padding: '0 12px', height: 30,
+        borderBottom: `2px solid ${C.border}`,
+        flexShrink: 0,
+      }}>
+        {(['devices', 'bom', 'cutlist'] as SubTab[]).map(t => (
+          <button
+            key={t}
+            onClick={() => setSubTab(t)}
+            style={{
+              background: subTab === t ? C.elevated : 'transparent',
+              color: subTab === t ? C.active : C.label,
+              border: 'none',
+              borderBottom: subTab === t ? `2px solid ${C.active}` : '2px solid transparent',
+              padding: '0 10px', height: '100%',
+              fontFamily: 'Arial', fontSize: 8, fontWeight: 700,
+              textTransform: 'uppercase', letterSpacing: 0.5,
+              cursor: 'pointer',
+            }}
+          >
+            {t === 'cutlist' ? 'CUT LIST' : t.toUpperCase()}
+          </button>
+        ))}
+
+        <div style={{ flex: 1 }} />
+
+        {subTab === 'devices' && (
+          <input
+            value={filter}
+            onChange={e => setFilter(e.target.value)}
+            placeholder="FILTER..."
+            style={{
+              background: C.surface, border: `1px solid ${C.border}`,
+              color: C.text, padding: '3px 8px',
+              fontFamily: "'Courier New', monospace", fontSize: 10, fontWeight: 700,
+              outline: 'none', width: 180,
+            }}
+          />
+        )}
+
+        {subTab === 'bom' && (
+          <button onClick={handleExportBOM} style={exportBtnStyle}>EXPORT BOM</button>
+        )}
+        {subTab === 'cutlist' && (
+          <button onClick={handleExportCutList} style={exportBtnStyle}>EXPORT CUT LIST</button>
+        )}
+      </div>
+
+      {/* ── Zone filter chips ── */}
+      {subTab === 'devices' && (
+        <div style={{
+          display: 'flex', gap: 4, padding: '4px 12px',
+          borderBottom: `1px solid ${C.border}`,
+          flexShrink: 0,
+        }}>
+          <button
+            onClick={() => setZoneFilter(null)}
+            style={{
+              ...chipStyle,
+              color: !zoneFilter ? C.active : C.muted,
+              borderColor: !zoneFilter ? C.active : C.border,
+            }}
+          >
+            ALL ({devices.length})
+          </button>
+          {Object.entries(zoneCounts).sort((a, b) => b[1] - a[1]).map(([zone, count]) => (
+            <button
+              key={zone}
+              onClick={() => setZoneFilter(zoneFilter === zone ? null : zone)}
+              style={{
+                ...chipStyle,
+                color: zoneFilter === zone ? ZONE_COLORS[zone] || C.active : C.muted,
+                borderColor: zoneFilter === zone ? ZONE_COLORS[zone] || C.active : C.border,
+              }}
+            >
+              {zone.replace(/_/g, ' ').toUpperCase()} ({count})
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* ── Content area ── */}
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {subTab === 'devices' && (
+          <DeviceTable
+            devices={filteredDevices}
+            selectedDeviceId={selectedDeviceId}
+            sortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+            onDeviceClick={onDeviceClick}
+          />
+        )}
+        {subTab === 'bom' && bomDoc && <BOMView doc={bomDoc} />}
+        {subTab === 'cutlist' && cutListDoc && <CutListView doc={cutListDoc} />}
+      </div>
+
+      {/* ── Status bar ── */}
+      <div style={{
+        display: 'flex', gap: 12, padding: '4px 12px',
+        borderTop: `2px solid ${C.border}`,
+        fontFamily: "'Courier New', monospace", fontSize: 9, fontWeight: 700,
+        color: C.muted, flexShrink: 0,
+      }}>
+        <span>{filteredDevices.length} / {devices.length} DEVICES</span>
+        <span>PURCHASED: {devices.filter(d => d.purchased).length}/{devices.length}</span>
+        <span>TOTAL: ${Math.round(result.partsCost).toLocaleString()}</span>
+        <span>COMPLETION: {result.avgCompletion}%</span>
+      </div>
+    </div>
+  );
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Device Table
+// ══════════════════════════════════════════════════════════════════════
+
+const COLUMNS: { key: SortKey; label: string; width?: number }[] = [
+  { key: 'device_name', label: 'NAME', width: 200 },
+  { key: 'location_zone', label: 'ZONE', width: 90 },
+  { key: 'device_category', label: 'CATEGORY', width: 100 },
+  { key: 'wire_gauge_recommended', label: 'AWG', width: 50 },
+  { key: 'power_draw_amps', label: 'AMPS', width: 60 },
+  { key: 'part_number', label: 'PART #', width: 120 },
+  { key: 'price', label: 'COST', width: 70 },
+  { key: 'status', label: 'STATUS', width: 80 },
+];
+
+function DeviceTable({ devices, selectedDeviceId, sortKey, sortDir, onSort, onDeviceClick }: {
+  devices: ManifestDevice[];
+  selectedDeviceId: string | null;
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onSort: (key: SortKey) => void;
+  onDeviceClick: (id: string, shiftKey?: boolean) => void;
+}) {
+  return (
+    <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+      <thead>
+        <tr>
+          {COLUMNS.map(col => (
+            <th
+              key={col.key}
+              onClick={() => onSort(col.key)}
+              style={{
+                ...thStyle,
+                width: col.width,
+                cursor: 'pointer',
+                color: sortKey === col.key ? C.active : C.label,
+                position: 'sticky',
+                top: 0,
+                background: C.bg,
+                zIndex: 1,
+              }}
+            >
+              {col.label}
+              {sortKey === col.key && (
+                <span style={{ marginLeft: 2 }}>{sortDir === 'asc' ? '\u25B2' : '\u25BC'}</span>
+              )}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {devices.map(d => {
+          const isSelected = d.id === selectedDeviceId;
+          return (
+            <tr
+              key={d.id}
+              onClick={(e) => onDeviceClick(d.id, e.shiftKey)}
+              style={{
+                cursor: 'pointer',
+                background: isSelected ? C.active + '15' : 'transparent',
+                borderLeft: isSelected ? `2px solid ${C.active}` : '2px solid transparent',
+              }}
+            >
+              <td style={tdStyle}>{d.device_name}</td>
+              <td style={tdStyle}>
+                {d.location_zone && (
+                  <span style={{
+                    padding: '0 4px',
+                    border: `1px solid ${ZONE_COLORS[d.location_zone] || C.border}`,
+                    color: ZONE_COLORS[d.location_zone] || C.muted,
+                    fontFamily: 'Arial', fontSize: 7, fontWeight: 700,
+                    textTransform: 'uppercase',
+                  }}>
+                    {d.location_zone.replace(/_/g, ' ')}
+                  </span>
+                )}
+              </td>
+              <td style={{ ...tdStyle, color: C.muted }}>{d.device_category?.replace(/_/g, ' ')}</td>
+              <td style={tdStyle}>{d.wire_gauge_recommended || '—'}</td>
+              <td style={tdStyle}>{d.power_draw_amps || '—'}</td>
+              <td style={{ ...tdStyle, fontSize: 8 }}>{d.part_number || '—'}</td>
+              <td style={{
+                ...tdStyle,
+                color: d.purchased ? C.pass : d.price ? C.fail : C.muted,
+              }}>
+                {d.price ? `$${d.price}` : '—'}
+              </td>
+              <td style={{
+                ...tdStyle,
+                color: d.status === 'validated' ? C.pass : d.status === 'wired' ? C.active : d.status === 'in_progress' ? C.warn : C.muted,
+              }}>
+                {d.status?.replace(/_/g, ' ').toUpperCase() || '—'}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// BOM View
+// ══════════════════════════════════════════════════════════════════════
+
+function BOMView({ doc }: { doc: BOMDocument }) {
+  return (
+    <div style={{ padding: 12 }}>
+      {doc.sections.map(section => (
+        <div key={section.section} style={{ marginBottom: 16 }}>
+          <div style={{
+            fontFamily: 'Arial', fontSize: 8, fontWeight: 700,
+            textTransform: 'uppercase', letterSpacing: 1,
+            color: C.active, paddingBottom: 4,
+            borderBottom: `2px solid ${C.border}`, marginBottom: 4,
+          }}>
+            {section.section} ({section.itemCount} ITEMS — ${Math.round(section.subtotal).toLocaleString()})
+          </div>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                {['PART', 'P/N', 'QTY', 'UNIT', 'TOTAL', 'STATUS'].map(h => (
+                  <th key={h} style={thStyle}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {section.items.map((item, i) => (
+                <tr key={i}>
+                  <td style={tdStyle}>{item.partName}</td>
+                  <td style={{ ...tdStyle, fontSize: 8 }}>{item.partNumber || '—'}</td>
+                  <td style={tdStyle}>{item.quantity}</td>
+                  <td style={tdStyle}>{item.unitPrice ? `$${item.unitPrice.toFixed(2)}` : '—'}</td>
+                  <td style={tdStyle}>{item.totalPrice ? `$${item.totalPrice.toFixed(2)}` : '—'}</td>
+                  <td style={{
+                    ...tdStyle,
+                    color: item.purchased ? C.pass : C.fail,
+                  }}>
+                    {item.purchased ? 'PURCHASED' : 'NEEDED'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+
+      {/* Totals */}
+      <div style={{
+        padding: '8px 0', borderTop: `2px solid ${C.border}`,
+        display: 'flex', gap: 16,
+        fontFamily: "'Courier New', monospace", fontSize: 11, fontWeight: 700,
+      }}>
+        <span style={{ color: C.label }}>PARTS: <span style={{ color: C.text }}>${Math.round(doc.totalCost).toLocaleString()}</span></span>
+        <span style={{ color: C.label }}>LABOR: <span style={{ color: C.text }}>${Math.round(doc.estimatedLaborCost).toLocaleString()}</span></span>
+        <span style={{ color: C.active }}>TOTAL: ${Math.round(doc.grandTotal).toLocaleString()}</span>
+      </div>
+    </div>
+  );
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Cut List View
+// ══════════════════════════════════════════════════════════════════════
+
+function CutListView({ doc }: { doc: CutListDocument }) {
+  return (
+    <div style={{ padding: 12 }}>
+      {doc.sections.map(section => (
+        <div key={section.section} style={{ marginBottom: 16 }}>
+          <div style={{
+            fontFamily: 'Arial', fontSize: 8, fontWeight: 700,
+            textTransform: 'uppercase', letterSpacing: 1,
+            color: C.active, paddingBottom: 4,
+            borderBottom: `2px solid ${C.border}`, marginBottom: 4,
+          }}>
+            {section.section} ({section.wires.length} WIRES — {section.totalLengthFt.toFixed(1)} FT)
+          </div>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                {['#', 'LABEL', 'FROM', 'TO', 'SPEC', 'COLOR', 'LENGTH'].map(h => (
+                  <th key={h} style={thStyle}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {section.wires.map(w => (
+                <tr key={w.wireNumber}>
+                  <td style={{ ...tdStyle, color: C.muted }}>W{w.wireNumber}</td>
+                  <td style={tdStyle}>{w.label}</td>
+                  <td style={{ ...tdStyle, fontSize: 8 }}>{w.from}</td>
+                  <td style={{ ...tdStyle, fontSize: 8 }}>{w.to}</td>
+                  <td style={tdStyle}>{w.spec}</td>
+                  <td style={tdStyle}>{w.color}</td>
+                  <td style={tdStyle}>{w.lengthFt.toFixed(1)} ft</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+
+      {/* Purchase summary */}
+      {doc.purchaseSummary.length > 0 && (
+        <div style={{ marginTop: 16 }}>
+          <div style={{
+            fontFamily: 'Arial', fontSize: 8, fontWeight: 700,
+            textTransform: 'uppercase', letterSpacing: 1,
+            color: C.label, paddingBottom: 4,
+            borderBottom: `2px solid ${C.border}`, marginBottom: 4,
+          }}>
+            WIRE PURCHASE SUMMARY
+          </div>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                {['GAUGE', 'TOTAL', 'SPOOL', 'COLORS'].map(h => (
+                  <th key={h} style={thStyle}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {doc.purchaseSummary.map(s => (
+                <tr key={s.gauge}>
+                  <td style={tdStyle}>{s.gauge} AWG</td>
+                  <td style={tdStyle}>{s.totalLengthFt.toFixed(1)} ft</td>
+                  <td style={tdStyle}>{s.suggestedSpoolFt} ft spool</td>
+                  <td style={{ ...tdStyle, fontSize: 8 }}>{s.colors.join(', ')}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function downloadText(text: string, filename: string) {
+  const blob = new Blob([text], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ── Styles ──────────────────────────────────────────────────────────
+
+const thStyle: React.CSSProperties = {
+  fontFamily: 'Arial', fontSize: 7, fontWeight: 700,
+  textTransform: 'uppercase', letterSpacing: 0.5,
+  color: '#a0a0b0',
+  padding: '4px 6px',
+  textAlign: 'left',
+  borderBottom: '2px solid #333355',
+};
+
+const tdStyle: React.CSSProperties = {
+  fontFamily: "'Courier New', monospace", fontSize: 10, fontWeight: 700,
+  color: '#e0e0e8',
+  padding: '3px 6px',
+  borderBottom: '1px solid #333355',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  maxWidth: 200,
+};
+
+const chipStyle: React.CSSProperties = {
+  background: 'transparent',
+  border: '1px solid #333355',
+  padding: '1px 6px',
+  fontFamily: 'Arial', fontSize: 7, fontWeight: 700,
+  textTransform: 'uppercase',
+  cursor: 'pointer',
+};
+
+const exportBtnStyle: React.CSSProperties = {
+  background: 'transparent',
+  border: '2px solid #333355',
+  color: '#00ddff',
+  padding: '3px 10px',
+  fontFamily: 'Arial', fontSize: 8, fontWeight: 700,
+  textTransform: 'uppercase', letterSpacing: 0.5,
+  cursor: 'pointer',
+};

--- a/nuke_frontend/src/components/wiring/DataView.tsx
+++ b/nuke_frontend/src/components/wiring/DataView.tsx
@@ -36,6 +36,11 @@ type SubTab = 'devices' | 'bom' | 'cutlist';
 type SortKey = 'device_name' | 'location_zone' | 'device_category' | 'wire_gauge_recommended' | 'power_draw_amps' | 'part_number' | 'price' | 'status';
 type SortDir = 'asc' | 'desc';
 
+interface DRCDeviceResult {
+  severity: 'pass' | 'warn' | 'fail';
+  rules: { ruleId: string; label: string; message: string; severity: 'pass' | 'warn' | 'fail' }[];
+}
+
 interface Props {
   devices: ManifestDevice[];
   result: OverlayResult;
@@ -47,6 +52,7 @@ interface Props {
   onDeselect: () => void;
   fitRequested: number;
   zoneColors: Record<string, string>;
+  drcMap?: Map<string, DRCDeviceResult>;
   overlay: {
     devices: ManifestDevice[];
     result: OverlayResult;
@@ -57,7 +63,7 @@ interface Props {
 
 export function DataView({
   devices, result, selectedDeviceId,
-  onDeviceClick, overlay,
+  onDeviceClick, overlay, drcMap,
 }: Props) {
   const [subTab, setSubTab] = useState<SubTab>('devices');
   const [filter, setFilter] = useState('');
@@ -234,6 +240,7 @@ export function DataView({
             sortDir={sortDir}
             onSort={handleSort}
             onDeviceClick={onDeviceClick}
+            drcMap={drcMap}
           />
         )}
         {subTab === 'bom' && bomDoc && <BOMView doc={bomDoc} />}
@@ -260,7 +267,8 @@ export function DataView({
 // Device Table
 // ══════════════════════════════════════════════════════════════════════
 
-const COLUMNS: { key: SortKey; label: string; width?: number }[] = [
+const COLUMNS: { key: SortKey | 'drc'; label: string; width?: number }[] = [
+  { key: 'drc', label: 'DRC', width: 30 },
   { key: 'device_name', label: 'NAME', width: 200 },
   { key: 'location_zone', label: 'ZONE', width: 90 },
   { key: 'device_category', label: 'CATEGORY', width: 100 },
@@ -271,13 +279,16 @@ const COLUMNS: { key: SortKey; label: string; width?: number }[] = [
   { key: 'status', label: 'STATUS', width: 80 },
 ];
 
-function DeviceTable({ devices, selectedDeviceId, sortKey, sortDir, onSort, onDeviceClick }: {
+const DRC_COLORS = { pass: '#22c55e', warn: '#eab308', fail: '#ef4444' } as const;
+
+function DeviceTable({ devices, selectedDeviceId, sortKey, sortDir, onSort, onDeviceClick, drcMap }: {
   devices: ManifestDevice[];
   selectedDeviceId: string | null;
   sortKey: SortKey;
   sortDir: SortDir;
   onSort: (key: SortKey) => void;
   onDeviceClick: (id: string, shiftKey?: boolean) => void;
+  drcMap?: Map<string, DRCDeviceResult>;
 }) {
   return (
     <table style={{ width: '100%', borderCollapse: 'collapse' }}>
@@ -286,11 +297,11 @@ function DeviceTable({ devices, selectedDeviceId, sortKey, sortDir, onSort, onDe
           {COLUMNS.map(col => (
             <th
               key={col.key}
-              onClick={() => onSort(col.key)}
+              onClick={() => col.key !== 'drc' && onSort(col.key as SortKey)}
               style={{
                 ...thStyle,
                 width: col.width,
-                cursor: 'pointer',
+                cursor: col.key !== 'drc' ? 'pointer' : 'default',
                 color: sortKey === col.key ? C.active : C.label,
                 position: 'sticky',
                 top: 0,
@@ -309,6 +320,8 @@ function DeviceTable({ devices, selectedDeviceId, sortKey, sortDir, onSort, onDe
       <tbody>
         {devices.map(d => {
           const isSelected = d.id === selectedDeviceId;
+          const drcResult = drcMap?.get(d.id);
+          const drcColor = drcResult ? DRC_COLORS[drcResult.severity] : undefined;
           return (
             <tr
               key={d.id}
@@ -319,6 +332,18 @@ function DeviceTable({ devices, selectedDeviceId, sortKey, sortDir, onSort, onDe
                 borderLeft: isSelected ? `2px solid ${C.active}` : '2px solid transparent',
               }}
             >
+              <td style={{ ...tdStyle, textAlign: 'center', width: 30 }}>
+                {drcColor && (
+                  <span
+                    style={{
+                      display: 'inline-block',
+                      width: 6, height: 6,
+                      background: drcColor,
+                    }}
+                    title={drcResult?.rules.filter(r => r.severity !== 'pass').map(r => r.message).join('; ') || 'All checks pass'}
+                  />
+                )}
+              </td>
               <td style={tdStyle}>{d.device_name}</td>
               <td style={tdStyle}>
                 {d.location_zone && (

--- a/nuke_frontend/src/components/wiring/DeviceDetailPanel.tsx
+++ b/nuke_frontend/src/components/wiring/DeviceDetailPanel.tsx
@@ -1,0 +1,457 @@
+// DeviceDetailPanel.tsx — THE one detail panel used by ALL views.
+// Slides in from the right (320px). Shows everything about a device:
+// product photo, procurement, electrical specs, every pin/wire,
+// connector face link, related parts with system total cost.
+
+import React, { useMemo } from 'react';
+import type { ManifestDevice, WireSpec, OverlayResult, PDMChannel } from './overlayCompute';
+
+// ── Design tokens ─────────────────────────────────────────────────────
+const C = {
+  bg: '#1a1a2e',
+  surface: '#1f1f35',
+  elevated: '#252540',
+  text: '#e0e0e8',
+  label: '#a0a0b0',
+  muted: '#666680',
+  border: '#333355',
+  active: '#00ddff',
+  pass: '#22c55e',
+  warn: '#eab308',
+  fail: '#ef4444',
+} as const;
+
+const ZONE_LABELS: Record<string, string> = {
+  engine_bay: 'ENGINE BAY',
+  firewall: 'FIREWALL',
+  dash: 'DASH',
+  doors: 'DOORS',
+  rear: 'REAR',
+  underbody: 'UNDERBODY',
+  roof: 'ROOF',
+};
+
+// ── Pin map row type ──────────────────────────────────────────────────
+interface PinMapRow {
+  pin_number: string;
+  pin_function: string;
+  signal_type: string;
+  max_current_amps: number;
+  default_wire_color: string;
+  default_wire_gauge_awg: number;
+  connected_to_device: string;
+  connected_to_pin: string;
+  requires_shielding: boolean;
+  connector_name: string;
+  device_model: string;
+}
+
+interface PartsReceptionRow {
+  part_number: string;
+  quantity_ordered: number;
+  quantity_received: number;
+  status: string;
+  unit_cost: number;
+  total_cost: number;
+  order_date: string;
+  actual_delivery_date: string;
+}
+
+interface WorkOrderPartRow {
+  part_name: string;
+  part_number: string;
+  brand: string;
+  quantity: number;
+  unit_price: number;
+  total_price: number;
+  status: string;
+  image_url: string;
+}
+
+// ── Props ─────────────────────────────────────────────────────────────
+interface Props {
+  device: ManifestDevice | null;
+  wire: WireSpec | null;
+  result: OverlayResult;
+  devices: ManifestDevice[];
+  pinMaps: Record<string, unknown[]>;
+  partsReception: unknown[];
+  workOrderParts: unknown[];
+  zoneColors: Record<string, string>;
+  onClose: () => void;
+  onShowOnFormboard: (deviceId: string) => void;
+}
+
+export function DeviceDetailPanel({
+  device, wire, result, devices, pinMaps, partsReception, workOrderParts,
+  zoneColors, onClose, onShowOnFormboard,
+}: Props) {
+  // ── Device wires from overlay ──
+  const deviceWires = useMemo(() => {
+    if (!device) return [];
+    return result.wires.filter(w => w.to === device.device_name || w.from.includes(device.device_name));
+  }, [device, result.wires]);
+
+  // ── PDM channel for this device ──
+  const pdmChannel = useMemo((): PDMChannel | null => {
+    if (!device) return null;
+    return result.pdmChannels.find(ch => ch.devices.includes(device.device_name)) ?? null;
+  }, [device, result.pdmChannels]);
+
+  // ── Pin maps for this device ──
+  const devicePins = useMemo((): PinMapRow[] => {
+    if (!device?.model_number) return [];
+    return (pinMaps[device.model_number] ?? []) as PinMapRow[];
+  }, [device, pinMaps]);
+
+  // ── Procurement data ──
+  const procurementData = useMemo((): PartsReceptionRow | null => {
+    if (!device?.part_number) return null;
+    return (partsReception as PartsReceptionRow[]).find(
+      p => p.part_number === device.part_number
+    ) ?? null;
+  }, [device, partsReception]);
+
+  const workOrderData = useMemo((): WorkOrderPartRow[] => {
+    if (!device?.part_number) return [];
+    return (workOrderParts as WorkOrderPartRow[]).filter(
+      p => p.part_number === device.part_number
+    );
+  }, [device, workOrderParts]);
+
+  // ── Related devices (same category or same zone) ──
+  const relatedDevices = useMemo(() => {
+    if (!device) return [];
+    return devices.filter(d =>
+      d.id !== device.id && (
+        d.device_category === device.device_category ||
+        d.location_zone === device.location_zone
+      )
+    ).slice(0, 8);
+  }, [device, devices]);
+
+  // ── System total cost (same category) ──
+  const systemCost = useMemo(() => {
+    if (!device) return 0;
+    return devices
+      .filter(d => d.device_category === device.device_category)
+      .reduce((sum, d) => sum + (d.price || 0), 0);
+  }, [device, devices]);
+
+  const categoryLabel = useMemo(() => {
+    if (!device) return '';
+    return device.device_category.replace(/_/g, ' ').toUpperCase();
+  }, [device]);
+
+  // ── Slide in/out ──
+  const isOpen = device !== null;
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        width: 320,
+        background: C.bg,
+        borderLeft: `2px solid ${C.border}`,
+        transform: isOpen ? 'translateX(0)' : 'translateX(320px)',
+        transition: 'transform 200ms cubic-bezier(0.16, 1, 0.3, 1)',
+        zIndex: 100,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        pointerEvents: isOpen ? 'auto' : 'none',
+      }}
+    >
+      {device && (
+        <>
+          {/* ── Header ── */}
+          <div style={{
+            padding: '10px 12px 8px',
+            borderBottom: `2px solid ${C.border}`,
+            flexShrink: 0,
+          }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+              <div>
+                <div style={{
+                  fontFamily: "'Courier New', monospace", fontSize: 12, fontWeight: 700,
+                  color: C.text, lineHeight: 1.2,
+                }}>
+                  {device.device_name}
+                </div>
+                <div style={{
+                  fontFamily: 'Arial', fontSize: 8, fontWeight: 700, textTransform: 'uppercase',
+                  letterSpacing: 1, color: C.label, marginTop: 2,
+                }}>
+                  {device.manufacturer} {device.model_number}
+                </div>
+              </div>
+              <button onClick={onClose} style={{
+                background: 'transparent', border: `1px solid ${C.border}`,
+                color: C.muted, cursor: 'pointer', padding: '2px 6px',
+                fontFamily: "'Courier New', monospace", fontSize: 10,
+              }}>
+                ESC
+              </button>
+            </div>
+            {/* Zone chip */}
+            {device.location_zone && (
+              <span style={{
+                display: 'inline-block', marginTop: 4,
+                padding: '1px 6px',
+                border: `1px solid ${zoneColors[device.location_zone] || C.border}`,
+                color: zoneColors[device.location_zone] || C.label,
+                fontFamily: 'Arial', fontSize: 7, fontWeight: 700,
+                textTransform: 'uppercase', letterSpacing: 0.5,
+              }}>
+                {ZONE_LABELS[device.location_zone] || device.location_zone}
+              </span>
+            )}
+          </div>
+
+          {/* ── Scrollable body ── */}
+          <div style={{ flex: 1, overflowY: 'auto', overflowX: 'hidden' }}>
+            {/* ── Product Photo ── */}
+            {device.product_image_url && (
+              <div style={{ padding: 12, borderBottom: `1px solid ${C.border}` }}>
+                <img
+                  src={device.product_image_url}
+                  alt={device.device_name}
+                  style={{
+                    width: '100%', height: 'auto', maxHeight: 200,
+                    objectFit: 'contain', background: '#111',
+                    border: `1px solid ${C.border}`,
+                  }}
+                />
+              </div>
+            )}
+
+            {/* ── Procurement Status ── */}
+            <Section title="PROCUREMENT">
+              <Row label="PRICE" value={device.price ? `$${device.price.toFixed(2)}` : '—'} color={device.price ? C.text : C.muted} />
+              <Row
+                label="STATUS"
+                value={device.purchased ? 'PURCHASED' : 'NOT PURCHASED'}
+                color={device.purchased ? C.pass : C.fail}
+              />
+              {procurementData && (
+                <>
+                  <Row label="ORDERED" value={String(procurementData.quantity_ordered)} />
+                  <Row label="RECEIVED" value={String(procurementData.quantity_received)}
+                    color={procurementData.quantity_received >= procurementData.quantity_ordered ? C.pass : C.warn} />
+                  <Row label="PROCUREMENT" value={procurementData.status?.toUpperCase() || '—'} />
+                </>
+              )}
+              {workOrderData.length > 0 && workOrderData.map((wo, i) => (
+                <Row key={i} label={`WO PART ${i + 1}`} value={`${wo.quantity}× $${wo.unit_price}`} />
+              ))}
+            </Section>
+
+            {/* ── Electrical Specs ── */}
+            <Section title="ELECTRICAL">
+              <Row label="PIN COUNT" value={String(device.pin_count || '—')} />
+              <Row label="POWER DRAW" value={device.power_draw_amps ? `${device.power_draw_amps}A` : '—'} />
+              <Row label="SIGNAL TYPE" value={device.signal_type?.replace(/_/g, ' ').toUpperCase() || '—'} />
+              <Row label="CONNECTOR" value={device.connector_type?.replace(/_/g, ' ').toUpperCase() || '—'} />
+              <Row label="WIRE GAUGE" value={device.wire_gauge_recommended ? `${device.wire_gauge_recommended} AWG` : '—'} />
+              {device.requires_shielding && <Row label="SHIELDING" value="REQUIRED" color={C.warn} />}
+              {device.pdm_controlled && <Row label="PDM CONTROLLED" value="YES" color={C.active} />}
+              {pdmChannel && (
+                <>
+                  <Row label="PDM CHANNEL" value={`OUT${pdmChannel.channel}`} color={C.active} />
+                  <Row label="PDM MAX" value={`${pdmChannel.maxAmps}A`} />
+                  <Row
+                    label="PDM LOAD"
+                    value={`${pdmChannel.totalAmps.toFixed(1)}A`}
+                    color={pdmChannel.totalAmps > pdmChannel.maxAmps ? C.fail : C.pass}
+                  />
+                </>
+              )}
+            </Section>
+
+            {/* ── Wiring ── */}
+            {deviceWires.length > 0 && (
+              <Section title={`WIRING (${deviceWires.length} WIRES)`}>
+                {deviceWires.map(w => (
+                  <div key={w.wireNumber} style={{
+                    padding: '3px 0',
+                    borderBottom: `1px solid ${C.border}`,
+                  }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                      <span style={valStyle}>W{w.wireNumber}</span>
+                      <span style={{ ...valStyle, color: C.active }}>{w.from} → {w.to}</span>
+                    </div>
+                    <div style={{ display: 'flex', gap: 8, marginTop: 1 }}>
+                      <span style={miniStyle}>{w.gauge} AWG</span>
+                      <span style={miniStyle}>{w.color}</span>
+                      <span style={miniStyle}>{w.lengthFt.toFixed(1)} FT</span>
+                      {w.voltageDrop > 0 && (
+                        <span style={{
+                          ...miniStyle,
+                          color: w.voltageDropPct > 3 ? C.fail : w.voltageDropPct > 2 ? C.warn : C.muted,
+                        }}>
+                          {w.voltageDropPct.toFixed(1)}% VDROP
+                        </span>
+                      )}
+                      {w.isShielded && <span style={{ ...miniStyle, color: C.warn }}>SH</span>}
+                      {w.isTwistedPair && <span style={{ ...miniStyle, color: C.warn }}>TP</span>}
+                      {w.fuseRating && <span style={miniStyle}>{w.fuseRating}A FUSE</span>}
+                    </div>
+                  </div>
+                ))}
+              </Section>
+            )}
+
+            {/* ── Pin Map ── */}
+            {devicePins.length > 0 && (
+              <Section title={`PIN MAP (${devicePins.length} PINS)`}>
+                <div style={{ maxHeight: 200, overflowY: 'auto' }}>
+                  <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                    <thead>
+                      <tr>
+                        {['PIN', 'FUNCTION', 'WIRE', 'TO'].map(h => (
+                          <th key={h} style={{
+                            ...lblStyle, textAlign: 'left', padding: '2px 4px',
+                            borderBottom: `1px solid ${C.border}`,
+                          }}>
+                            {h}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {devicePins.map((pin, i) => (
+                        <tr key={i}>
+                          <td style={cellStyle}>{pin.pin_number}</td>
+                          <td style={cellStyle}>{pin.pin_function}</td>
+                          <td style={cellStyle}>{pin.default_wire_color} {pin.default_wire_gauge_awg}AWG</td>
+                          <td style={cellStyle}>{pin.connected_to_device}{pin.connected_to_pin ? `:${pin.connected_to_pin}` : ''}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </Section>
+            )}
+
+            {/* ── Completion & Status ── */}
+            <Section title="STATUS">
+              <Row label="DATA COMPLETE" value={`${device.pct_complete || 0}%`}
+                color={(device.pct_complete || 0) > 70 ? C.pass : (device.pct_complete || 0) > 40 ? C.warn : C.fail} />
+              <Row label="BUILD STATUS" value={device.status?.replace(/_/g, ' ').toUpperCase() || 'NOT STARTED'} />
+              {/* Progress bar */}
+              <div style={{ margin: '4px 0', height: 3, background: C.border }}>
+                <div style={{
+                  height: '100%', width: `${device.pct_complete || 0}%`,
+                  background: (device.pct_complete || 0) > 70 ? C.pass : (device.pct_complete || 0) > 40 ? C.warn : C.fail,
+                }} />
+              </div>
+            </Section>
+
+            {/* ── Related Devices / System Cost ── */}
+            {relatedDevices.length > 0 && (
+              <Section title={`RELATED — ${categoryLabel}`}>
+                {relatedDevices.map(d => (
+                  <div key={d.id} style={{
+                    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                    padding: '2px 0', cursor: 'pointer',
+                  }}>
+                    <span style={{ ...valStyle, fontSize: 9 }}>{d.device_name}</span>
+                    <span style={{
+                      ...valStyle, fontSize: 9,
+                      color: d.purchased ? C.pass : C.fail,
+                    }}>
+                      {d.price ? `$${d.price}` : '—'}
+                    </span>
+                  </div>
+                ))}
+                <div style={{
+                  marginTop: 6, paddingTop: 4,
+                  borderTop: `2px solid ${C.border}`,
+                  display: 'flex', justifyContent: 'space-between',
+                }}>
+                  <span style={lblStyle}>{categoryLabel} TOTAL</span>
+                  <span style={{ ...valStyle, color: C.active, fontSize: 11 }}>
+                    ${Math.round(systemCost).toLocaleString()}
+                  </span>
+                </div>
+              </Section>
+            )}
+
+            {/* ── Actions ── */}
+            <div style={{ padding: '8px 12px 16px', display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <button
+                onClick={() => onShowOnFormboard(device.id)}
+                style={actionButtonStyle}
+              >
+                SHOW ON FORMBOARD
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Section wrapper ─────────────────────────────────────────────────
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ padding: '6px 12px 8px', borderBottom: `1px solid ${C.border}` }}>
+      <div style={{
+        fontFamily: 'Arial', fontSize: 7, fontWeight: 700,
+        textTransform: 'uppercase', letterSpacing: 1,
+        color: '#a0a0b0', marginBottom: 4,
+        paddingBottom: 2, borderBottom: `1px solid ${C.border}`,
+      }}>
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ── Row (label: value) ──────────────────────────────────────────────
+function Row({ label, value, color }: { label: string; value: string; color?: string }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', padding: '1px 0' }}>
+      <span style={lblStyle}>{label}</span>
+      <span style={{ ...valStyle, color: color || '#e0e0e8' }}>{value}</span>
+    </div>
+  );
+}
+
+// ── Shared styles ─────────────────────────────────────────────────────
+const lblStyle: React.CSSProperties = {
+  fontFamily: 'Arial', fontSize: 8, fontWeight: 700,
+  textTransform: 'uppercase', letterSpacing: 0.5,
+  color: '#a0a0b0',
+};
+
+const valStyle: React.CSSProperties = {
+  fontFamily: "'Courier New', monospace", fontSize: 10, fontWeight: 700,
+  color: '#e0e0e8',
+};
+
+const miniStyle: React.CSSProperties = {
+  fontFamily: "'Courier New', monospace", fontSize: 8, fontWeight: 700,
+  color: '#666680',
+};
+
+const cellStyle: React.CSSProperties = {
+  ...valStyle, fontSize: 8, padding: '1px 4px',
+  borderBottom: '1px solid #333355',
+};
+
+const actionButtonStyle: React.CSSProperties = {
+  background: 'transparent',
+  border: '2px solid #333355',
+  color: '#00ddff',
+  padding: '6px 12px',
+  fontFamily: 'Arial', fontSize: 8, fontWeight: 700,
+  textTransform: 'uppercase', letterSpacing: 1,
+  cursor: 'pointer',
+  transition: 'all 200ms cubic-bezier(0.16, 1, 0.3, 1)',
+};

--- a/nuke_frontend/src/components/wiring/FormboardView.tsx
+++ b/nuke_frontend/src/components/wiring/FormboardView.tsx
@@ -1,0 +1,751 @@
+// FormboardView.tsx — Canvas 2D formboard, 200×96" pegboard at 1:1 scale.
+// Figma-like camera: scroll-to-zoom on cursor, smooth lerp, pinch, space+drag pan.
+// 5 LOD levels. Connector click → detail panel (via parent onDeviceClick).
+
+import React, { useRef, useEffect, useCallback, useState } from 'react';
+import type { ManifestDevice, WireSpec, OverlayResult } from './overlayCompute';
+import { K5_HARNESS_GRAPH, routeWiresAlongHarness, computeTrunkSegments } from './harnessRouting';
+import type { TrunkRenderSegment } from './harnessRouting';
+
+// ── Design tokens ─────────────────────────────────────────────────────
+const C = {
+  bg: '#1a1a2e',
+  surface: '#1f1f35',
+  elevated: '#252540',
+  text: '#e0e0e8',
+  label: '#a0a0b0',
+  muted: '#666680',
+  border: '#333355',
+  active: '#00ddff',
+};
+
+const ZONE_COLORS: Record<string, string> = {
+  engine_bay: '#cc2222',
+  firewall: '#cc6600',
+  dash: '#2266cc',
+  doors: '#8822cc',
+  rear: '#22aa44',
+  underbody: '#666666',
+};
+
+const WIRE_DISPLAY_COLORS: Record<string, string> = {
+  RED: '#ff4444', BLK: '#888888', GRN: '#22cc44', WHT: '#ffffff',
+  BLU: '#4488ff', YEL: '#ffdd00', ORG: '#ff8800', VIO: '#aa44ff',
+  TAN: '#cc9966', PPL: '#9944cc', PNK: '#ff88aa', BRN: '#884422',
+  GRY: '#999999', 'LT GRN': '#66ee66', 'LT BLU': '#66aaff',
+  'DK GRN': '#228822', 'DK BLU': '#2244aa',
+};
+
+// Board dimensions in inches (the physical formboard)
+const BOARD_W = 200;
+const BOARD_H = 96;
+// Scale: 1 board inch = 5 canvas pixels (base)
+const PX_PER_INCH = 5;
+const CANVAS_W = BOARD_W * PX_PER_INCH; // 1000
+const CANVAS_H = BOARD_H * PX_PER_INCH; // 480
+
+interface CameraState { x: number; y: number; zoom: number; }
+
+interface Props {
+  devices: ManifestDevice[];
+  result: OverlayResult;
+  selectedDeviceId: string | null;
+  selectedDeviceIds: Set<string>;
+  selectedWireId: number | null;
+  onDeviceClick: (id: string, shiftKey?: boolean) => void;
+  onWireClick: (wireNumber: number) => void;
+  onDeselect: () => void;
+  fitRequested: number;
+  zoneColors: Record<string, string>;
+  cameraRef: CameraState;
+}
+
+export function FormboardView({
+  devices, result, selectedDeviceId, selectedDeviceIds, selectedWireId,
+  onDeviceClick, onWireClick, onDeselect, fitRequested, cameraRef,
+}: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // ── Camera (lerp target + current) ──
+  const targetCam = useRef<CameraState>({ ...cameraRef });
+  const currentCam = useRef<CameraState>({ ...cameraRef });
+  const animFrame = useRef(0);
+  const isPanning = useRef(false);
+  const spaceDown = useRef(false);
+  const lastMouse = useRef({ x: 0, y: 0 });
+  const mouseCanvas = useRef({ x: 0, y: 0 }); // mouse pos in canvas coords
+
+  // ── Precomputed routing data ──
+  const routingRef = useRef<{ trunks: TrunkRenderSegment[] }>({ trunks: [] });
+
+  // Compute trunk segments once
+  useEffect(() => {
+    const requests = result.wires.map(w => {
+      const fromDev = devices.find(d => d.device_name === w.from.split(':')[0]);
+      const toDev = devices.find(d => d.device_name === w.to);
+      return {
+        wireNumber: w.wireNumber,
+        fromX: (fromDev?.pos_x_pct ?? 50) * PX_PER_INCH,
+        fromY: (fromDev?.pos_y_pct ?? 50) * PX_PER_INCH,
+        toX: (toDev?.pos_x_pct ?? 50) * PX_PER_INCH,
+        toY: (toDev?.pos_y_pct ?? 50) * PX_PER_INCH,
+      };
+    });
+    const routed = routeWiresAlongHarness(requests);
+    routingRef.current.trunks = computeTrunkSegments(routed);
+  }, [devices, result.wires]);
+
+  // ── Screen <-> canvas coordinate transforms ──
+  const screenToCanvas = useCallback((sx: number, sy: number): { x: number; y: number } => {
+    const cam = currentCam.current;
+    return {
+      x: (sx - cam.x) / cam.zoom,
+      y: (sy - cam.y) / cam.zoom,
+    };
+  }, []);
+
+  // ── Smooth camera animation loop ──
+  const render = useCallback(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d');
+    if (!canvas || !ctx) return;
+
+    const container = containerRef.current;
+    if (container) {
+      const dpr = window.devicePixelRatio || 1;
+      const w = container.clientWidth;
+      const h = container.clientHeight;
+      if (canvas.width !== w * dpr || canvas.height !== h * dpr) {
+        canvas.width = w * dpr;
+        canvas.height = h * dpr;
+        canvas.style.width = `${w}px`;
+        canvas.style.height = `${h}px`;
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      }
+    }
+
+    // Lerp camera toward target
+    const lerp = 0.15;
+    const cam = currentCam.current;
+    const tgt = targetCam.current;
+    cam.x += (tgt.x - cam.x) * lerp;
+    cam.y += (tgt.y - cam.y) * lerp;
+    cam.zoom += (tgt.zoom - cam.zoom) * lerp;
+
+    // Sync back to parent ref
+    cameraRef.x = cam.x;
+    cameraRef.y = cam.y;
+    cameraRef.zoom = cam.zoom;
+
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+
+    // Clear
+    ctx.clearRect(0, 0, w, h);
+    ctx.fillStyle = C.bg;
+    ctx.fillRect(0, 0, w, h);
+
+    // Apply camera transform
+    ctx.save();
+    ctx.translate(cam.x, cam.y);
+    ctx.scale(cam.zoom, cam.zoom);
+
+    const zoom = cam.zoom;
+
+    // ── LOD Rendering ──
+    drawBoard(ctx, zoom);
+    drawZones(ctx, devices, zoom);
+    drawTrunks(ctx, routingRef.current.trunks, zoom, selectedWireId);
+    drawWires(ctx, result.wires, devices, zoom, selectedWireId);
+    drawConnectors(ctx, devices, zoom, selectedDeviceId, selectedDeviceIds);
+
+    ctx.restore();
+
+    // ── HUD overlay ──
+    drawHUD(ctx, w, h, zoom);
+
+    // Continue loop
+    animFrame.current = requestAnimationFrame(render);
+  }, [devices, result.wires, selectedDeviceId, selectedDeviceIds, selectedWireId, cameraRef, screenToCanvas]);
+
+  // Start/stop render loop
+  useEffect(() => {
+    animFrame.current = requestAnimationFrame(render);
+    return () => cancelAnimationFrame(animFrame.current);
+  }, [render]);
+
+  // ── Fit-to-view ──
+  useEffect(() => {
+    if (fitRequested <= 0) return;
+    const container = containerRef.current;
+    if (!container) return;
+    const w = container.clientWidth;
+    const h = container.clientHeight;
+    const padding = 40;
+    const zx = (w - padding * 2) / CANVAS_W;
+    const zy = (h - padding * 2) / CANVAS_H;
+    const z = Math.min(zx, zy, 1);
+    targetCam.current = {
+      zoom: z,
+      x: (w - CANVAS_W * z) / 2,
+      y: (h - CANVAS_H * z) / 2,
+    };
+  }, [fitRequested]);
+
+  // Initial fit
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const w = container.clientWidth;
+    const h = container.clientHeight;
+    const padding = 40;
+    const zx = (w - padding * 2) / CANVAS_W;
+    const zy = (h - padding * 2) / CANVAS_H;
+    const z = Math.min(zx, zy, 1);
+    const cam = { zoom: z, x: (w - CANVAS_W * z) / 2, y: (h - CANVAS_H * z) / 2 };
+    targetCam.current = { ...cam };
+    currentCam.current = { ...cam };
+  }, []);
+
+  // ── Scroll-to-zoom (Figma behavior: zoom on cursor) ──
+  const handleWheel = useCallback((e: WheelEvent) => {
+    e.preventDefault();
+    const cam = targetCam.current;
+
+    if (e.ctrlKey) {
+      // Trackpad pinch-to-zoom
+      const zoomFactor = 1 - e.deltaY * 0.01;
+      const newZoom = Math.max(0.3, Math.min(15, cam.zoom * zoomFactor));
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+      // Zoom around cursor
+      const scale = newZoom / cam.zoom;
+      cam.x = mx - (mx - cam.x) * scale;
+      cam.y = my - (my - cam.y) * scale;
+      cam.zoom = newZoom;
+    } else {
+      // Scroll wheel zoom or pan
+      if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
+        // Horizontal scroll = pan
+        cam.x -= e.deltaX;
+      } else {
+        // Vertical scroll = zoom on cursor
+        const zoomFactor = e.deltaY > 0 ? 0.92 : 1.08;
+        const newZoom = Math.max(0.3, Math.min(15, cam.zoom * zoomFactor));
+        const rect = containerRef.current?.getBoundingClientRect();
+        if (!rect) return;
+        const mx = e.clientX - rect.left;
+        const my = e.clientY - rect.top;
+        const scale = newZoom / cam.zoom;
+        cam.x = mx - (mx - cam.x) * scale;
+        cam.y = my - (my - cam.y) * scale;
+        cam.zoom = newZoom;
+      }
+    }
+  }, []);
+
+  // Attach wheel handler (passive: false to prevent default)
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.addEventListener('wheel', handleWheel, { passive: false });
+    return () => el.removeEventListener('wheel', handleWheel);
+  }, [handleWheel]);
+
+  // ── Mouse handlers for pan + click ──
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    const isMiddle = e.button === 1;
+    if (isMiddle || spaceDown.current) {
+      isPanning.current = true;
+      lastMouse.current = { x: e.clientX, y: e.clientY };
+      e.preventDefault();
+      return;
+    }
+    // Left click — check for device hit
+    if (e.button === 0) {
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const sx = e.clientX - rect.left;
+      const sy = e.clientY - rect.top;
+      const c = screenToCanvas(sx, sy);
+      mouseCanvas.current = c;
+
+      // Hit test devices
+      const hit = hitTestDevice(c.x, c.y, devices, currentCam.current.zoom);
+      if (hit) {
+        onDeviceClick(hit.id, e.shiftKey);
+      } else {
+        // Hit test wires
+        const wireHit = hitTestWire(c.x, c.y, result.wires, devices);
+        if (wireHit) {
+          onWireClick(wireHit.wireNumber);
+        } else {
+          onDeselect();
+        }
+      }
+    }
+  }, [devices, result.wires, onDeviceClick, onWireClick, onDeselect, screenToCanvas]);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (isPanning.current) {
+      const dx = e.clientX - lastMouse.current.x;
+      const dy = e.clientY - lastMouse.current.y;
+      targetCam.current.x += dx;
+      targetCam.current.y += dy;
+      lastMouse.current = { x: e.clientX, y: e.clientY };
+    }
+  }, []);
+
+  const handleMouseUp = useCallback(() => {
+    isPanning.current = false;
+  }, []);
+
+  // ── Double-click: zoom to element ──
+  const handleDoubleClick = useCallback((e: React.MouseEvent) => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const sx = e.clientX - rect.left;
+    const sy = e.clientY - rect.top;
+    const c = screenToCanvas(sx, sy);
+    const hit = hitTestDevice(c.x, c.y, devices, currentCam.current.zoom);
+    if (hit) {
+      const dx = (hit.pos_x_pct ?? 50) * PX_PER_INCH;
+      const dy = (hit.pos_y_pct ?? 50) * PX_PER_INCH;
+      const container = containerRef.current;
+      if (!container) return;
+      const newZoom = 6;
+      targetCam.current = {
+        zoom: newZoom,
+        x: container.clientWidth / 2 - dx * newZoom,
+        y: container.clientHeight / 2 - dy * newZoom,
+      };
+      onDeviceClick(hit.id);
+    }
+  }, [devices, onDeviceClick, screenToCanvas]);
+
+  // ── Space key for pan mode ──
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.code === 'Space' && !(e.target as HTMLElement).matches('input, textarea')) {
+        e.preventDefault();
+        spaceDown.current = true;
+      }
+    };
+    const up = (e: KeyboardEvent) => {
+      if (e.code === 'Space') spaceDown.current = false;
+    };
+    window.addEventListener('keydown', down);
+    window.addEventListener('keyup', up);
+    return () => {
+      window.removeEventListener('keydown', down);
+      window.removeEventListener('keyup', up);
+    };
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        width: '100%', height: '100%',
+        cursor: spaceDown.current || isPanning.current ? 'grabbing' : 'crosshair',
+        overflow: 'hidden',
+        position: 'relative',
+      }}
+    >
+      <canvas
+        ref={canvasRef}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+        onDoubleClick={handleDoubleClick}
+        style={{ display: 'block' }}
+      />
+    </div>
+  );
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Drawing functions
+// ══════════════════════════════════════════════════════════════════════
+
+function drawBoard(ctx: CanvasRenderingContext2D, zoom: number) {
+  // Board outline
+  ctx.strokeStyle = '#333355';
+  ctx.lineWidth = 2 / zoom;
+  ctx.strokeRect(0, 0, CANVAS_W, CANVAS_H);
+
+  // Grid lines (pegboard holes at 1" intervals)
+  if (zoom > 0.8) {
+    ctx.strokeStyle = '#222244';
+    ctx.lineWidth = 0.5 / zoom;
+    const step = PX_PER_INCH;
+    for (let x = 0; x <= CANVAS_W; x += step) {
+      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, CANVAS_H); ctx.stroke();
+    }
+    for (let y = 0; y <= CANVAS_H; y += step) {
+      ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(CANVAS_W, y); ctx.stroke();
+    }
+  }
+
+  // Board dimension labels
+  if (zoom > 0.4) {
+    ctx.fillStyle = '#666680';
+    ctx.font = `bold ${Math.max(8, 10 / zoom)}px Arial`;
+    ctx.textAlign = 'center';
+    ctx.fillText('200"', CANVAS_W / 2, -6 / zoom);
+    ctx.save();
+    ctx.translate(-6 / zoom, CANVAS_H / 2);
+    ctx.rotate(-Math.PI / 2);
+    ctx.fillText('96"', 0, 0);
+    ctx.restore();
+  }
+}
+
+function drawZones(ctx: CanvasRenderingContext2D, devices: ManifestDevice[], zoom: number) {
+  // Draw zone color fills behind everything
+  const zoneDevices: Record<string, ManifestDevice[]> = {};
+  for (const d of devices) {
+    if (d.location_zone && d.pos_x_pct != null && d.pos_y_pct != null) {
+      if (!zoneDevices[d.location_zone]) zoneDevices[d.location_zone] = [];
+      zoneDevices[d.location_zone].push(d);
+    }
+  }
+
+  for (const [zone, devs] of Object.entries(zoneDevices)) {
+    if (devs.length < 2) continue;
+    const xs = devs.map(d => (d.pos_x_pct ?? 0) * PX_PER_INCH);
+    const ys = devs.map(d => (d.pos_y_pct ?? 0) * PX_PER_INCH);
+    const pad = 20;
+    const minX = Math.min(...xs) - pad;
+    const minY = Math.min(...ys) - pad;
+    const maxX = Math.max(...xs) + pad;
+    const maxY = Math.max(...ys) + pad;
+    const color = ZONE_COLORS[zone] || '#444';
+
+    ctx.fillStyle = color + '10'; // very faint fill
+    ctx.fillRect(minX, minY, maxX - minX, maxY - minY);
+    ctx.strokeStyle = color + '30';
+    ctx.lineWidth = 1 / zoom;
+    ctx.strokeRect(minX, minY, maxX - minX, maxY - minY);
+
+    // Zone label
+    if (zoom > 0.4) {
+      ctx.fillStyle = color + '80';
+      ctx.font = `bold ${Math.max(6, 9 / zoom)}px Arial`;
+      ctx.textAlign = 'left';
+      ctx.fillText(zone.replace(/_/g, ' ').toUpperCase(), minX + 4 / zoom, minY + 12 / zoom);
+    }
+  }
+}
+
+function drawTrunks(ctx: CanvasRenderingContext2D, trunks: TrunkRenderSegment[], zoom: number, selectedWireId: number | null) {
+  if (zoom < 0.4) {
+    // At very low zoom, show trunk centerlines
+    for (const t of trunks) {
+      const color = ZONE_COLORS[t.zone] || '#444';
+      ctx.strokeStyle = color + '60';
+      ctx.lineWidth = Math.max(1, Math.min(t.wireCount * 0.5, 6)) / zoom;
+      ctx.beginPath();
+      ctx.moveTo(t.x1, t.y1);
+      ctx.lineTo(t.x2, t.y2);
+      ctx.stroke();
+    }
+  } else if (zoom < 2) {
+    // At medium zoom, show wire bundles as thick paths
+    for (const t of trunks) {
+      const color = ZONE_COLORS[t.zone] || '#444';
+      ctx.strokeStyle = color + '40';
+      ctx.lineWidth = Math.max(2, Math.min(t.wireCount * 0.8, 12)) / zoom;
+      ctx.beginPath();
+      ctx.moveTo(t.x1, t.y1);
+      ctx.lineTo(t.x2, t.y2);
+      ctx.stroke();
+    }
+  }
+}
+
+function drawWires(
+  ctx: CanvasRenderingContext2D,
+  wires: WireSpec[],
+  devices: ManifestDevice[],
+  zoom: number,
+  selectedWireId: number | null,
+) {
+  if (zoom < 2) return; // Only show individual wires at higher zoom
+
+  const deviceMap = new Map(devices.map(d => [d.device_name, d]));
+
+  for (const w of wires) {
+    const fromName = w.from.split(':')[0];
+    const fromDev = deviceMap.get(fromName);
+    const toDev = deviceMap.get(w.to);
+    if (!fromDev || !toDev) continue;
+    if (fromDev.pos_x_pct == null || toDev.pos_x_pct == null) continue;
+
+    const x1 = (fromDev.pos_x_pct ?? 0) * PX_PER_INCH;
+    const y1 = (fromDev.pos_y_pct ?? 0) * PX_PER_INCH;
+    const x2 = (toDev.pos_x_pct ?? 0) * PX_PER_INCH;
+    const y2 = (toDev.pos_y_pct ?? 0) * PX_PER_INCH;
+
+    const isSelected = w.wireNumber === selectedWireId;
+    const baseColor = w.color.split('/')[0];
+    const displayColor = WIRE_DISPLAY_COLORS[baseColor] || '#888';
+
+    ctx.strokeStyle = isSelected ? C.active : (selectedWireId != null ? displayColor + '30' : displayColor + '80');
+    ctx.lineWidth = (isSelected ? 2 : 0.8) / zoom;
+    ctx.beginPath();
+    // Manhattan routing: horizontal then vertical
+    const midX = x2;
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(midX, y1);
+    ctx.lineTo(midX, y2);
+    ctx.lineTo(x2, y2);
+    ctx.stroke();
+
+    // Wire labels at zoom > 4
+    if (zoom > 4) {
+      ctx.fillStyle = isSelected ? C.active : displayColor + '90';
+      ctx.font = `bold ${8 / zoom}px Courier New`;
+      ctx.textAlign = 'center';
+      const labelX = (x1 + x2) / 2;
+      const labelY = y1 - 3 / zoom;
+      ctx.fillText(`${w.gauge}AWG ${w.color}`, labelX, labelY);
+    }
+  }
+}
+
+function drawConnectors(
+  ctx: CanvasRenderingContext2D,
+  devices: ManifestDevice[],
+  zoom: number,
+  selectedDeviceId: string | null,
+  selectedDeviceIds: Set<string>,
+) {
+  for (const d of devices) {
+    if (d.pos_x_pct == null || d.pos_y_pct == null) continue;
+
+    const x = d.pos_x_pct * PX_PER_INCH;
+    const y = d.pos_y_pct * PX_PER_INCH;
+    const isSelected = d.id === selectedDeviceId || selectedDeviceIds.has(d.id);
+    const hasSelection = selectedDeviceId !== null;
+    const zoneColor = ZONE_COLORS[d.location_zone || ''] || '#666';
+
+    // Dim non-selected when a selection exists
+    const alpha = hasSelection && !isSelected ? 0.3 : 1;
+
+    if (zoom < 0.5) {
+      // ── LOD 1: colored dots ──
+      ctx.fillStyle = isSelected ? C.active : (zoneColor + (hasSelection && !isSelected ? '4d' : 'cc'));
+      ctx.beginPath();
+      ctx.arc(x, y, 3 / zoom, 0, Math.PI * 2);
+      ctx.fill();
+    } else if (zoom < 2) {
+      // ── LOD 2: small blocks with abbreviated names ──
+      const bw = 24 / zoom;
+      const bh = 14 / zoom;
+      ctx.fillStyle = isSelected ? C.active + '30' : C.elevated;
+      ctx.globalAlpha = alpha;
+      ctx.fillRect(x - bw / 2, y - bh / 2, bw, bh);
+      ctx.strokeStyle = isSelected ? C.active : zoneColor;
+      ctx.lineWidth = (isSelected ? 2 : 1) / zoom;
+      ctx.strokeRect(x - bw / 2, y - bh / 2, bw, bh);
+
+      // 3-char abbreviation
+      const abbr = d.device_name.substring(0, 3).toUpperCase();
+      ctx.fillStyle = isSelected ? C.active : C.text;
+      ctx.font = `bold ${Math.max(6, 8 / zoom)}px Arial`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(abbr, x, y);
+      ctx.globalAlpha = 1;
+    } else if (zoom < 4) {
+      // ── LOD 3: full device name, connector outlines ──
+      const pinCount = d.pin_count || 2;
+      const bw = Math.max(30, pinCount * 2 + 10) / zoom;
+      const bh = 20 / zoom;
+      ctx.fillStyle = isSelected ? C.active + '20' : C.surface;
+      ctx.globalAlpha = alpha;
+      ctx.fillRect(x - bw / 2, y - bh / 2, bw, bh);
+      ctx.strokeStyle = isSelected ? C.active : zoneColor;
+      ctx.lineWidth = (isSelected ? 2 : 1) / zoom;
+      ctx.strokeRect(x - bw / 2, y - bh / 2, bw, bh);
+
+      ctx.fillStyle = isSelected ? C.active : C.text;
+      ctx.font = `bold ${9 / zoom}px Arial`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(d.device_name.toUpperCase(), x, y);
+      ctx.globalAlpha = 1;
+    } else if (zoom < 8) {
+      // ── LOD 4: pins visible, wire gauge labels ──
+      const pinCount = d.pin_count || 2;
+      const cols = Math.min(pinCount, 6);
+      const rows = Math.ceil(pinCount / cols);
+      const pinR = 2 / zoom;
+      const pinSpacing = 5 / zoom;
+      const bw = cols * pinSpacing + 20 / zoom;
+      const bh = rows * pinSpacing + 24 / zoom;
+
+      ctx.fillStyle = isSelected ? C.active + '15' : C.bg;
+      ctx.globalAlpha = alpha;
+      ctx.fillRect(x - bw / 2, y - bh / 2, bw, bh);
+      ctx.strokeStyle = isSelected ? C.active : zoneColor;
+      ctx.lineWidth = (isSelected ? 2 : 1) / zoom;
+      ctx.strokeRect(x - bw / 2, y - bh / 2, bw, bh);
+
+      // Device name
+      ctx.fillStyle = isSelected ? C.active : C.text;
+      ctx.font = `bold ${8 / zoom}px Arial`;
+      ctx.textAlign = 'center';
+      ctx.fillText(d.device_name.toUpperCase(), x, y - bh / 2 + 8 / zoom);
+
+      // Pins
+      const pinStartY = y - bh / 2 + 16 / zoom;
+      for (let i = 0; i < pinCount; i++) {
+        const col = i % cols;
+        const row = Math.floor(i / cols);
+        const px = x - (cols - 1) * pinSpacing / 2 + col * pinSpacing;
+        const py = pinStartY + row * pinSpacing;
+        ctx.fillStyle = isSelected ? C.active : zoneColor;
+        ctx.beginPath();
+        ctx.arc(px, py, pinR, 0, Math.PI * 2);
+        ctx.fill();
+      }
+
+      // Power draw
+      if (d.power_draw_amps) {
+        ctx.fillStyle = C.muted;
+        ctx.font = `bold ${7 / zoom}px Courier New`;
+        ctx.fillText(`${d.power_draw_amps}A`, x, y + bh / 2 - 3 / zoom);
+      }
+      ctx.globalAlpha = 1;
+    } else {
+      // ── LOD 5: maximum detail ──
+      const pinCount = d.pin_count || 2;
+      const cols = Math.min(pinCount, 6);
+      const rows = Math.ceil(pinCount / cols);
+      const pinR = 2 / zoom;
+      const pinSpacing = 5 / zoom;
+      const bw = Math.max(cols * pinSpacing + 30 / zoom, 60 / zoom);
+      const bh = rows * pinSpacing + 50 / zoom;
+
+      ctx.fillStyle = isSelected ? C.active + '10' : '#0d0d1a';
+      ctx.globalAlpha = alpha;
+      ctx.fillRect(x - bw / 2, y - bh / 2, bw, bh);
+      ctx.strokeStyle = isSelected ? C.active : zoneColor;
+      ctx.lineWidth = (isSelected ? 2 : 1) / zoom;
+      ctx.strokeRect(x - bw / 2, y - bh / 2, bw, bh);
+
+      // Name
+      ctx.fillStyle = isSelected ? C.active : C.text;
+      ctx.font = `bold ${8 / zoom}px Arial`;
+      ctx.textAlign = 'center';
+      ctx.fillText(d.device_name.toUpperCase(), x, y - bh / 2 + 8 / zoom);
+
+      // Connector type
+      ctx.fillStyle = C.muted;
+      ctx.font = `bold ${6 / zoom}px Arial`;
+      ctx.fillText((d.connector_type || '').replace(/_/g, ' ').toUpperCase(), x, y - bh / 2 + 15 / zoom);
+
+      // Pins with numbers
+      const pinStartY = y - bh / 2 + 22 / zoom;
+      for (let i = 0; i < pinCount; i++) {
+        const col = i % cols;
+        const row = Math.floor(i / cols);
+        const px = x - (cols - 1) * pinSpacing / 2 + col * pinSpacing;
+        const py = pinStartY + row * pinSpacing;
+        ctx.fillStyle = isSelected ? C.active : zoneColor;
+        ctx.beginPath();
+        ctx.arc(px, py, pinR, 0, Math.PI * 2);
+        ctx.fill();
+
+        // Pin number
+        ctx.fillStyle = C.muted;
+        ctx.font = `${5 / zoom}px Courier New`;
+        ctx.fillText(String(i + 1), px, py + pinR + 4 / zoom);
+      }
+
+      // Power + gauge
+      const infoY = y + bh / 2 - 12 / zoom;
+      ctx.fillStyle = C.label;
+      ctx.font = `bold ${6 / zoom}px Courier New`;
+      if (d.power_draw_amps) ctx.fillText(`${d.power_draw_amps}A`, x - 10 / zoom, infoY);
+      if (d.wire_gauge_recommended) ctx.fillText(`${d.wire_gauge_recommended}AWG`, x + 10 / zoom, infoY);
+
+      // Price
+      if (d.price) {
+        ctx.fillStyle = d.purchased ? '#22c55e' : '#ef4444';
+        ctx.font = `bold ${6 / zoom}px Courier New`;
+        ctx.fillText(`$${d.price}`, x, infoY + 7 / zoom);
+      }
+      ctx.globalAlpha = 1;
+    }
+  }
+}
+
+function drawHUD(ctx: CanvasRenderingContext2D, w: number, h: number, zoom: number) {
+  // Zoom level indicator
+  ctx.fillStyle = '#666680';
+  ctx.font = 'bold 9px Courier New';
+  ctx.textAlign = 'left';
+  ctx.fillText(`ZOOM: ${zoom.toFixed(2)}x`, 8, h - 8);
+
+  // Controls hint
+  ctx.textAlign = 'right';
+  ctx.fillText('SCROLL=ZOOM  SPACE+DRAG=PAN  DBL-CLICK=FOCUS  F=FIT', w - 8, h - 8);
+}
+
+// ── Hit testing ─────────────────────────────────────────────────────
+function hitTestDevice(
+  cx: number, cy: number,
+  devices: ManifestDevice[],
+  zoom: number,
+): ManifestDevice | null {
+  const hitR = Math.max(8, 20 / zoom);
+  for (const d of devices) {
+    if (d.pos_x_pct == null || d.pos_y_pct == null) continue;
+    const dx = d.pos_x_pct * PX_PER_INCH;
+    const dy = d.pos_y_pct * PX_PER_INCH;
+    if (Math.abs(cx - dx) < hitR && Math.abs(cy - dy) < hitR) return d;
+  }
+  return null;
+}
+
+function hitTestWire(
+  cx: number, cy: number,
+  wires: WireSpec[],
+  devices: ManifestDevice[],
+): WireSpec | null {
+  const threshold = 5;
+  const deviceMap = new Map(devices.map(d => [d.device_name, d]));
+
+  for (const w of wires) {
+    const fromName = w.from.split(':')[0];
+    const fromDev = deviceMap.get(fromName);
+    const toDev = deviceMap.get(w.to);
+    if (!fromDev || !toDev) continue;
+    if (fromDev.pos_x_pct == null || toDev.pos_x_pct == null) continue;
+
+    const x1 = (fromDev.pos_x_pct ?? 0) * PX_PER_INCH;
+    const y1 = (fromDev.pos_y_pct ?? 0) * PX_PER_INCH;
+    const x2 = (toDev.pos_x_pct ?? 0) * PX_PER_INCH;
+    const y2 = (toDev.pos_y_pct ?? 0) * PX_PER_INCH;
+
+    // Manhattan path: horiz then vert
+    // Segment 1: (x1,y1) to (x2,y1)
+    if (cy >= Math.min(y1, y1) - threshold && cy <= Math.max(y1, y1) + threshold &&
+        cx >= Math.min(x1, x2) - threshold && cx <= Math.max(x1, x2) + threshold) {
+      if (Math.abs(cy - y1) < threshold) return w;
+    }
+    // Segment 2: (x2,y1) to (x2,y2)
+    if (cx >= x2 - threshold && cx <= x2 + threshold &&
+        cy >= Math.min(y1, y2) - threshold && cy <= Math.max(y1, y2) + threshold) {
+      return w;
+    }
+  }
+  return null;
+}

--- a/nuke_frontend/src/components/wiring/HarnessView3D.tsx
+++ b/nuke_frontend/src/components/wiring/HarnessView3D.tsx
@@ -1,0 +1,271 @@
+// HarnessView3D.tsx — Three.js / React Three Fiber 3D harness view
+// Transparent K5 shell, zone volumes, harness trunks as 3D tubes,
+// OrbitControls. Click connector → detail panel.
+
+import React, { useMemo, useRef, useState, useCallback } from 'react';
+import { Canvas, useFrame, useThree, type ThreeEvent } from '@react-three/fiber';
+import { OrbitControls, Text } from '@react-three/drei';
+import * as THREE from 'three';
+import type { ManifestDevice, OverlayResult } from './overlayCompute';
+import { K5_HARNESS_GRAPH, routeWiresAlongHarness, computeTrunkSegments } from './harnessRouting';
+import type { TrunkRenderSegment } from './harnessRouting';
+
+// ── K5 Blazer dimensions (inches) ────────────────────────────────────
+const K5_L = 184.8;
+const K5_W = 79.6;
+const K5_H = 73;
+
+// Scale factor: 3D units = inches / 10
+const S = 0.1;
+
+// Zone volumes (approximate regions in 3D space)
+const ZONES: Record<string, { position: [number, number, number]; size: [number, number, number]; color: string }> = {
+  engine_bay: { position: [7, 1.5, 0], size: [4, 3, 6], color: '#cc2222' },
+  firewall:   { position: [4.5, 2, 0], size: [0.5, 4, 7], color: '#cc6600' },
+  dash:       { position: [2.5, 2.5, 0], size: [3, 2.5, 7], color: '#2266cc' },
+  doors:      { position: [2, 1.5, 0], size: [3, 3, 0.5], color: '#8822cc' },
+  rear:       { position: [-4, 1, 0], size: [6, 3, 6], color: '#22aa44' },
+  underbody:  { position: [0, -0.5, 0], size: [16, 0.5, 6], color: '#666666' },
+};
+
+const ZONE_COLORS: Record<string, string> = {
+  engine_bay: '#cc2222',
+  firewall: '#cc6600',
+  dash: '#2266cc',
+  doors: '#8822cc',
+  rear: '#22aa44',
+  underbody: '#666666',
+};
+
+interface Props {
+  devices: ManifestDevice[];
+  result: OverlayResult;
+  selectedDeviceId: string | null;
+  selectedDeviceIds: Set<string>;
+  selectedWireId: number | null;
+  onDeviceClick: (id: string, shiftKey?: boolean) => void;
+  onWireClick: (wireNumber: number) => void;
+  onDeselect: () => void;
+  fitRequested: number;
+  zoneColors: Record<string, string>;
+}
+
+// Map 1000×1000 canvas space to 3D coordinates
+// Canvas: x=0..1000 (left to right), y=0..1000 (top to bottom)
+// 3D: x = front-to-rear of vehicle, y = height, z = left-to-right
+function canvasTo3D(cx: number, cy: number): [number, number, number] {
+  const x = ((1000 - cy) / 1000) * K5_L * S - K5_L * S / 2; // cy maps to vehicle length
+  const z = (cx / 1000) * K5_W * S - K5_W * S / 2; // cx maps to vehicle width
+  const y = 2; // default height at mid-vehicle
+  return [x, y, z];
+}
+
+export function HarnessView3D({
+  devices, result, selectedDeviceId, selectedWireId,
+  onDeviceClick, onDeselect,
+}: Props) {
+  const [hovered, setHovered] = useState<string | null>(null);
+
+  // ── Compute trunk segments for rendering ──
+  const trunkSegments = useMemo((): TrunkRenderSegment[] => {
+    const requests = result.wires.map(w => {
+      const fromDev = devices.find(d => d.device_name === w.from.split(':')[0]);
+      const toDev = devices.find(d => d.device_name === w.to);
+      return {
+        wireNumber: w.wireNumber,
+        fromX: (fromDev?.pos_x_pct ?? 50) * 5,
+        fromY: (fromDev?.pos_y_pct ?? 50) * 5,
+        toX: (toDev?.pos_x_pct ?? 50) * 5,
+        toY: (toDev?.pos_y_pct ?? 50) * 5,
+      };
+    });
+    const routed = routeWiresAlongHarness(requests);
+    return computeTrunkSegments(routed);
+  }, [devices, result.wires]);
+
+  return (
+    <div style={{ width: '100%', height: '100%', background: '#0a0a18' }}>
+      <Canvas
+        camera={{ position: [15, 10, 15], fov: 45, near: 0.1, far: 200 }}
+        style={{ background: '#0a0a18' }}
+        onClick={(e) => {
+          // Click on empty space = deselect
+          if ((e.target as HTMLElement).tagName === 'CANVAS') {
+            // Only deselect if nothing was hit (handled by mesh click stopPropagation)
+          }
+        }}
+      >
+        <ambientLight intensity={0.4} />
+        <directionalLight position={[10, 15, 10]} intensity={0.6} />
+        <directionalLight position={[-10, 10, -5]} intensity={0.3} />
+
+        {/* Controls */}
+        <OrbitControls
+          enableDamping
+          dampingFactor={0.1}
+          minDistance={3}
+          maxDistance={50}
+        />
+
+        {/* Ground grid */}
+        <gridHelper args={[30, 30, '#222244', '#161630']} position={[0, -1, 0]} />
+
+        {/* K5 shell (transparent wireframe box) */}
+        <VehicleShell />
+
+        {/* Zone volumes */}
+        {Object.entries(ZONES).map(([zoneId, zone]) => (
+          <ZoneVolume key={zoneId} {...zone} label={zoneId.replace(/_/g, ' ').toUpperCase()} />
+        ))}
+
+        {/* Harness trunks */}
+        {trunkSegments.map((seg, i) => (
+          <HarnessTube key={i} segment={seg} />
+        ))}
+
+        {/* Device connectors */}
+        {devices.map(d => {
+          if (d.pos_x_pct == null || d.pos_y_pct == null) return null;
+          const pos = canvasTo3D(d.pos_x_pct * 5, d.pos_y_pct * 5);
+          const isSelected = d.id === selectedDeviceId;
+          const isHovered = d.id === hovered;
+          const zoneColor = ZONE_COLORS[d.location_zone || ''] || '#666';
+
+          return (
+            <group key={d.id} position={pos}>
+              <mesh
+                onClick={(e: ThreeEvent<MouseEvent>) => {
+                  e.stopPropagation();
+                  onDeviceClick(d.id, e.nativeEvent.shiftKey);
+                }}
+                onPointerOver={() => setHovered(d.id)}
+                onPointerOut={() => setHovered(null)}
+              >
+                <boxGeometry args={[0.4, 0.3, 0.3]} />
+                <meshStandardMaterial
+                  color={isSelected ? '#00ddff' : isHovered ? '#00ddff' : zoneColor}
+                  transparent
+                  opacity={isSelected ? 1 : isHovered ? 0.9 : 0.7}
+                  emissive={isSelected ? '#00ddff' : '#000000'}
+                  emissiveIntensity={isSelected ? 0.5 : 0}
+                />
+              </mesh>
+              {/* Label */}
+              {(isSelected || isHovered) && (
+                <Text
+                  position={[0, 0.5, 0]}
+                  fontSize={0.2}
+                  color={isSelected ? '#00ddff' : '#e0e0e8'}
+                  anchorX="center"
+                  anchorY="bottom"
+                  font={undefined}
+                >
+                  {d.device_name}
+                </Text>
+              )}
+            </group>
+          );
+        })}
+
+        {/* Junction nodes from harness graph */}
+        {K5_HARNESS_GRAPH.nodes.map(node => {
+          const pos = canvasTo3D(node.x, node.y);
+          return (
+            <mesh key={node.id} position={pos}>
+              <sphereGeometry args={[0.1, 8, 8]} />
+              <meshStandardMaterial color="#333355" transparent opacity={0.4} />
+            </mesh>
+          );
+        })}
+      </Canvas>
+
+      {/* HUD overlay */}
+      <div style={{
+        position: 'absolute', bottom: 8, left: 8,
+        fontFamily: "'Courier New', monospace", fontSize: 9, fontWeight: 700,
+        color: '#666680',
+      }}>
+        ORBIT=DRAG  ZOOM=SCROLL  PAN=RIGHT-DRAG  CLICK=SELECT
+      </div>
+    </div>
+  );
+}
+
+// ── Vehicle shell ─────────────────────────────────────────────────────
+function VehicleShell() {
+  return (
+    <mesh>
+      <boxGeometry args={[K5_L * S, K5_H * S, K5_W * S]} />
+      <meshStandardMaterial
+        color="#2266cc"
+        transparent
+        opacity={0.04}
+        wireframe
+      />
+    </mesh>
+  );
+}
+
+// ── Zone volume ─────────────────────────────────────────────────────
+function ZoneVolume({ position, size, color, label }: {
+  position: [number, number, number];
+  size: [number, number, number];
+  color: string;
+  label: string;
+}) {
+  return (
+    <group position={position}>
+      <mesh>
+        <boxGeometry args={size} />
+        <meshStandardMaterial
+          color={color}
+          transparent
+          opacity={0.06}
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+      <lineSegments>
+        <edgesGeometry args={[new THREE.BoxGeometry(...size)]} />
+        <lineBasicMaterial color={color} transparent opacity={0.2} />
+      </lineSegments>
+      <Text
+        position={[0, size[1] / 2 + 0.2, 0]}
+        fontSize={0.25}
+        color={color}
+        anchorX="center"
+        anchorY="bottom"
+        font={undefined}
+      >
+        {label}
+      </Text>
+    </group>
+  );
+}
+
+// ── Harness tube ─────────────────────────────────────────────────────
+function HarnessTube({ segment }: { segment: TrunkRenderSegment }) {
+  const geometry = useMemo(() => {
+    const start = canvasTo3D(segment.x1, segment.y1);
+    const end = canvasTo3D(segment.x2, segment.y2);
+    const curve = new THREE.LineCurve3(
+      new THREE.Vector3(...start),
+      new THREE.Vector3(...end),
+    );
+    const radius = Math.max(0.05, Math.min(segment.wireCount * 0.03, 0.4));
+    return new THREE.TubeGeometry(curve, 8, radius, 6, false);
+  }, [segment]);
+
+  const color = ZONE_COLORS[segment.zone] || '#555577';
+
+  return (
+    <mesh geometry={geometry}>
+      <meshStandardMaterial
+        color={color}
+        transparent
+        opacity={0.6}
+        roughness={0.3}
+        metalness={0.2}
+      />
+    </mesh>
+  );
+}

--- a/nuke_frontend/src/components/wiring/SchematicView.tsx
+++ b/nuke_frontend/src/components/wiring/SchematicView.tsx
@@ -1,0 +1,481 @@
+// SchematicView.tsx — SVG schematics, 5 sub-sheets
+// Power Distribution | Engine Management | Lighting | Body Electronics | Audio
+// LEFT-TO-RIGHT signal flow, Manhattan wire routing, dark/light toggle.
+
+import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
+import type { ManifestDevice, WireSpec, OverlayResult } from './overlayCompute';
+
+// ── Design tokens ─────────────────────────────────────────────────────
+const C = {
+  bg: '#1a1a2e',
+  bgLight: '#f0f0f4',
+  surface: '#1f1f35',
+  surfaceLight: '#ffffff',
+  text: '#e0e0e8',
+  textLight: '#222222',
+  label: '#a0a0b0',
+  labelLight: '#666666',
+  muted: '#666680',
+  border: '#333355',
+  borderLight: '#cccccc',
+  active: '#00ddff',
+  wire: '#555577',
+  wireLight: '#999999',
+};
+
+const ZONE_COLORS: Record<string, string> = {
+  engine_bay: '#cc2222',
+  firewall: '#cc6600',
+  dash: '#2266cc',
+  doors: '#8822cc',
+  rear: '#22aa44',
+  underbody: '#666666',
+};
+
+// ── Sheet definitions ─────────────────────────────────────────────────
+type SheetId = 'power' | 'engine' | 'lighting' | 'body' | 'audio';
+
+interface SheetDef {
+  id: SheetId;
+  label: string;
+  categories: string[];
+}
+
+const SHEETS: SheetDef[] = [
+  { id: 'power', label: 'POWER DISTRIBUTION', categories: ['power_distribution', 'power_source', 'grounds'] },
+  { id: 'engine', label: 'ENGINE MANAGEMENT', categories: ['engine_mgmt', 'sensors', 'fuel_system'] },
+  { id: 'lighting', label: 'LIGHTING', categories: ['lighting'] },
+  { id: 'body', label: 'BODY ELECTRONICS', categories: ['body', 'doors', 'hvac', 'security', 'gauges'] },
+  { id: 'audio', label: 'AUDIO', categories: ['audio'] },
+];
+
+interface CameraState { x: number; y: number; zoom: number; }
+
+interface Props {
+  devices: ManifestDevice[];
+  result: OverlayResult;
+  selectedDeviceId: string | null;
+  selectedDeviceIds: Set<string>;
+  selectedWireId: number | null;
+  onDeviceClick: (id: string, shiftKey?: boolean) => void;
+  onWireClick: (wireNumber: number) => void;
+  onDeselect: () => void;
+  fitRequested: number;
+  zoneColors: Record<string, string>;
+  cameraRef: CameraState;
+}
+
+// Layout constants
+const SHEET_W = 1400;
+const SHEET_H = 900;
+const MARGIN = 60;
+const DEVICE_H = 40;
+const DEVICE_MIN_W = 120;
+const DEVICE_PIN_W = 8;
+
+export function SchematicView({
+  devices, result, selectedDeviceId, selectedWireId,
+  onDeviceClick, onWireClick, onDeselect, fitRequested, cameraRef,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [activeSheet, setActiveSheet] = useState<SheetId>('power');
+  const [darkMode, setDarkMode] = useState(true);
+
+  // Camera state
+  const [cam, setCam] = useState<CameraState>({ ...cameraRef });
+  const isPanning = useRef(false);
+  const lastMouse = useRef({ x: 0, y: 0 });
+  const spaceDown = useRef(false);
+
+  // Sync camera back to parent ref
+  useEffect(() => {
+    cameraRef.x = cam.x;
+    cameraRef.y = cam.y;
+    cameraRef.zoom = cam.zoom;
+  }, [cam, cameraRef]);
+
+  const theme = darkMode ? {
+    bg: C.bg, surface: C.surface, text: C.text, label: C.label,
+    border: C.border, wire: C.wire, muted: C.muted,
+  } : {
+    bg: C.bgLight, surface: C.surfaceLight, text: C.textLight, label: C.labelLight,
+    border: C.borderLight, wire: C.wireLight, muted: '#aaa',
+  };
+
+  // ── Filter devices for active sheet ──
+  const sheetDef = SHEETS.find(s => s.id === activeSheet)!;
+
+  const sheetDevices = useMemo(() => {
+    // For engine sheet, include sensors connected to ECU
+    if (activeSheet === 'engine') {
+      return devices.filter(d =>
+        sheetDef.categories.includes(d.device_category) ||
+        d.signal_type === 'analog_5v' || d.signal_type === 'analog_temp' ||
+        d.signal_type === 'piezoelectric' || d.signal_type === 'wideband_lambda' ||
+        d.signal_type === 'h_bridge_motor' || d.signal_type === 'can_bus' ||
+        d.device_name.startsWith('Fuel Injector') || d.device_name.startsWith('Ignition Coil')
+      );
+    }
+    return devices.filter(d => sheetDef.categories.includes(d.device_category));
+  }, [devices, sheetDef, activeSheet]);
+
+  // ── Layout: left-to-right signal flow ──
+  const layout = useMemo(() => {
+    // Group into columns: Source (left) → Distribution (center) → Load (right)
+    const sources: ManifestDevice[] = [];
+    const distribution: ManifestDevice[] = [];
+    const loads: ManifestDevice[] = [];
+    const grounds: ManifestDevice[] = [];
+
+    for (const d of sheetDevices) {
+      if (d.signal_type === 'ground' || d.device_name.includes('Ground')) {
+        grounds.push(d);
+      } else if (d.signal_type === 'power_source' || d.device_name.includes('Battery') || d.device_name.includes('Alternator')) {
+        sources.push(d);
+      } else if (d.device_name.includes('PDM') || d.device_name.includes('Fuse') || d.device_name.includes('Relay')) {
+        distribution.push(d);
+      } else if (activeSheet === 'engine' && (d.device_name.includes('ECU') || d.device_name.includes('M130') || d.device_name.includes('M150'))) {
+        distribution.push(d);
+      } else {
+        loads.push(d);
+      }
+    }
+
+    // If no sources/distribution, treat first few as sources
+    if (sources.length === 0 && distribution.length === 0) {
+      // PDM is always a source in non-power sheets
+      const pdm = devices.find(d => d.device_name.includes('PDM30'));
+      if (pdm) sources.push(pdm);
+    }
+
+    const positions = new Map<string, { x: number; y: number; w: number; h: number }>();
+
+    const placeColumn = (col: ManifestDevice[], colX: number) => {
+      const spacing = Math.max(DEVICE_H + 10, (SHEET_H - 2 * MARGIN) / Math.max(col.length, 1));
+      col.forEach((d, i) => {
+        const w = Math.max(DEVICE_MIN_W, (d.pin_count || 2) * DEVICE_PIN_W + 40);
+        const y = MARGIN + i * spacing;
+        positions.set(d.id, { x: colX, y, w, h: DEVICE_H });
+      });
+    };
+
+    placeColumn(sources, MARGIN);
+    placeColumn(distribution, SHEET_W * 0.35);
+    placeColumn(loads, SHEET_W * 0.65);
+
+    // Grounds at bottom
+    grounds.forEach((d, i) => {
+      const w = Math.max(DEVICE_MIN_W, (d.pin_count || 2) * DEVICE_PIN_W + 40);
+      positions.set(d.id, {
+        x: MARGIN + i * (w + 20),
+        y: SHEET_H - MARGIN - DEVICE_H,
+        w, h: DEVICE_H,
+      });
+    });
+
+    return positions;
+  }, [sheetDevices, devices, activeSheet]);
+
+  // ── Wires for this sheet ──
+  const sheetWires = useMemo(() => {
+    const deviceNames = new Set(sheetDevices.map(d => d.device_name));
+    return result.wires.filter(w =>
+      deviceNames.has(w.to) || deviceNames.has(w.from.split(':')[0])
+    );
+  }, [sheetDevices, result.wires]);
+
+  // ── Wire paths (Manhattan routing) ──
+  const wirePaths = useMemo(() => {
+    const deviceMap = new Map(devices.map(d => [d.device_name, d]));
+    const paths: { wire: WireSpec; path: string }[] = [];
+    const usedYOffsets = new Map<number, number>(); // track vertical offsets
+
+    for (const w of sheetWires) {
+      const fromName = w.from.split(':')[0];
+      const fromDev = deviceMap.get(fromName);
+      const toDev = deviceMap.get(w.to);
+      const fromPos = fromDev ? layout.get(fromDev.id) : null;
+      const toPos = toDev ? layout.get(toDev.id) : null;
+
+      if (!fromPos || !toPos) continue;
+
+      // Manhattan: horizontal then vertical
+      const x1 = fromPos.x + fromPos.w;
+      const y1 = fromPos.y + fromPos.h / 2;
+      const x2 = toPos.x;
+      const y2 = toPos.y + toPos.h / 2;
+
+      // Add jog offset to avoid overlaps
+      const jogKey = Math.round(y1);
+      const jogOffset = (usedYOffsets.get(jogKey) || 0) * 3;
+      usedYOffsets.set(jogKey, (usedYOffsets.get(jogKey) || 0) + 1);
+
+      const midX = (x1 + x2) / 2 + jogOffset;
+      const path = `M ${x1} ${y1} H ${midX} V ${y2} H ${x2}`;
+
+      paths.push({ wire: w, path });
+    }
+
+    return paths;
+  }, [sheetWires, layout, devices]);
+
+  // ── Scroll-to-zoom ──
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const handler = (e: WheelEvent) => {
+      e.preventDefault();
+      if (e.ctrlKey || Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+        const factor = e.ctrlKey ? (1 - e.deltaY * 0.01) : (e.deltaY > 0 ? 0.92 : 1.08);
+        setCam(prev => {
+          const newZoom = Math.max(0.3, Math.min(15, prev.zoom * factor));
+          const rect = el.getBoundingClientRect();
+          const mx = e.clientX - rect.left;
+          const my = e.clientY - rect.top;
+          const scale = newZoom / prev.zoom;
+          return {
+            zoom: newZoom,
+            x: mx - (mx - prev.x) * scale,
+            y: my - (my - prev.y) * scale,
+          };
+        });
+      } else {
+        setCam(prev => ({ ...prev, x: prev.x - e.deltaX }));
+      }
+    };
+    el.addEventListener('wheel', handler, { passive: false });
+    return () => el.removeEventListener('wheel', handler);
+  }, []);
+
+  // ── Fit to view ──
+  useEffect(() => {
+    if (fitRequested <= 0) return;
+    const el = containerRef.current;
+    if (!el) return;
+    const w = el.clientWidth;
+    const h = el.clientHeight;
+    const padding = 40;
+    const zx = (w - padding * 2) / SHEET_W;
+    const zy = (h - padding * 2) / SHEET_H;
+    const z = Math.min(zx, zy, 1);
+    setCam({ zoom: z, x: (w - SHEET_W * z) / 2, y: (h - SHEET_H * z) / 2 });
+  }, [fitRequested]);
+
+  // Initial fit
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const w = el.clientWidth;
+    const h = el.clientHeight;
+    const padding = 40;
+    const zx = (w - padding * 2) / SHEET_W;
+    const zy = (h - padding * 2) / SHEET_H;
+    const z = Math.min(zx, zy, 1);
+    setCam({ zoom: z, x: (w - SHEET_W * z) / 2, y: (h - SHEET_H * z) / 2 });
+  }, []);
+
+  // ── Pan handlers ──
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if (e.button === 1 || spaceDown.current) {
+      isPanning.current = true;
+      lastMouse.current = { x: e.clientX, y: e.clientY };
+      e.preventDefault();
+    }
+  }, []);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (isPanning.current) {
+      setCam(prev => ({
+        ...prev,
+        x: prev.x + e.clientX - lastMouse.current.x,
+        y: prev.y + e.clientY - lastMouse.current.y,
+      }));
+      lastMouse.current = { x: e.clientX, y: e.clientY };
+    }
+  }, []);
+
+  const handleMouseUp = useCallback(() => { isPanning.current = false; }, []);
+
+  // Space key
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.code === 'Space' && !(e.target as HTMLElement).matches('input, textarea')) {
+        e.preventDefault(); spaceDown.current = true;
+      }
+    };
+    const up = (e: KeyboardEvent) => { if (e.code === 'Space') spaceDown.current = false; };
+    window.addEventListener('keydown', down);
+    window.addEventListener('keyup', up);
+    return () => { window.removeEventListener('keydown', down); window.removeEventListener('keyup', up); };
+  }, []);
+
+  return (
+    <div style={{
+      width: '100%', height: '100%', display: 'flex', flexDirection: 'column',
+      background: theme.bg, overflow: 'hidden',
+    }}>
+      {/* ── Sheet tabs + controls ── */}
+      <div style={{
+        display: 'flex', alignItems: 'center', height: 26,
+        padding: '0 8px', borderBottom: `2px solid ${theme.border}`,
+        flexShrink: 0,
+      }}>
+        {SHEETS.map(s => (
+          <button
+            key={s.id}
+            onClick={() => setActiveSheet(s.id)}
+            style={{
+              background: activeSheet === s.id ? theme.surface : 'transparent',
+              color: activeSheet === s.id ? C.active : theme.label,
+              border: 'none',
+              borderBottom: activeSheet === s.id ? `2px solid ${C.active}` : '2px solid transparent',
+              padding: '0 10px', height: '100%',
+              fontFamily: 'Arial', fontSize: 8, fontWeight: 700,
+              textTransform: 'uppercase', letterSpacing: 0.5,
+              cursor: 'pointer',
+            }}
+          >
+            {s.label}
+          </button>
+        ))}
+        <div style={{ flex: 1 }} />
+        <button
+          onClick={() => setDarkMode(!darkMode)}
+          style={{
+            background: 'transparent', border: `1px solid ${theme.border}`,
+            color: theme.label, padding: '2px 8px',
+            fontFamily: "'Courier New', monospace", fontSize: 8, fontWeight: 700,
+            cursor: 'pointer',
+          }}
+        >
+          {darkMode ? 'LIGHT' : 'DARK'}
+        </button>
+        <span style={{
+          marginLeft: 8, fontFamily: "'Courier New', monospace",
+          fontSize: 8, color: theme.muted,
+        }}>
+          {sheetDevices.length} DEVICES / {sheetWires.length} WIRES
+        </span>
+      </div>
+
+      {/* ── SVG viewport ── */}
+      <div
+        ref={containerRef}
+        style={{ flex: 1, overflow: 'hidden', cursor: spaceDown.current ? 'grab' : 'default' }}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+      >
+        <svg
+          width="100%"
+          height="100%"
+          style={{ display: 'block' }}
+          onClick={(e) => {
+            if ((e.target as SVGElement).tagName === 'svg') onDeselect();
+          }}
+        >
+          <g transform={`translate(${cam.x}, ${cam.y}) scale(${cam.zoom})`}>
+            {/* Sheet border */}
+            <rect x={0} y={0} width={SHEET_W} height={SHEET_H}
+              fill="none" stroke={theme.border} strokeWidth={2} />
+
+            {/* Sheet title */}
+            <text x={SHEET_W / 2} y={30}
+              fill={theme.label}
+              fontFamily="Arial" fontSize={10} fontWeight={700}
+              textAnchor="middle" style={{ textTransform: 'uppercase' as const, letterSpacing: 2 }}
+            >
+              {sheetDef.label}
+            </text>
+
+            {/* Column labels */}
+            <text x={MARGIN} y={MARGIN - 10} fill={theme.muted}
+              fontFamily="Arial" fontSize={7} fontWeight={700}>SOURCE</text>
+            <text x={SHEET_W * 0.35} y={MARGIN - 10} fill={theme.muted}
+              fontFamily="Arial" fontSize={7} fontWeight={700}>DISTRIBUTION</text>
+            <text x={SHEET_W * 0.65} y={MARGIN - 10} fill={theme.muted}
+              fontFamily="Arial" fontSize={7} fontWeight={700}>LOAD</text>
+
+            {/* ── Wires ── */}
+            {wirePaths.map(({ wire: w, path }) => {
+              const isSelected = w.wireNumber === selectedWireId;
+              const hasSelection = selectedWireId != null;
+              return (
+                <path
+                  key={w.wireNumber}
+                  d={path}
+                  fill="none"
+                  stroke={isSelected ? C.active : (hasSelection ? theme.wire + '30' : theme.wire)}
+                  strokeWidth={isSelected ? 2 : 1}
+                  style={{ cursor: 'pointer', transition: 'stroke 200ms' }}
+                  onClick={(e) => { e.stopPropagation(); onWireClick(w.wireNumber); }}
+                />
+              );
+            })}
+
+            {/* ── Device boxes ── */}
+            {sheetDevices.map(d => {
+              const pos = layout.get(d.id);
+              if (!pos) return null;
+              const isSelected = d.id === selectedDeviceId;
+              const hasSelection = selectedDeviceId !== null;
+              const zoneColor = ZONE_COLORS[d.location_zone || ''] || '#666';
+
+              return (
+                <g key={d.id}
+                  style={{
+                    cursor: 'pointer',
+                    opacity: hasSelection && !isSelected ? 0.4 : 1,
+                    transition: 'opacity 200ms',
+                  }}
+                  onClick={(e) => { e.stopPropagation(); onDeviceClick(d.id, e.shiftKey); }}
+                >
+                  <rect
+                    x={pos.x} y={pos.y} width={pos.w} height={pos.h}
+                    fill={isSelected ? C.active + '15' : theme.surface}
+                    stroke={isSelected ? C.active : zoneColor}
+                    strokeWidth={isSelected ? 2 : 1}
+                  />
+                  {/* Device name */}
+                  <text
+                    x={pos.x + pos.w / 2} y={pos.y + 14}
+                    fill={isSelected ? C.active : theme.text}
+                    fontFamily="Arial" fontSize={8} fontWeight={700}
+                    textAnchor="middle"
+                    style={{ textTransform: 'uppercase' as const }}
+                  >
+                    {d.device_name.length > 20 ? d.device_name.substring(0, 18) + '...' : d.device_name}
+                  </text>
+                  {/* Specs line */}
+                  <text
+                    x={pos.x + pos.w / 2} y={pos.y + 26}
+                    fill={theme.muted}
+                    fontFamily="'Courier New', monospace" fontSize={7} fontWeight={700}
+                    textAnchor="middle"
+                  >
+                    {[
+                      d.pin_count ? `${d.pin_count}P` : null,
+                      d.power_draw_amps ? `${d.power_draw_amps}A` : null,
+                      d.wire_gauge_recommended ? `${d.wire_gauge_recommended}AWG` : null,
+                    ].filter(Boolean).join(' · ')}
+                  </text>
+                  {/* Pin dots along left and right edges */}
+                  {Array.from({ length: Math.min(d.pin_count || 0, 10) }).map((_, i) => {
+                    const pinY = pos.y + 8 + i * (pos.h - 16) / Math.max((d.pin_count || 2) - 1, 1);
+                    return (
+                      <React.Fragment key={i}>
+                        <circle cx={pos.x} cy={pinY} r={2} fill={zoneColor} />
+                        <circle cx={pos.x + pos.w} cy={pinY} r={2} fill={zoneColor} />
+                      </React.Fragment>
+                    );
+                  })}
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/nuke_frontend/src/components/wiring/TopologyView.tsx
+++ b/nuke_frontend/src/components/wiring/TopologyView.tsx
@@ -1,0 +1,531 @@
+// TopologyView.tsx — SVG-based harness topology node-link diagram
+// Shows K5 trunk routing graph: junction nodes, trunk segments with wire counts,
+// and device dots positioned near their nearest zone junction node.
+// Camera: scroll-to-zoom on cursor, space+drag pan, dark background.
+
+import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
+import type { ManifestDevice, WireSpec, OverlayResult } from './overlayCompute';
+import {
+  K5_HARNESS_GRAPH,
+  computeTrunkSegments,
+  routeWiresAlongHarness,
+} from './harnessRouting';
+import type { TrunkRenderSegment } from './harnessRouting';
+
+// ── Design tokens ─────────────────────────────────────────────────────
+const C = {
+  bg: '#1a1a2e',
+  surface: '#1f1f35',
+  text: '#e0e0e8',
+  label: '#a0a0b0',
+  muted: '#666680',
+  border: '#333355',
+  active: '#00ddff',
+} as const;
+
+const ZONE_COLORS: Record<string, string> = {
+  engine_bay: '#cc2222',
+  firewall: '#cc6600',
+  dash: '#2266cc',
+  doors: '#8822cc',
+  rear: '#22aa44',
+  underbody: '#666666',
+};
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+interface DRCDeviceResult {
+  severity: 'pass' | 'warn' | 'fail';
+  rules: { ruleId: string; label: string; message: string; severity: 'pass' | 'warn' | 'fail' }[];
+}
+
+interface Props {
+  devices: ManifestDevice[];
+  wires: WireSpec[];
+  result: OverlayResult;
+  selectedDeviceId: string | null;
+  selectedDeviceIds: Set<string>;
+  selectedWireId: number | null;
+  onDeviceClick: (id: string, e: React.MouseEvent) => void;
+  onWireClick: (wireNumber: number) => void;
+  drcMap?: Map<string, DRCDeviceResult>;
+}
+
+// ── Camera state ──────────────────────────────────────────────────────
+interface Camera {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+// Map each device to its nearest trunk node based on zone
+function mapDevicesToNodes(devices: ManifestDevice[]): Map<string, { x: number; y: number; nodeId: string }> {
+  const result = new Map<string, { x: number; y: number; nodeId: string }>();
+  const nodes = K5_HARNESS_GRAPH.nodes;
+
+  // Group nodes by zone
+  const nodesByZone = new Map<string, typeof nodes>();
+  for (const n of nodes) {
+    if (!nodesByZone.has(n.zone)) nodesByZone.set(n.zone, []);
+    nodesByZone.get(n.zone)!.push(n);
+  }
+
+  // Distribute devices around their nearest zone node
+  const nodeDeviceCounts = new Map<string, number>();
+
+  for (const d of devices) {
+    const zone = d.location_zone || 'engine_bay';
+    const zoneNodes = nodesByZone.get(zone) || nodesByZone.get('engine_bay') || [nodes[0]];
+
+    // Find nearest node in zone
+    let best = zoneNodes[0];
+    let bestDist = Infinity;
+    // Use device pos if available, otherwise hash device name for stable position
+    const px = d.pos_x_pct != null ? (d.pos_x_pct / 200) * 1000 : hashCode(d.device_name) % 1000;
+    const py = d.pos_y_pct != null ? (d.pos_y_pct / 96) * 1000 : (hashCode(d.id) % 1000);
+
+    for (const n of zoneNodes) {
+      const dist = Math.sqrt((n.x - px) ** 2 + (n.y - py) ** 2);
+      if (dist < bestDist) { bestDist = dist; best = n; }
+    }
+
+    // Offset from node to avoid overlap
+    const count = nodeDeviceCounts.get(best.id) || 0;
+    nodeDeviceCounts.set(best.id, count + 1);
+
+    // Arrange devices in a circle around the node
+    const angle = (count * 2.4) % (Math.PI * 2); // golden angle distribution
+    const radius = 22 + Math.floor(count / 8) * 14;
+    const ox = Math.cos(angle) * radius;
+    const oy = Math.sin(angle) * radius;
+
+    result.set(d.id, { x: best.x + ox, y: best.y + oy, nodeId: best.id });
+  }
+
+  return result;
+}
+
+function hashCode(s: string): number {
+  let hash = 0;
+  for (let i = 0; i < s.length; i++) {
+    hash = ((hash << 5) - hash + s.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+// ── Component ─────────────────────────────────────────────────────────
+
+export function TopologyView({
+  devices, result, selectedDeviceId, selectedDeviceIds,
+  selectedWireId, onDeviceClick, onWireClick, drcMap,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [camera, setCamera] = useState<Camera>({ x: 500, y: 480, zoom: 0.8 });
+  const [isPanning, setIsPanning] = useState(false);
+  const [spaceDown, setSpaceDown] = useState(false);
+  const panStart = useRef<{ x: number; y: number; cx: number; cy: number } | null>(null);
+
+  // Build trunk segments with wire count data
+  const trunkSegments = useMemo((): TrunkRenderSegment[] => {
+    // Route wires through the harness graph to get segment usage
+    const requests = result.wires.map(w => {
+      const fromDevice = devices.find(d => d.device_name === w.from.split(':')[0]);
+      const toDevice = devices.find(d => d.device_name === w.to);
+      return {
+        wireNumber: w.wireNumber,
+        fromX: fromDevice?.pos_x_pct != null ? (fromDevice.pos_x_pct / 200) * 1000 : 500,
+        fromY: fromDevice?.pos_y_pct != null ? (fromDevice.pos_y_pct / 96) * 1000 : 300,
+        toX: toDevice?.pos_x_pct != null ? (toDevice.pos_x_pct / 200) * 1000 : 500,
+        toY: toDevice?.pos_y_pct != null ? (toDevice.pos_y_pct / 96) * 1000 : 500,
+      };
+    });
+
+    const routed = routeWiresAlongHarness(requests);
+    return computeTrunkSegments(routed);
+  }, [result.wires, devices]);
+
+  // Map all trunk segments (even with 0 wires) for display
+  const allSegments = useMemo(() => {
+    const nodes = K5_HARNESS_GRAPH.nodes;
+    const nodeMap = new Map(nodes.map(n => [n.id, n]));
+    return K5_HARNESS_GRAPH.segments.map(seg => {
+      const from = nodeMap.get(seg.from)!;
+      const to = nodeMap.get(seg.to)!;
+      const trunkSeg = trunkSegments.find(ts =>
+        (Math.abs(ts.x1 - from.x) < 1 && Math.abs(ts.y1 - from.y) < 1 &&
+         Math.abs(ts.x2 - to.x) < 1 && Math.abs(ts.y2 - to.y) < 1) ||
+        (Math.abs(ts.x1 - to.x) < 1 && Math.abs(ts.y1 - to.y) < 1 &&
+         Math.abs(ts.x2 - from.x) < 1 && Math.abs(ts.y2 - from.y) < 1)
+      );
+      return {
+        x1: from.x, y1: from.y,
+        x2: to.x, y2: to.y,
+        wireCount: trunkSeg?.wireCount ?? 0,
+        zone: seg.zone,
+      };
+    });
+  }, [trunkSegments]);
+
+  // Device positions on the graph
+  const devicePositions = useMemo(() => mapDevicesToNodes(devices), [devices]);
+
+  // ── Camera controls ──
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+
+    setCamera(prev => {
+      const factor = e.deltaY < 0 ? 1.08 : 1 / 1.08;
+      const newZoom = Math.max(0.3, Math.min(15, prev.zoom * factor));
+      const ratio = newZoom / prev.zoom;
+
+      // Zoom centered on cursor
+      const wx = prev.x + (mx - rect.width / 2) / prev.zoom;
+      const wy = prev.y + (my - rect.height / 2) / prev.zoom;
+      const nx = wx - (wx - prev.x) / ratio;
+      const ny = wy - (wy - prev.y) / ratio;
+
+      return { x: nx, y: ny, zoom: newZoom };
+    });
+  }, []);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if (spaceDown || e.button === 1) {
+      e.preventDefault();
+      setIsPanning(true);
+      panStart.current = { x: e.clientX, y: e.clientY, cx: camera.x, cy: camera.y };
+    }
+  }, [spaceDown, camera.x, camera.y]);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (isPanning && panStart.current) {
+      const dx = e.clientX - panStart.current.x;
+      const dy = e.clientY - panStart.current.y;
+      setCamera(prev => ({
+        ...prev,
+        x: panStart.current!.cx - dx / prev.zoom,
+        y: panStart.current!.cy - dy / prev.zoom,
+      }));
+    }
+  }, [isPanning]);
+
+  const handleMouseUp = useCallback(() => {
+    setIsPanning(false);
+    panStart.current = null;
+  }, []);
+
+  // Space key for pan mode
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.code === 'Space' && !e.repeat) { e.preventDefault(); setSpaceDown(true); }
+    };
+    const up = (e: KeyboardEvent) => {
+      if (e.code === 'Space') { setSpaceDown(false); setIsPanning(false); }
+    };
+    window.addEventListener('keydown', down);
+    window.addEventListener('keyup', up);
+    return () => { window.removeEventListener('keydown', down); window.removeEventListener('keyup', up); };
+  }, []);
+
+  // ── Render ──
+  const rect = containerRef.current?.getBoundingClientRect();
+  const vw = rect?.width ?? 1200;
+  const vh = rect?.height ?? 800;
+
+  // SVG viewBox based on camera
+  const halfW = vw / (2 * camera.zoom);
+  const halfH = vh / (2 * camera.zoom);
+  const viewBox = `${camera.x - halfW} ${camera.y - halfH} ${halfW * 2} ${halfH * 2}`;
+
+  const hasSelection = selectedDeviceId != null;
+
+  return (
+    <div
+      ref={containerRef}
+      onWheel={handleWheel}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
+      style={{
+        width: '100%', height: '100%',
+        background: C.bg,
+        cursor: isPanning ? 'grabbing' : spaceDown ? 'grab' : 'default',
+        overflow: 'hidden',
+        userSelect: 'none',
+      }}
+    >
+      <svg
+        width="100%"
+        height="100%"
+        viewBox={viewBox}
+        style={{ display: 'block' }}
+      >
+        {/* ── Zone background regions ── */}
+        <ZoneRegions />
+
+        {/* ── Trunk segments ── */}
+        {allSegments.map((seg, i) => {
+          const thickness = seg.wireCount > 0
+            ? Math.max(2, Math.min(12, 1 + seg.wireCount * 0.3))
+            : 1;
+          const zoneColor = ZONE_COLORS[seg.zone] || '#555577';
+          const opacity = seg.wireCount > 0 ? 0.7 : 0.2;
+
+          return (
+            <g key={`seg-${i}`}>
+              <line
+                x1={seg.x1} y1={seg.y1}
+                x2={seg.x2} y2={seg.y2}
+                stroke={zoneColor}
+                strokeWidth={thickness}
+                strokeOpacity={opacity}
+                strokeLinecap="square"
+              />
+              {/* Wire count label on segment midpoint */}
+              {seg.wireCount > 0 && camera.zoom > 0.6 && (
+                <text
+                  x={(seg.x1 + seg.x2) / 2}
+                  y={(seg.y1 + seg.y2) / 2 - 4}
+                  fill={C.label}
+                  fontSize={8 / camera.zoom}
+                  fontFamily="'Courier New', monospace"
+                  fontWeight={700}
+                  textAnchor="middle"
+                >
+                  {seg.wireCount}W
+                </text>
+              )}
+            </g>
+          );
+        })}
+
+        {/* ── Junction nodes ── */}
+        {K5_HARNESS_GRAPH.nodes.map(node => {
+          const zoneColor = ZONE_COLORS[node.zone] || '#555577';
+          return (
+            <g key={node.id}>
+              <rect
+                x={node.x - 6}
+                y={node.y - 6}
+                width={12}
+                height={12}
+                fill={zoneColor}
+                fillOpacity={0.5}
+                stroke={zoneColor}
+                strokeWidth={2}
+              />
+              {/* Node label at higher zoom */}
+              {camera.zoom > 1.0 && (
+                <text
+                  x={node.x}
+                  y={node.y - 10}
+                  fill={C.label}
+                  fontSize={7 / camera.zoom}
+                  fontFamily="Arial, sans-serif"
+                  fontWeight={700}
+                  textAnchor="middle"
+                  style={{ textTransform: 'uppercase' } as React.CSSProperties}
+                >
+                  {node.label}
+                </text>
+              )}
+            </g>
+          );
+        })}
+
+        {/* ── Device dots ── */}
+        {devices.map(d => {
+          const pos = devicePositions.get(d.id);
+          if (!pos) return null;
+
+          const isSelected = d.id === selectedDeviceId || selectedDeviceIds.has(d.id);
+          const zoneColor = ZONE_COLORS[d.location_zone || ''] || '#555577';
+          const dimmed = hasSelection && !isSelected;
+
+          // DRC indicator
+          const drc = drcMap?.get(d.id);
+          const drcColor = drc?.severity === 'fail' ? '#ef4444'
+            : drc?.severity === 'warn' ? '#eab308'
+            : drc ? '#22c55e' : undefined;
+
+          return (
+            <g
+              key={d.id}
+              onClick={(e) => onDeviceClick(d.id, e)}
+              style={{ cursor: 'pointer' }}
+              opacity={dimmed ? 0.4 : 1}
+            >
+              {/* Connection line from device dot to its junction node */}
+              {(() => {
+                const node = K5_HARNESS_GRAPH.nodes.find(n => n.id === pos.nodeId);
+                if (!node) return null;
+                return (
+                  <line
+                    x1={pos.x} y1={pos.y}
+                    x2={node.x} y2={node.y}
+                    stroke={zoneColor}
+                    strokeWidth={0.5}
+                    strokeOpacity={0.3}
+                    strokeDasharray="2,2"
+                  />
+                );
+              })()}
+
+              {/* Device dot */}
+              <rect
+                x={pos.x - 4}
+                y={pos.y - 4}
+                width={8}
+                height={8}
+                fill={zoneColor}
+                stroke={isSelected ? C.active : zoneColor}
+                strokeWidth={isSelected ? 2 : 1}
+              />
+
+              {/* Selection highlight */}
+              {isSelected && (
+                <rect
+                  x={pos.x - 7}
+                  y={pos.y - 7}
+                  width={14}
+                  height={14}
+                  fill="none"
+                  stroke={C.active}
+                  strokeWidth={2}
+                />
+              )}
+
+              {/* DRC dot */}
+              {drcColor && (
+                <rect
+                  x={pos.x + 4}
+                  y={pos.y - 7}
+                  width={5}
+                  height={5}
+                  fill={drcColor}
+                />
+              )}
+
+              {/* Device label at higher zoom */}
+              {camera.zoom > 1.2 && (
+                <text
+                  x={pos.x}
+                  y={pos.y + 12}
+                  fill={isSelected ? C.active : C.text}
+                  fontSize={6 / camera.zoom}
+                  fontFamily="Arial, sans-serif"
+                  fontWeight={700}
+                  textAnchor="middle"
+                  style={{ textTransform: 'uppercase' } as React.CSSProperties}
+                >
+                  {d.device_name.length > 16 ? d.device_name.slice(0, 14) + '..' : d.device_name}
+                </text>
+              )}
+            </g>
+          );
+        })}
+
+        {/* ── Legend ── */}
+        <Legend zoom={camera.zoom} viewBox={{ x: camera.x - halfW, y: camera.y - halfH, w: halfW * 2, h: halfH * 2 }} />
+      </svg>
+    </div>
+  );
+}
+
+// ── Zone background regions ───────────────────────────────────────────
+function ZoneRegions() {
+  // Approximate zone boundaries on the 1000x1000 grid
+  const zones = [
+    { zone: 'engine_bay', x: 140, y: 30, w: 720, h: 270, label: 'ENGINE BAY' },
+    { zone: 'firewall', x: 280, y: 290, w: 460, h: 50, label: 'FIREWALL' },
+    { zone: 'dash', x: 220, y: 340, w: 560, h: 180, label: 'DASH' },
+    { zone: 'doors', x: 120, y: 400, w: 760, h: 100, label: 'DOORS' },
+    { zone: 'rear', x: 160, y: 560, w: 680, h: 400, label: 'REAR' },
+  ];
+
+  return (
+    <g>
+      {zones.map(z => (
+        <g key={z.zone}>
+          <rect
+            x={z.x} y={z.y} width={z.w} height={z.h}
+            fill={ZONE_COLORS[z.zone] || '#555577'}
+            fillOpacity={0.04}
+            stroke={ZONE_COLORS[z.zone] || '#555577'}
+            strokeWidth={1}
+            strokeOpacity={0.15}
+            strokeDasharray="4,4"
+          />
+          <text
+            x={z.x + 6} y={z.y + 12}
+            fill={ZONE_COLORS[z.zone] || '#555577'}
+            fillOpacity={0.25}
+            fontSize={9}
+            fontFamily="Arial, sans-serif"
+            fontWeight={700}
+            letterSpacing={1}
+          >
+            {z.label}
+          </text>
+        </g>
+      ))}
+    </g>
+  );
+}
+
+// ── Legend ─────────────────────────────────────────────────────────────
+function Legend({ zoom, viewBox }: { zoom: number; viewBox: { x: number; y: number; w: number; h: number } }) {
+  const s = 1 / zoom; // scale factor so legend stays fixed-size on screen
+  const lx = viewBox.x + viewBox.w - 180 * s;
+  const ly = viewBox.y + 12 * s;
+
+  const entries = [
+    { zone: 'engine_bay', label: 'ENGINE' },
+    { zone: 'firewall', label: 'FIREWALL' },
+    { zone: 'dash', label: 'DASH' },
+    { zone: 'doors', label: 'DOORS' },
+    { zone: 'rear', label: 'REAR' },
+    { zone: 'underbody', label: 'UNDERBODY' },
+  ];
+
+  return (
+    <g>
+      <rect
+        x={lx} y={ly}
+        width={170 * s} height={(entries.length * 14 + 8) * s}
+        fill="#1a1a2e"
+        fillOpacity={0.85}
+        stroke="#333355"
+        strokeWidth={s}
+      />
+      {entries.map((e, i) => (
+        <g key={e.zone}>
+          <rect
+            x={lx + 6 * s}
+            y={ly + (6 + i * 14) * s}
+            width={8 * s}
+            height={8 * s}
+            fill={ZONE_COLORS[e.zone]}
+          />
+          <text
+            x={lx + 20 * s}
+            y={ly + (13 + i * 14) * s}
+            fill="#a0a0b0"
+            fontSize={8 * s}
+            fontFamily="Arial, sans-serif"
+            fontWeight={700}
+          >
+            {e.label}
+          </text>
+        </g>
+      ))}
+    </g>
+  );
+}

--- a/nuke_frontend/src/components/wiring/useDRC.ts
+++ b/nuke_frontend/src/components/wiring/useDRC.ts
@@ -1,0 +1,297 @@
+// useDRC.ts — Design Rule Check hook
+// Runs 8 design rule checks against device manifest + pin maps + overlay result.
+// Returns per-device severity map and summary counts.
+
+import { useMemo } from 'react';
+import type { ManifestDevice, OverlayResult } from './overlayCompute';
+import { AWG_TABLE } from './harnessConstants';
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export interface DRCRule {
+  ruleId: string;
+  label: string;
+  message: string;
+  severity: 'pass' | 'warn' | 'fail';
+}
+
+export interface DRCDeviceResult {
+  severity: 'pass' | 'warn' | 'fail';
+  rules: DRCRule[];
+}
+
+export interface DRCSummary {
+  pass: number;
+  warn: number;
+  fail: number;
+}
+
+export interface DRCResult {
+  drcMap: Map<string, DRCDeviceResult>;
+  summary: DRCSummary;
+}
+
+// ── AWG lookup ────────────────────────────────────────────────────────
+// Build a map from gauge number to max amps
+const AWG_MAX_AMPS = new Map<number, number>();
+for (const entry of AWG_TABLE) {
+  const gaugeNum = parseInt(entry.gauge);
+  if (!isNaN(gaugeNum)) AWG_MAX_AMPS.set(gaugeNum, entry.maxAmps);
+}
+
+// Special handling for 0 AWG
+if (!AWG_MAX_AMPS.has(0)) {
+  const zeroEntry = AWG_TABLE.find(e => e.gauge === '0 AWG');
+  if (zeroEntry) AWG_MAX_AMPS.set(0, zeroEntry.maxAmps);
+}
+
+// Critical device categories
+const CRITICAL_CATEGORIES = new Set([
+  'engine_mgmt', 'engine_management', 'sensors', 'safety',
+]);
+
+// ── Hook ──────────────────────────────────────────────────────────────
+
+export function useDRC(
+  devices: ManifestDevice[],
+  result: OverlayResult,
+  pinMaps?: Record<string, unknown[]>,
+): DRCResult {
+  return useMemo(() => {
+    const drcMap = new Map<string, DRCDeviceResult>();
+
+    // Build wire lookup by device name
+    const wiresByDevice = new Map<string, typeof result.wires>();
+    for (const w of result.wires) {
+      // "to" field is the device name
+      if (!wiresByDevice.has(w.to)) wiresByDevice.set(w.to, []);
+      wiresByDevice.get(w.to)!.push(w);
+      // "from" can be "PDM30:OUT5" — extract device name
+      const fromDevice = w.from.split(':')[0];
+      if (!wiresByDevice.has(fromDevice)) wiresByDevice.set(fromDevice, []);
+      wiresByDevice.get(fromDevice)!.push(w);
+    }
+
+    // PDM channel map for overload check
+    const pdmChannelAmps = new Map<number, number>();
+    const pdmChannelMaxAmps = new Map<number, number>();
+    for (const ch of result.pdmChannels) {
+      pdmChannelAmps.set(ch.channel, ch.totalAmps);
+      pdmChannelMaxAmps.set(ch.channel, ch.maxAmps);
+    }
+
+    for (const device of devices) {
+      const rules: DRCRule[] = [];
+      const modelPins = pinMaps?.[device.model_number || ''] as Array<{
+        pin_number?: string;
+        connected_to_device?: string;
+        connected_to_pin?: string;
+      }> | undefined;
+
+      // ── Rule 1: Pin conflict ──
+      if (modelPins && modelPins.length > 0) {
+        const pinAssignments = new Map<string, string[]>();
+        for (const pin of modelPins) {
+          const pn = pin.pin_number || '';
+          const target = `${pin.connected_to_device || ''}:${pin.connected_to_pin || ''}`;
+          if (!pinAssignments.has(pn)) pinAssignments.set(pn, []);
+          pinAssignments.get(pn)!.push(target);
+        }
+        const duplicates = Array.from(pinAssignments.entries())
+          .filter(([, targets]) => {
+            const unique = new Set(targets.filter(t => t !== ':'));
+            return unique.size > 1;
+          });
+        if (duplicates.length > 0) {
+          rules.push({
+            ruleId: 'pin-conflict',
+            label: 'Pin Conflict',
+            message: `Duplicate pin assignments: ${duplicates.map(([p]) => p).join(', ')}`,
+            severity: 'fail',
+          });
+        } else {
+          rules.push({
+            ruleId: 'pin-conflict',
+            label: 'Pin Conflict',
+            message: 'No pin conflicts',
+            severity: 'pass',
+          });
+        }
+      }
+
+      // ── Rule 2: Gauge vs ampacity ──
+      if (device.power_draw_amps && device.wire_gauge_recommended) {
+        const maxAmps = AWG_MAX_AMPS.get(device.wire_gauge_recommended);
+        if (maxAmps != null) {
+          if (device.power_draw_amps > maxAmps) {
+            rules.push({
+              ruleId: 'gauge-ampacity',
+              label: 'Gauge vs Ampacity',
+              message: `${device.wire_gauge_recommended} AWG max ${maxAmps}A < draw ${device.power_draw_amps}A`,
+              severity: 'fail',
+            });
+          } else if (device.power_draw_amps > maxAmps * 0.8) {
+            rules.push({
+              ruleId: 'gauge-ampacity',
+              label: 'Gauge vs Ampacity',
+              message: `${device.wire_gauge_recommended} AWG at ${Math.round((device.power_draw_amps / maxAmps) * 100)}% capacity`,
+              severity: 'warn',
+            });
+          } else {
+            rules.push({
+              ruleId: 'gauge-ampacity',
+              label: 'Gauge vs Ampacity',
+              message: `${device.wire_gauge_recommended} AWG OK for ${device.power_draw_amps}A`,
+              severity: 'pass',
+            });
+          }
+        }
+      }
+
+      // ── Rule 3: Voltage drop ──
+      const deviceWires = wiresByDevice.get(device.device_name) || [];
+      const highDropWires = deviceWires.filter(w => w.voltageDropPct > 3);
+      if (highDropWires.length > 0) {
+        const worst = highDropWires.reduce((a, b) => a.voltageDropPct > b.voltageDropPct ? a : b);
+        rules.push({
+          ruleId: 'voltage-drop',
+          label: 'Voltage Drop',
+          message: `${worst.voltageDropPct.toFixed(1)}% drop on ${worst.label} (>3% limit)`,
+          severity: worst.voltageDropPct > 5 ? 'fail' : 'warn',
+        });
+      } else if (deviceWires.length > 0) {
+        rules.push({
+          ruleId: 'voltage-drop',
+          label: 'Voltage Drop',
+          message: 'All wires within 3% drop limit',
+          severity: 'pass',
+        });
+      }
+
+      // ── Rule 4: Missing pin map ──
+      if (!modelPins || modelPins.length === 0) {
+        rules.push({
+          ruleId: 'missing-pin-map',
+          label: 'Missing Pin Map',
+          message: `No pin map entries for ${device.model_number || device.device_name}`,
+          severity: 'warn',
+        });
+      } else {
+        rules.push({
+          ruleId: 'missing-pin-map',
+          label: 'Missing Pin Map',
+          message: `${modelPins.length} pin mappings found`,
+          severity: 'pass',
+        });
+      }
+
+      // ── Rule 5: Missing connector type ──
+      if (!device.connector_type) {
+        rules.push({
+          ruleId: 'missing-connector',
+          label: 'Missing Connector Type',
+          message: 'Connector type not specified',
+          severity: 'warn',
+        });
+      } else {
+        rules.push({
+          ruleId: 'missing-connector',
+          label: 'Missing Connector Type',
+          message: device.connector_type,
+          severity: 'pass',
+        });
+      }
+
+      // ── Rule 6: Missing location zone ──
+      if (!device.location_zone) {
+        rules.push({
+          ruleId: 'missing-zone',
+          label: 'Missing Location Zone',
+          message: 'Location zone not specified',
+          severity: 'warn',
+        });
+      } else {
+        rules.push({
+          ruleId: 'missing-zone',
+          label: 'Missing Location Zone',
+          message: device.location_zone.replace(/_/g, ' '),
+          severity: 'pass',
+        });
+      }
+
+      // ── Rule 7: PDM overload ──
+      if (device.pdm_controlled) {
+        // Find PDM channel for this device
+        const deviceCh = result.pdmChannels.find(ch =>
+          ch.devices.includes(device.device_name)
+        );
+        if (deviceCh && deviceCh.totalAmps > deviceCh.maxAmps) {
+          rules.push({
+            ruleId: 'pdm-overload',
+            label: 'PDM Overload',
+            message: `Channel ${deviceCh.channel}: ${deviceCh.totalAmps.toFixed(1)}A > ${deviceCh.maxAmps}A max`,
+            severity: 'fail',
+          });
+        } else if (deviceCh && deviceCh.totalAmps > deviceCh.maxAmps * 0.8) {
+          rules.push({
+            ruleId: 'pdm-overload',
+            label: 'PDM Overload',
+            message: `Channel ${deviceCh.channel}: ${Math.round((deviceCh.totalAmps / deviceCh.maxAmps) * 100)}% capacity`,
+            severity: 'warn',
+          });
+        } else if (deviceCh) {
+          rules.push({
+            ruleId: 'pdm-overload',
+            label: 'PDM Overload',
+            message: `Channel ${deviceCh.channel} OK`,
+            severity: 'pass',
+          });
+        }
+      }
+
+      // ── Rule 8: Unpurchased critical ──
+      const isCritical = CRITICAL_CATEGORIES.has(device.device_category || '');
+      if (!device.purchased && isCritical) {
+        rules.push({
+          ruleId: 'unpurchased-critical',
+          label: 'Unpurchased Critical',
+          message: `Critical ${device.device_category?.replace(/_/g, ' ')} device not purchased`,
+          severity: 'fail',
+        });
+      } else if (!device.purchased) {
+        rules.push({
+          ruleId: 'unpurchased-critical',
+          label: 'Unpurchased Critical',
+          message: 'Not purchased (non-critical)',
+          severity: 'pass',
+        });
+      } else {
+        rules.push({
+          ruleId: 'unpurchased-critical',
+          label: 'Unpurchased Critical',
+          message: 'Purchased',
+          severity: 'pass',
+        });
+      }
+
+      // Compute worst severity
+      let severity: 'pass' | 'warn' | 'fail' = 'pass';
+      for (const r of rules) {
+        if (r.severity === 'fail') { severity = 'fail'; break; }
+        if (r.severity === 'warn') severity = 'warn';
+      }
+
+      drcMap.set(device.id, { severity, rules });
+    }
+
+    // Summary
+    let pass = 0, warn = 0, fail = 0;
+    for (const [, v] of drcMap) {
+      if (v.severity === 'pass') pass++;
+      else if (v.severity === 'warn') warn++;
+      else fail++;
+    }
+
+    return { drcMap, summary: { pass, warn, fail } };
+  }, [devices, result, pinMaps]);
+}

--- a/nuke_frontend/src/pages/WiringPlan.tsx
+++ b/nuke_frontend/src/pages/WiringPlan.tsx
@@ -1,20 +1,108 @@
-// WiringPlan.tsx — Entry point for /vehicle/:vehicleId/wiring
-// Loads vehicle_build_manifest → WiringWorkspace (data view + reference images).
+// WiringPlan.tsx — Parent page for /vehicle/:vehicleId/wiring
+// 5-tab system: FORMBOARD | SCHEMATICS | 3D | DATA | TOPOLOGY
+// Shared state: selectedDeviceId, selectedDeviceIds, selectedWireId
+// Hosts DeviceDetailPanel (right-side), CommandPalette (overlay)
+// Keyboard shortcuts: 1-5 tabs, F fit, Esc deselect, Cmd+K search
 
-import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
-import { WiringWorkspace } from '../components/wiring/WiringWorkspace';
-import type { ManifestDevice } from '../components/wiring/overlayCompute';
+import type { ManifestDevice, WireSpec } from '../components/wiring/overlayCompute';
+import { useOverlayCompute } from '../components/wiring/useOverlayCompute';
+import { DeviceDetailPanel } from '../components/wiring/DeviceDetailPanel';
+import { FormboardView } from '../components/wiring/FormboardView';
+import { SchematicView } from '../components/wiring/SchematicView';
+import { HarnessView3D } from '../components/wiring/HarnessView3D';
+import { DataView } from '../components/wiring/DataView';
+import { CommandPalette } from '../components/wiring/CommandPalette';
+
+// ── Design tokens ─────────────────────────────────────────────────────
+const C = {
+  bg: '#1a1a2e',
+  surface: '#1f1f35',
+  elevated: '#252540',
+  text: '#e0e0e8',
+  label: '#a0a0b0',
+  muted: '#666680',
+  border: '#333355',
+  active: '#00ddff',
+  pass: '#22c55e',
+  warn: '#eab308',
+  fail: '#ef4444',
+} as const;
+
+const ZONE_COLORS: Record<string, string> = {
+  engine_bay: '#cc2222',
+  firewall: '#cc6600',
+  dash: '#2266cc',
+  doors: '#8822cc',
+  rear: '#22aa44',
+  underbody: '#666666',
+};
+
+type ViewTab = 'formboard' | 'schematics' | '3d' | 'data' | 'topology';
+const TABS: { id: ViewTab; label: string; key: string }[] = [
+  { id: 'formboard', label: 'FORMBOARD', key: '1' },
+  { id: 'schematics', label: 'SCHEMATICS', key: '2' },
+  { id: '3d', label: '3D', key: '3' },
+  { id: 'data', label: 'DATA', key: '4' },
+  { id: 'topology', label: 'TOPOLOGY', key: '5' },
+];
+
+// ── Camera state per view ─────────────────────────────────────────────
+interface CameraState {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+const defaultCamera = (): CameraState => ({ x: 0, y: 0, zoom: 1 });
 
 export default function WiringPlan() {
-  const navigate = useNavigate();
   const { vehicleId } = useParams();
 
+  // ── Data loading ──
   const [vehicleInfo, setVehicleInfo] = useState<{ year?: number; make?: string; model?: string } | null>(null);
   const [manifestDevices, setManifestDevices] = useState<ManifestDevice[]>([]);
   const [loading, setLoading] = useState(true);
 
+  // ── Overlay compute ──
+  const overlay = useOverlayCompute(manifestDevices);
+
+  // ── Shared selection state ──
+  const [activeTab, setActiveTab] = useState<ViewTab>('formboard');
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
+  const [selectedDeviceIds, setSelectedDeviceIds] = useState<Set<string>>(new Set());
+  const [selectedWireId, setSelectedWireId] = useState<number | null>(null);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [fitRequested, setFitRequested] = useState(0);
+
+  // ── Camera state per view (persists across tab switches) ──
+  const cameraRefs = useRef<Record<ViewTab, CameraState>>({
+    formboard: defaultCamera(),
+    schematics: defaultCamera(),
+    '3d': defaultCamera(),
+    data: defaultCamera(),
+    topology: defaultCamera(),
+  });
+
+  // ── Selected device lookup ──
+  const selectedDevice = useMemo(
+    () => selectedDeviceId ? overlay.devices.find(d => d.id === selectedDeviceId) ?? null : null,
+    [selectedDeviceId, overlay.devices]
+  );
+
+  const selectedWire = useMemo(
+    () => selectedWireId != null ? overlay.result.wires.find(w => w.wireNumber === selectedWireId) ?? null : null,
+    [selectedWireId, overlay.result.wires]
+  );
+
+  // ── Supabase queries for detail panel ──
+  const [pinMaps, setPinMaps] = useState<Record<string, unknown[]>>({});
+  const [partsReception, setPartsReception] = useState<unknown[]>([]);
+  const [workOrderParts, setWorkOrderParts] = useState<unknown[]>([]);
+
+  // ── Load manifest ──
   useEffect(() => {
     async function init() {
       if (!vehicleId) return;
@@ -28,7 +116,6 @@ export default function WiringPlan() {
             .order('device_category')
             .order('device_name'),
         ]);
-
         if (vehicleRes.data) setVehicleInfo(vehicleRes.data);
         if (manifestRes.data) setManifestDevices(manifestRes.data as ManifestDevice[]);
       } finally {
@@ -38,11 +125,309 @@ export default function WiringPlan() {
     init();
   }, [vehicleId]);
 
-  if (loading) return null;
+  // ── Load pin maps once ──
+  useEffect(() => {
+    async function loadPinMaps() {
+      const { data } = await supabase.from('device_pin_maps').select('*');
+      if (data) {
+        const grouped: Record<string, unknown[]> = {};
+        for (const row of data) {
+          const model = (row as { device_model: string }).device_model;
+          if (!grouped[model]) grouped[model] = [];
+          grouped[model].push(row);
+        }
+        setPinMaps(grouped);
+      }
+    }
+    loadPinMaps();
+  }, []);
+
+  // ── Load procurement data once ──
+  useEffect(() => {
+    async function loadProcurement() {
+      const [prRes, woRes] = await Promise.all([
+        supabase.from('parts_reception').select('*'),
+        supabase.from('work_order_parts').select('*'),
+      ]);
+      if (prRes.data) setPartsReception(prRes.data);
+      if (woRes.data) setWorkOrderParts(woRes.data);
+    }
+    loadProcurement();
+  }, []);
+
+  // ── Click handlers ──
+  const handleDeviceClick = useCallback((deviceId: string, shiftKey?: boolean) => {
+    if (shiftKey) {
+      setSelectedDeviceIds(prev => {
+        const next = new Set(prev);
+        if (next.has(deviceId)) next.delete(deviceId);
+        else next.add(deviceId);
+        return next;
+      });
+    }
+    setSelectedDeviceId(deviceId);
+    setSelectedWireId(null);
+  }, []);
+
+  const handleWireClick = useCallback((wireNumber: number) => {
+    setSelectedWireId(wireNumber);
+    const wire = overlay.result.wires.find(w => w.wireNumber === wireNumber);
+    if (wire) {
+      const device = overlay.devices.find(d => d.device_name === wire.to);
+      if (device) setSelectedDeviceId(device.id);
+    }
+  }, [overlay.result.wires, overlay.devices]);
+
+  const handleDeselect = useCallback(() => {
+    setSelectedDeviceId(null);
+    setSelectedDeviceIds(new Set());
+    setSelectedWireId(null);
+  }, []);
+
+  const handleClosePanel = useCallback(() => {
+    setSelectedDeviceId(null);
+    setSelectedWireId(null);
+  }, []);
+
+  // ── Navigate to device on formboard ──
+  const handleShowOnFormboard = useCallback((deviceId: string) => {
+    setActiveTab('formboard');
+    setSelectedDeviceId(deviceId);
+    // Zoom-to-fit will be handled by the formboard view
+  }, []);
+
+  // ── Keyboard shortcuts ──
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return;
+
+      // Cmd+K / Ctrl+K or / → command palette
+      if ((e.key === 'k' && (e.metaKey || e.ctrlKey)) || (e.key === '/' && !e.metaKey && !e.ctrlKey)) {
+        e.preventDefault();
+        setCommandPaletteOpen(prev => !prev);
+        return;
+      }
+
+      // 1-5 → switch tabs
+      const tabIdx = parseInt(e.key) - 1;
+      if (tabIdx >= 0 && tabIdx < TABS.length && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault();
+        setActiveTab(TABS[tabIdx].id);
+        return;
+      }
+
+      // F → fit all
+      if (e.key === 'f' || e.key === 'F') {
+        e.preventDefault();
+        setFitRequested(prev => prev + 1);
+        return;
+      }
+
+      // Escape → deselect / close
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        if (commandPaletteOpen) {
+          setCommandPaletteOpen(false);
+        } else {
+          handleDeselect();
+        }
+        return;
+      }
+
+      // Tab / Shift+Tab → cycle devices
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        const devices = overlay.devices;
+        if (devices.length === 0) return;
+        const currentIdx = selectedDeviceId ? devices.findIndex(d => d.id === selectedDeviceId) : -1;
+        const nextIdx = e.shiftKey
+          ? (currentIdx - 1 + devices.length) % devices.length
+          : (currentIdx + 1) % devices.length;
+        setSelectedDeviceId(devices[nextIdx].id);
+        return;
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [commandPaletteOpen, handleDeselect, overlay.devices, selectedDeviceId]);
+
+  // ── Loading state ──
+  if (loading) {
+    return (
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        height: 'calc(100vh - 42px)', background: C.bg, color: C.muted,
+        fontFamily: "'Courier New', monospace", fontSize: 11,
+      }}>
+        LOADING HARNESS DATA...
+      </div>
+    );
+  }
+
+  // ── Shared view props ──
+  const viewProps = {
+    devices: overlay.devices,
+    result: overlay.result,
+    selectedDeviceId,
+    selectedDeviceIds,
+    selectedWireId,
+    onDeviceClick: handleDeviceClick,
+    onWireClick: handleWireClick,
+    onDeselect: handleDeselect,
+    fitRequested,
+    vehicleId,
+    zoneColors: ZONE_COLORS,
+  };
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 42px)' }}>
-      <WiringWorkspace initialDevices={manifestDevices} vehicleId={vehicleId} />
+    <div style={{
+      display: 'flex', flexDirection: 'column',
+      height: 'calc(100vh - 42px)',
+      background: C.bg, color: C.text,
+      fontFamily: 'Arial, sans-serif',
+      overflow: 'hidden',
+      position: 'relative',
+    }}>
+      {/* ── Status Bar ── */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 16,
+        padding: '0 12px', height: 28,
+        background: C.surface,
+        borderBottom: `2px solid ${C.border}`,
+        fontFamily: "'Courier New', monospace",
+        fontSize: 10, fontWeight: 700,
+        flexShrink: 0,
+      }}>
+        <span style={{ color: C.label, fontFamily: 'Arial', fontSize: 8, textTransform: 'uppercase', letterSpacing: 1 }}>
+          {vehicleInfo ? `${vehicleInfo.year} ${vehicleInfo.make} ${vehicleInfo.model}` : 'VEHICLE'} — WIRING HARNESS
+        </span>
+        <span style={{ marginLeft: 'auto' }} />
+        <StatusChip label="DEVICES" value={overlay.result.deviceCount} />
+        <StatusChip label="WIRES" value={overlay.result.wireCount} />
+        <StatusChip label="LENGTH" value={`${overlay.result.totalWireLengthFt} FT`} />
+        <StatusChip label="AMPS" value={overlay.result.totalContinuousAmps} />
+        <StatusChip label="ECU" value={overlay.result.recommendedConfig.ecu.model} />
+        <StatusChip label="PDM" value={overlay.result.recommendedConfig.pdm.config} />
+        <StatusChip label="COST" value={`$${Math.round(overlay.result.partsCost).toLocaleString()}`} />
+        {overlay.result.warnings.length > 0 && (
+          <span style={{ color: C.warn }}>
+            {overlay.result.warnings.length} WARNINGS
+          </span>
+        )}
+      </div>
+
+      {/* ── Tab Bar ── */}
+      <div style={{
+        display: 'flex', alignItems: 'stretch',
+        height: 28, flexShrink: 0,
+        background: C.bg,
+        borderBottom: `2px solid ${C.border}`,
+      }}>
+        {TABS.map(tab => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            style={{
+              background: activeTab === tab.id ? C.elevated : 'transparent',
+              color: activeTab === tab.id ? C.active : C.label,
+              border: 'none',
+              borderBottom: activeTab === tab.id ? `2px solid ${C.active}` : '2px solid transparent',
+              padding: '0 16px',
+              fontFamily: 'Arial, sans-serif',
+              fontSize: 9,
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: 1,
+              cursor: 'pointer',
+              transition: 'all 200ms cubic-bezier(0.16, 1, 0.3, 1)',
+            }}
+          >
+            {tab.label}
+            <span style={{ color: C.muted, marginLeft: 4, fontSize: 8 }}>{tab.key}</span>
+          </button>
+        ))}
+        <div style={{ flex: 1 }} />
+        <button
+          onClick={() => setCommandPaletteOpen(true)}
+          style={{
+            background: 'transparent',
+            color: C.muted,
+            border: `1px solid ${C.border}`,
+            padding: '0 10px',
+            fontFamily: "'Courier New', monospace",
+            fontSize: 9,
+            cursor: 'pointer',
+            margin: '3px 8px',
+          }}
+        >
+          SEARCH ⌘K
+        </button>
+      </div>
+
+      {/* ── View Container ── */}
+      <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
+        {/* All views stay mounted but hidden for camera persistence */}
+        <div style={{ position: 'absolute', inset: 0, display: activeTab === 'formboard' ? 'block' : 'none' }}>
+          <FormboardView {...viewProps} cameraRef={cameraRefs.current.formboard} />
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: activeTab === 'schematics' ? 'block' : 'none' }}>
+          <SchematicView {...viewProps} cameraRef={cameraRefs.current.schematics} />
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: activeTab === '3d' ? 'block' : 'none' }}>
+          <HarnessView3D {...viewProps} />
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: activeTab === 'data' ? 'block' : 'none' }}>
+          <DataView {...viewProps} overlay={overlay} />
+        </div>
+        <div style={{ position: 'absolute', inset: 0, display: activeTab === 'topology' ? 'flex' : 'none', alignItems: 'center', justifyContent: 'center' }}>
+          <span style={{ color: C.muted, fontFamily: "'Courier New', monospace", fontSize: 11 }}>
+            TOPOLOGY VIEW — COMING SOON
+          </span>
+        </div>
+
+        {/* ── Detail Panel (slides in from right) ── */}
+        <DeviceDetailPanel
+          device={selectedDevice}
+          wire={selectedWire}
+          result={overlay.result}
+          devices={overlay.devices}
+          pinMaps={pinMaps}
+          partsReception={partsReception}
+          workOrderParts={workOrderParts}
+          zoneColors={ZONE_COLORS}
+          onClose={handleClosePanel}
+          onShowOnFormboard={handleShowOnFormboard}
+        />
+      </div>
+
+      {/* ── Command Palette ── */}
+      {commandPaletteOpen && (
+        <CommandPalette
+          devices={overlay.devices}
+          wires={overlay.result.wires}
+          zoneColors={ZONE_COLORS}
+          onSelectDevice={(id) => { handleDeviceClick(id); setCommandPaletteOpen(false); }}
+          onSelectWire={(n) => { handleWireClick(n); setCommandPaletteOpen(false); }}
+          onSwitchTab={(tab) => { setActiveTab(tab as ViewTab); setCommandPaletteOpen(false); }}
+          onClose={() => setCommandPaletteOpen(false)}
+        />
+      )}
     </div>
+  );
+}
+
+// ── Status chip ─────────────────────────────────────────────────────
+function StatusChip({ label, value }: { label: string; value: string | number }) {
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+      <span style={{ color: '#a0a0b0', fontFamily: 'Arial', fontSize: 7, textTransform: 'uppercase', letterSpacing: 0.5, fontWeight: 700 }}>
+        {label}
+      </span>
+      <span style={{ color: '#e0e0e8', fontFamily: "'Courier New', monospace", fontSize: 10, fontWeight: 700 }}>
+        {value}
+      </span>
+    </span>
   );
 }

--- a/nuke_frontend/src/pages/WiringPlan.tsx
+++ b/nuke_frontend/src/pages/WiringPlan.tsx
@@ -15,6 +15,8 @@ import { SchematicView } from '../components/wiring/SchematicView';
 import { HarnessView3D } from '../components/wiring/HarnessView3D';
 import { DataView } from '../components/wiring/DataView';
 import { CommandPalette } from '../components/wiring/CommandPalette';
+import { TopologyView } from '../components/wiring/TopologyView';
+import { useDRC } from '../components/wiring/useDRC';
 
 // ── Design tokens ─────────────────────────────────────────────────────
 const C = {
@@ -85,6 +87,9 @@ export default function WiringPlan() {
     data: defaultCamera(),
     topology: defaultCamera(),
   });
+
+  // ── DRC ──
+  const drc = useDRC(overlay.devices, overlay.result, pinMaps);
 
   // ── Selected device lookup ──
   const selectedDevice = useMemo(
@@ -279,6 +284,7 @@ export default function WiringPlan() {
     fitRequested,
     vehicleId,
     zoneColors: ZONE_COLORS,
+    drcMap: drc.drcMap,
   };
 
   return (
@@ -316,6 +322,21 @@ export default function WiringPlan() {
             {overlay.result.warnings.length} WARNINGS
           </span>
         )}
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, borderLeft: `1px solid ${C.border}`, paddingLeft: 8 }}>
+          <span style={{ color: C.label, fontFamily: 'Arial', fontSize: 7, textTransform: 'uppercase', letterSpacing: 0.5, fontWeight: 700 }}>DRC:</span>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+            <span style={{ width: 6, height: 6, background: C.pass, display: 'inline-block' }} />
+            <span style={{ color: C.pass, fontFamily: "'Courier New', monospace", fontSize: 10, fontWeight: 700 }}>{drc.summary.pass}</span>
+          </span>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+            <span style={{ width: 6, height: 6, background: C.warn, display: 'inline-block' }} />
+            <span style={{ color: C.warn, fontFamily: "'Courier New', monospace", fontSize: 10, fontWeight: 700 }}>{drc.summary.warn}</span>
+          </span>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2 }}>
+            <span style={{ width: 6, height: 6, background: C.fail, display: 'inline-block' }} />
+            <span style={{ color: C.fail, fontFamily: "'Courier New', monospace", fontSize: 10, fontWeight: 700 }}>{drc.summary.fail}</span>
+          </span>
+        </span>
       </div>
 
       {/* ── Tab Bar ── */}
@@ -381,10 +402,18 @@ export default function WiringPlan() {
         <div style={{ position: 'absolute', inset: 0, display: activeTab === 'data' ? 'block' : 'none' }}>
           <DataView {...viewProps} overlay={overlay} />
         </div>
-        <div style={{ position: 'absolute', inset: 0, display: activeTab === 'topology' ? 'flex' : 'none', alignItems: 'center', justifyContent: 'center' }}>
-          <span style={{ color: C.muted, fontFamily: "'Courier New', monospace", fontSize: 11 }}>
-            TOPOLOGY VIEW — COMING SOON
-          </span>
+        <div style={{ position: 'absolute', inset: 0, display: activeTab === 'topology' ? 'block' : 'none' }}>
+          <TopologyView
+            devices={overlay.devices}
+            wires={overlay.result.wires}
+            result={overlay.result}
+            selectedDeviceId={selectedDeviceId}
+            selectedDeviceIds={selectedDeviceIds}
+            selectedWireId={selectedWireId}
+            onDeviceClick={(id, e) => handleDeviceClick(id, e.shiftKey)}
+            onWireClick={handleWireClick}
+            drcMap={drc.drcMap}
+          />
         </div>
 
         {/* ── Detail Panel (slides in from right) ── */}


### PR DESCRIPTION
## Summary

Complete UI rebuild of the wiring harness workspace, replacing the old 2-panel layout (reference images + device table) with a modern 5-tab system. All compute engine files are kept untouched.

**New architecture:**
- **WiringPlan.tsx** — Parent page with 5-tab system, shared selection state (`selectedDeviceId`, `selectedDeviceIds`, `selectedWireId`), keyboard shortcuts (1-5 tabs, F=fit, Esc=deselect, Cmd+K=search, Tab=cycle devices)
- **DeviceDetailPanel.tsx** — THE single detail panel used by ALL views. Slides in from right (320px). Shows: product photo, procurement status (price, purchased, parts_reception, work_order_parts), electrical specs (pin count, amps, PDM channel/load), all wires with gauge/color/length/voltage drop, pin map from device_pin_maps, related devices with system total cost
- **FormboardView.tsx** — Canvas 2D, 200×96" pegboard. Figma-like camera: scroll-to-zoom centered on cursor with lerp interpolation, space+drag pan, trackpad pinch, double-click zoom-to-fit. 5 LOD levels from colored dots to full pin numbers with voltage drop values
- **SchematicView.tsx** — SVG schematics with 5 sub-sheets (Power Distribution, Engine Management, Lighting, Body Electronics, Audio). Left-to-right signal flow layout, Manhattan wire routing with jog offsets, dark/light toggle
- **HarnessView3D.tsx** — Three.js / React Three Fiber. Transparent K5 Blazer shell (184.8"×79.6"×73"), colored zone volumes, harness trunks as 3D tubes from harnessRouting.ts graph, OrbitControls
- **DataView.tsx** — HTML device table with column sorting, text filtering, zone filter chips. Sub-tabs: DEVICES | BOM | CUT LIST with text export buttons
- **CommandPalette.tsx** — Cmd+K overlay with fuzzy search across devices, wires, zones, and navigation actions. Keyboard navigable (arrows, enter, escape)

**Design system:** `#1a1a2e` dark background, zero border-radius, zero shadows, zero gradients, 2px solid borders, `#00ddff` selection/highlight, Arial 8-9px ALL CAPS bold labels, Courier New data values

**Files kept untouched:** overlayCompute.ts, harnessRouting.ts, terminationCompute.ts, harnessConstants.ts, useOverlayCompute.ts, useComponentLibrary.ts, ConnectorFaceView.tsx, generateBOM.ts, generateCutList.ts, and 10 other compute/utility files

## Test plan

- [ ] Navigate to wiring page — verify 5-tab system renders with status bar showing device/wire/cost counts
- [ ] FORMBOARD: scroll to zoom (should center on cursor), space+drag to pan, double-click a device to zoom-to-fit, verify 5 LOD levels as zoom changes
- [ ] Click any device — DeviceDetailPanel slides in from right showing product photo, price, procurement status, electrical specs, wiring connections, pin map
- [ ] SCHEMATICS: switch between 5 sub-sheets, verify left-to-right signal flow layout, click wires for net highlight
- [ ] 3D: verify transparent K5 shell renders, orbit/zoom/pan with OrbitControls, click connectors
- [ ] DATA: sort columns, filter by text, use zone chips, switch to BOM and CUT LIST sub-tabs, test export buttons
- [ ] Keyboard shortcuts: 1-5 switch tabs, F=fit, Esc=deselect/close, Cmd+K=search, Tab/Shift+Tab=cycle
- [ ] Command palette: Cmd+K opens, type to fuzzy search, arrow keys navigate, Enter selects
- [ ] TypeScript compiles without errors (`npx tsc --noEmit` exits 0)
- [ ] All KEEP files are untouched (compute engine, utilities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command palette for quick search and navigation of devices, wires, and actions
  * Added four interactive visualization modes: Formboard canvas, Schematics diagram, 3D harness view, and Topology graph
  * Added device detail panel displaying specifications, wiring, procurement status, and related information
  * Added data view with DEVICES, BOM, and CUT LIST tabs including export functionality
  * Added design rule checking to validate device configuration, wiring integrity, and sourcing status
  * Added keyboard shortcuts for tab switching, command palette, and viewport controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->