### PR TITLE
Mustang dogfood close-out: mcp-remote bridge + screenshot script

### DIFF
--- a/docs/api/CLAUDE_DESKTOP_SETUP.md
+++ b/docs/api/CLAUDE_DESKTOP_SETUP.md
@@ -17,13 +17,17 @@ Open `~/Library/Application Support/Claude/claude_desktop_config.json`. If it do
       "command": "npx",
       "args": [
         "-y",
-        "@modelcontextprotocol/server-fetch",
-        "https://nuke.ag/mcp"
+        "mcp-remote",
+        "https://nuke.ag/mcp",
+        "--header",
+        "X-API-Key:nk_live_..."
       ]
     }
   }
 }
 ```
+
+`mcp-remote` is the de facto bridge for HTTP MCPs. It speaks stdio to Claude Desktop and HTTP to the remote endpoint. The `--header` arg attaches your API key to every request, so authenticated tools like `submit_vehicle_event` work.
 
 If you already have other MCP servers configured (Linear, Postgres, etc.), keep them — just add the `nuke` key alongside them.
 
@@ -41,25 +45,17 @@ Tools that write (`submit_vehicle_event`, `submit_observation`, `submit_attribut
 
 ## Where the key goes
 
-Two options.
+`mcp-remote` accepts headers via `--header` args. Pass your key:
 
-### Option A — Header in the MCP server config
-
-If your MCP server config supports custom headers (some forks of `server-fetch` do), add the key as `X-API-Key`. Specifics vary by adapter; check your installed `server-fetch` docs.
-
-### Option B — Env var, picked up by the connector
-
-If your MCP fork doesn't pass headers, you can set `NUKE_API_KEY` in your shell environment. The MCP server reads it at startup. Restart Claude Desktop after exporting.
-
-```bash
-export NUKE_API_KEY=nk_live_…
+```
+"args": ["-y", "mcp-remote", "https://nuke.ag/mcp", "--header", "X-API-Key:nk_live_..."]
 ```
 
-(Persist by adding to your `~/.zshrc`.)
+(No space after the colon — `mcp-remote` parses `Name:Value`.)
 
-### Option C — Service role (you only)
+### Service role (you only)
 
-For your own dogfooding only — never share — you can skip the API key entirely if your MCP server passes a `Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY`. Service-role auth bypasses scope checks. **Don't use this for any external integration**, only for local debugging on your own machine.
+For your own dogfooding only — never share — you can swap `X-API-Key:...` for `Authorization:Bearer $SUPABASE_SERVICE_ROLE_KEY`. Service-role auth bypasses scope checks. **Don't use this for any external integration**, only for local debugging on your own machine.
 
 ## Tonight's session — replay it
 

--- a/scripts/screenshot-mustang.mjs
+++ b/scripts/screenshot-mustang.mjs
@@ -1,0 +1,53 @@
+import { chromium } from 'playwright';
+
+const URL = 'https://nuke.ag/vehicle/83f6f033-a3c3-4cf4-a85e-a60d2c588838';
+const OUT = '/Users/skylar/Downloads/mustang-timeline-2026-05-03.png';
+const TIMELINE_OUT = '/Users/skylar/Downloads/mustang-timeline-only-2026-05-03.png';
+
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext({
+  viewport: { width: 1440, height: 1800 },
+  deviceScaleFactor: 2,
+});
+const page = await ctx.newPage();
+
+console.log('navigating:', URL);
+await page.goto(URL, { waitUntil: 'networkidle', timeout: 60000 });
+
+// Wait for page chrome
+await page.waitForTimeout(2000);
+
+// Try several render markers — any one means timeline likely rendered
+const markers = ['WORK RECORD', 'Mustang', '6F07C219593', '1966'];
+let foundMarker = null;
+for (const m of markers) {
+  try {
+    await page.waitForSelector(`text=${m}`, { timeout: 3000 });
+    foundMarker = m;
+    break;
+  } catch {}
+}
+console.log('marker found:', foundMarker || '(none)');
+
+// Scroll down to trigger any lazy rendering, then back to top for screenshot
+await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+await page.waitForTimeout(1500);
+await page.evaluate(() => window.scrollTo(0, 0));
+await page.waitForTimeout(1000);
+
+await page.screenshot({ path: OUT, fullPage: true });
+console.log('full-page screenshot:', OUT);
+
+const wr = await page.locator('text=WORK RECORD').first();
+if (await wr.count() > 0) {
+  const card = wr.locator('xpath=ancestor::*[contains(@class,"timeline") or contains(@id,"timeline") or contains(@class,"observation")][1]');
+  if (await card.count() > 0) {
+    await card.first().screenshot({ path: TIMELINE_OUT });
+    console.log('timeline-only screenshot:', TIMELINE_OUT);
+  }
+}
+
+console.log('current URL:', page.url());
+console.log('title:', await page.title());
+
+await browser.close();


### PR DESCRIPTION
## Summary
- Corrects `CLAUDE_DESKTOP_SETUP.md` — the bridge for remote HTTP MCPs is `mcp-remote`, not `@modelcontextprotocol/server-fetch` (server-fetch is for the *fetch* tool, not bridging)
- Adds `scripts/screenshot-mustang.mjs` (playwright headless capture for the public vehicle profile page)

## Test plan
- [x] Local config at `~/Library/Application Support/Claude/claude_desktop_config.json` written using these args; key matches issued Mustang-scoped key
- [x] `node scripts/screenshot-mustang.mjs` produces a 1966 Ford Mustang profile screenshot at /Users/skylar/Downloads/mustang-timeline-2026-05-03.png
- [ ] **Known gap (separate ticket):** work_record events written via `/v1/events` don't appear on the public vehicle profile page yet — they're in `vehicle_observations` and reachable via `GET /v1/events`, but the profile timeline component doesn't surface this `kind`. Investigate next session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)