### PR TITLE
WS-5: surface owner-trust observations on vehicle profile timeline

### DIFF
--- a/nuke_frontend/src/pages/vehicle-profile/ObservationTimeline.tsx
+++ b/nuke_frontend/src/pages/vehicle-profile/ObservationTimeline.tsx
@@ -255,27 +255,39 @@ const ObservationTimeline: React.FC = () => {
     });
   }, [observations]);
 
+  // Pin owner-trust observations (shop, agent-submission, owner-input) to top regardless of date.
+  // Within each tier, fall back to observed_at desc.
+  const sortedObservations = useMemo(() => {
+    const OWNER_TRUST_SOURCES = new Set(['shop', 'agent-submission', 'owner-input']);
+    const ownerTrustOrder = (obs: Observation) => OWNER_TRUST_SOURCES.has(obs.source_slug ?? '') ? 0 : 1;
+    return [...cleanObservations].sort((a, b) => {
+      const trustDelta = ownerTrustOrder(a) - ownerTrustOrder(b);
+      if (trustDelta !== 0) return trustDelta;
+      return new Date(b.observed_at ?? 0).getTime() - new Date(a.observed_at ?? 0).getTime();
+    });
+  }, [cleanObservations]);
+
   // Kind counts for filter badges
   const kindCounts = useMemo(() => {
     const counts: Record<string, number> = {};
-    for (const obs of cleanObservations) {
+    for (const obs of sortedObservations) {
       counts[obs.kind] = (counts[obs.kind] || 0) + 1;
     }
     return counts;
-  }, [cleanObservations]);
+  }, [sortedObservations]);
 
   // Filtered observations
   const filtered = useMemo(() => {
-    if (!activeFilter) return cleanObservations;
-    return cleanObservations.filter(o => o.kind === activeFilter);
-  }, [cleanObservations, activeFilter]);
+    if (!activeFilter) return sortedObservations;
+    return sortedObservations.filter(o => o.kind === activeFilter);
+  }, [sortedObservations, activeFilter]);
 
   const displayed = showAll ? filtered : filtered.slice(0, 25);
 
   if (!vehicle) return null;
 
   // If all observations are errors (or no observations), return null — don't render the widget
-  if (!loading && cleanObservations.length === 0) return null;
+  if (!loading && sortedObservations.length === 0) return null;
 
   return (
     <div style={{
@@ -307,7 +319,7 @@ const ObservationTimeline: React.FC = () => {
           color: 'var(--text-secondary)',
           letterSpacing: '0.06em',
         }}>
-          {cleanObservations.length} TOTAL
+          {sortedObservations.length} TOTAL
         </span>
       </div>
 
@@ -336,7 +348,7 @@ const ObservationTimeline: React.FC = () => {
               cursor: 'pointer',
             }}
           >
-            ALL {cleanObservations.length}
+            ALL {sortedObservations.length}
           </button>
           {ALL_KINDS.filter(k => kindCounts[k]).map(kind => {
             const kc = getKindConfig(kind);

--- a/nuke_frontend/src/pages/vehicle-profile/WorkspaceContent.tsx
+++ b/nuke_frontend/src/pages/vehicle-profile/WorkspaceContent.tsx
@@ -264,7 +264,7 @@ const WorkspaceContent: React.FC<WorkspaceContentProps> = ({
 
           {/* Observation History — all observations for this vehicle, chronological */}
           {observationCount > 0 && (
-            <CollapsibleWidget variant="profile" title="Observation History" defaultCollapsed={true}>
+            <CollapsibleWidget variant="profile" title="Observation History" defaultCollapsed={observationCount > 50}>
               <React.Suspense fallback={null}>
                 <ObservationTimeline />
               </React.Suspense>


### PR DESCRIPTION
## Summary
- `WorkspaceContent.tsx`: Observation History widget `defaultCollapsed` becomes dynamic. Vehicles with <=50 observations render the timeline expanded; auction-heavy vehicles (>50) stay collapsed by default.
- `ObservationTimeline.tsx`: pin owner-trust observations (`shop`, `agent-submission`, `owner-input` source slugs) to the top of the timeline regardless of `observed_at`. Within each tier, `observed_at desc` is preserved.

## Why
Tonight's `/v1/events` writes landed `work_record` rows in the DB but the public profile page hid them inside a default-collapsed widget. Skylar couldn't see what got written. Per `nuke_frontend/.../frontend.md` "convergence point" rule, we feed the data into the existing timeline structure instead of building a parallel display.

## Acceptance
- Mustang (`83f6f033-...`, 363 observations): still default-collapsed (>50)
- K5 (`93119305-...`, 25 observations): default-expanded (<=50)
- After WS-1 photo backfill grows K5 past 50, owner-trust rows still pin to top
- Surgical edit — two files only, no new components, no CSS changes

## Test plan
- [x] `npm run build` exits 0 (10.5s, 1 pre-existing chunk-size warning)
- [x] `npx tsc --noEmit` zero new errors
- [ ] Visual: open K5 profile, confirm timeline expanded with WORK RECORD rows at top
- [ ] Visual: open Mustang profile, confirm widget still collapsed by default

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Prioritized observations from shop, agent submissions, and owner input are now pinned to the top of the Observation Timeline, followed by other sources sorted chronologically.
  * The Observation History section intelligently defaults to expanded view for vehicles with 50+ observations, improving data accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->