### PR TITLE
WS-10: form-shape framing in library (encyclopedia + dictionary + contemplation)

### DIFF
--- a/docs/library/intellectual/contemplations/the-form-is-the-thing.md
+++ b/docs/library/intellectual/contemplations/the-form-is-the-thing.md
@@ -1,0 +1,84 @@
+# The Form Is the Thing
+
+> "It's not just mobile but I should be able to access through Claude on my phone and Claude will submit it for me with its interpretation of what it's seeing and then it's gonna fill in the form shape that we require."
+> — Skylar, 2026-05-02 (the night the moat became visible)
+
+---
+
+The session started in the wrong place. We were arguing about OAuth. Token endpoints, magic-link redirects, fragment-only callbacks, the two open Anthropic client bugs. Hours of it. We were building plumbing as if plumbing were the product.
+
+Then Skylar pulled the cord.
+
+> "We need it to work perfectly for one user and then we will define… the ingestion process, then we start practicing scale."
+
+The form is the thing. Everything else is plumbing to deliver Claude to it.
+
+---
+
+## What the system does, plainly
+
+A vehicle is an immutable entity. Testimony attaches to it from many sources at many times. The library calls this the provenance engine. The truth is that nobody knows the truth — the system stores claims, weighted by source, decayed by time, and lets convergence approximate it.
+
+For five years that testimony came from auctions, comments, listings — sources that already had structure. We scraped HTML and pulled fields. The shape was given to us by the source.
+
+Now the source is a person standing in a garage with a phone and a vision agent. There is no HTML. There is a photo and a sentence. The shape has to come from somewhere else.
+
+It comes from the form.
+
+---
+
+## What a form-shape is
+
+The form-shape is the contract Claude reads before it writes. It is per-event-type — `service`, `inspection`, `modification`, `note`, `condition_assessment`. For each one, we publish a JSON Schema with required and optional fields, enums where the answer is bounded, length limits where it isn't. And alongside the schema, we publish a checklist: for every field, an annotation telling Claude where the answer comes from.
+
+- **vision-fillable** — Claude can populate this from the photo alone. Engine bay zone? Look at the photo. Severity of a leak? Look at the photo.
+- **context-fillable** — Claude can populate this from what the user just said. Labor minutes. Shop name. Why we did the work.
+- **tool-fillable** — Claude has to call another tool. VIN lookup. Recent service history. Resolving a vehicle reference.
+
+That triplet is the moat. Without it, a vision agent is just a verbose camera. With it, the agent has a checklist, and the output is structured testimony that lands on the timeline with attribution.
+
+---
+
+## Why a permissive schema isn't enough
+
+I built loose schemas first. `additionalProperties: true`, optional everything, just-give-me-something. The thinking: agents are smart, the system will figure it out, structure can come later.
+
+That was wrong. Vision agents without a form will hallucinate structure. They will invent fields. They will write `paint_condition: "lovely"` in one submission and `exterior_paint: "nice"` in the next. The data lands, but it doesn't compose. Two months later you can't query it. Six months later you've lost the testimony — it's there in the JSONB but it's noise.
+
+A vision agent with a form has a checklist. It fills the fields. The fields are the same on every submission. The data composes. The timeline renders. The vehicle profile gets denser, not noisier.
+
+> "Get the depth and then fix it."
+
+The form is the depth. The depth is the form.
+
+---
+
+## The library's load-bearing axiom, enforced
+
+The library has said for a long time that this is a provenance engine for testimony. Vehicles are the immutable entities. Observations are the testimony. Sources have trust. Time has decay. Convergence is the approach to truth. That is in the encyclopedia, the contemplations, the rules. It has always been there.
+
+But until tonight, the testimony was shaped by the source. A BaT listing has its own structure. A Mecum extraction has its own structure. A receipt has its own structure. The observation table accepted whatever the source produced, and the system did its best to compose it.
+
+When the source becomes Claude reading a photo, there is no native structure. The form-shape becomes the source of structure. It is not metadata about the testimony — it IS the testimony's shape. Without it, Claude's interpretations are narrative. With it, they are atoms.
+
+The form-shape is the enforcer of the testimony axiom in the agent era.
+
+---
+
+## Two surfaces, one form
+
+REST and MCP are two ways to deliver Claude to the form. They consume the same JSON Schemas. They return the same checklist. The auth differs (X-API-Key on REST, OAuth on MCP for claude.ai compatibility), but the contract is identical: read the checklist, fill the form, submit.
+
+The point is that there is one form. Whatever transport, whatever client, whatever auth — the agent fills the same fields and the testimony lands the same way. That's why the form is the moat: it is the single thing every agent has to agree to. Everything else can vary.
+
+---
+
+## What this means for the work
+
+Every new event type that gets added is a new form. The work is not "add an endpoint." The work is "design the form": what does Claude need to fill, and where does each field come from? When the form is right, the endpoint is trivial. When the form is wrong, no amount of API polish makes the testimony composable.
+
+OAuth, scopes, rate limits, telemetry — that is plumbing. Document it, ship it, monitor it, but do not lead with it. Lead with the form.
+
+> "It's gonna fill in the form shape that we require."
+
+The form is the thing. The form is the thing. The form is the thing.

--- a/docs/library/reference/dictionary/condition_assessment.md
+++ b/docs/library/reference/dictionary/condition_assessment.md
@@ -1,0 +1,13 @@
+# condition_assessment
+
+**Type:** `event_type` value (External Agent Write API v1)
+**Routes to:** `vehicle_observations.kind = 'condition'`, `source_slug = 'agent-submission'`
+**Schema:** `docs/api/schemas/v1/condition_assessment.json` (v1.1)
+
+A `condition_assessment` event is a rolled-up state report on a vehicle at a moment in time. Distinct from `inspection` because it is a synthesis, not a fresh examination — the agent is composing a current-state summary from prior testimony, photos, owner input, and recent service history rather than walking around the car with a clipboard.
+
+Form-shape includes: `summary`, `narrative`, `as_of_date`, per-system condition ratings (`engine`, `transmission`, `suspension`, `brakes`, `body`, `interior`, `electrical` — each rated `excellent`/`good`/`fair`/`rough`/`project`/`parts_only`), `overall_condition`, `confidence_basis` (how the agent reached this assessment — `photo_audit`/`recent_inspection`/`owner_input`/`shop_records`/`composite`), `known_flaws[]`, `deferred_maintenance_minutes`.
+
+The half-life of a condition assessment is shorter than an inspection's because synthesis decays faster than direct observation. The next service event, the next photo, the next sale changes the assessment. The system treats condition assessments as snapshots — they appear on the timeline at their `as_of_date` and are superseded by newer assessments via the supersession chain rather than overwriting.
+
+See also: `inspection`, `condition`, `form-shape`, contemplation `testimony-and-half-lives.md`.

--- a/docs/library/reference/dictionary/form-shape.md
+++ b/docs/library/reference/dictionary/form-shape.md
@@ -1,0 +1,16 @@
+# form-shape
+
+**Type:** architectural concept
+**Canonical doc:** `docs/library/intellectual/contemplations/the-form-is-the-thing.md`
+**Schemas:** `docs/api/schemas/v1/`
+**Encyclopedia ref:** Chapter 2 (per-kind structured_data shape), Chapter 7 (External Agent Write API).
+
+A form-shape is the contract Claude reads before it writes. Per event type — `service`, `inspection`, `modification`, `note`, `condition_assessment` — the system publishes a JSON Schema (Draft 2020-12) and a per-field checklist. Together they define what the event IS: which fields are required, which are optional, which enums are bounded, which lengths are capped, and where each field's answer comes from (vision, context, tool).
+
+The form-shape is the moat. NUKE is a provenance engine for testimony; vehicles are the immutable entities, observations are the testimony. For five years, observation structure was inherited from the source — a BaT listing has its own fields, a Mecum extraction has its own fields. When the source becomes a vision agent reading a photo, there is no native structure. The form-shape becomes the structure.
+
+A vision agent without a form will hallucinate fields. A vision agent with a form has a checklist and produces composable testimony. The form is enforced both at submission (JSON Schema validates) and at suggestion-time (`get_event_checklist` MCP tool returns per-field guidance). REST and MCP consume the same form-shape; the transport varies, the form does not.
+
+> "The form is the thing. Everything else is plumbing to deliver Claude to it."
+
+See also: `service`, `inspection`, `modification`, `note`, `condition_assessment`, `vision-fillable`.

--- a/docs/library/reference/dictionary/inspection.md
+++ b/docs/library/reference/dictionary/inspection.md
@@ -1,0 +1,15 @@
+# inspection
+
+**Type:** `event_type` value (External Agent Write API v1)
+**Routes to:** `vehicle_observations.kind = 'condition'`, `source_slug = 'agent-submission'`
+**Schema:** `docs/api/schemas/v1/inspection.json` (closed schema — `additionalProperties: false`)
+
+An `inspection` event records a deliberate examination of a vehicle: a pre-purchase inspection, a walk-around, a photo audit, a post-work QC pass, an annual check. Distinct from `service` because no work was performed — only observation.
+
+Required: `summary` and at least one `findings[]` entry. Each finding carries a `system` enum (engine_bay, top_end, bottom_end, undercarriage, interior, wheels, drivetrain, cooling, electrical, fuel, ignition, suspension, brakes, body, other), a `finding` text, a `severity` (`info`/`monitor`/`concern`/`critical`), and an optional `evidence_photo_ref`. Optional rollups: `inspection_type` (pre_purchase, walk_around, photo_audit, post_work_qc, annual_check, incident_report), `inspector_role` (agent_vision, owner_self, shop, third_party_expert), `zones_inspected[]`, `overall_condition` (excellent/good/fair/rough/project/parts_only), `deferred_maintenance_minutes`.
+
+The closed schema is intentional: inspections are checklists. Unknown fields are rejected so that future versions stay explicit. The agent fills the form; it does not redesign it.
+
+A `vision_condition_v1` extraction running over a single photo is one common path to an inspection event — Claude reads the photo, fills the checklist, submits.
+
+See also: `service`, `condition_assessment`, `form-shape`, `vision-fillable`.

--- a/docs/library/reference/dictionary/modification.md
+++ b/docs/library/reference/dictionary/modification.md
@@ -1,0 +1,13 @@
+# modification
+
+**Type:** `event_type` value (External Agent Write API v1)
+**Routes to:** `vehicle_observations.kind = 'work_record'`, `source_slug = 'agent-submission'`
+**Schema:** `docs/api/schemas/v1/modification.json` (v1.1; reuses `service.json` shape with `modification_type` added)
+
+A `modification` event is a deviation from factory specification: an LS swap, a coilover install, a custom paint job, a wheel-and-tire upgrade. Distinct from `service` because the intent is to change what the vehicle IS, not to maintain what it already was.
+
+Modifications are testimony with long half-life — once a vehicle has been modified, that fact persists across all future observations. A condition assessment of a modified vehicle is meaningless without knowing the modification baseline. A future buyer's PPI must reckon with the modification chain. The system stores modifications as `work_record` so they appear on the timeline alongside service, but the `modification_type` field flags them for downstream filters: "show me only stock vehicles", "show me LS-swapped K5s", "show me cars with paint older than the original color".
+
+Form-shape inherits from `service`: `summary`, `narrative`, `zones_touched`, `parts[]`, `decisions[]`, `labor_minutes`, plus `modification_type` and `reverts_to_stock` (boolean — was this an undo of a prior modification?).
+
+See also: `service`, `form-shape`.

--- a/docs/library/reference/dictionary/note.md
+++ b/docs/library/reference/dictionary/note.md
@@ -1,0 +1,13 @@
+# note
+
+**Type:** `event_type` value (External Agent Write API v1)
+**Routes to:** `vehicle_observations.kind = 'comment'`, `source_slug = 'agent-submission'`
+**Schema:** `docs/api/schemas/v1/note.json`
+
+A `note` event is the escape hatch. When an agent has something to say about a vehicle that doesn't fit `service` (no wrench was turned), `inspection` (no examination was performed), `modification` (nothing was changed), or `condition_assessment` (no rollup was rendered), it submits a `note`.
+
+Form-shape is minimal: required `summary` (1–280 chars, headline-shaped) and optional `narrative` (≤32K, long-form body). No required structure beyond that. The note lands as a `comment` observation on the vehicle timeline with full agent attribution.
+
+Notes carry lower implicit trust than the structured event types because they cannot be cross-referenced field-by-field. They are preserved testimony, not composable testimony. Use them when you have something true to say but no shape exists for it; if you find yourself submitting many notes of the same shape, that shape needs to become a real event type with its own JSON Schema.
+
+See also: `service`, `inspection`, `form-shape`.

--- a/docs/library/reference/dictionary/service.md
+++ b/docs/library/reference/dictionary/service.md
@@ -1,0 +1,15 @@
+# service
+
+**Type:** `event_type` value (External Agent Write API v1)
+**Routes to:** `vehicle_observations.kind = 'work_record'`, `source_slug = 'shop'`
+**Schema:** `docs/api/schemas/v1/service.json`
+
+A `service` event is a wrench-time session — work performed on a specific vehicle on a specific day. It is the canonical event type for owner-trust testimony about what was done to a car: parts removed, parts installed, conditions discovered, decisions made, time spent.
+
+The form-shape is intentionally rich. Required: a `summary` headline. Optional but encouraged: `narrative` (long-form), `zones_touched` (engine_bay, drivetrain, etc.), `work_performed[]`, `work_planned[]`, `parts[]` with status (`needed`/`ordered`/`installed`/`considered_rejected`), `decisions[]` with question and outcome, `condition_observations[]` with severity (`info`/`monitor`/`concern`/`critical`), `labor_minutes`, `shop_ref`.
+
+A service event with `condition_observations` is testimony plus inspection — the agent records what it touched AND what it noticed while touching. Those condition findings appear on the timeline as separate atoms attributed to the same session.
+
+A service event submitted by an authenticated owner or shop carries source slug `shop` (high trust). Submitted via REST `POST /v1/events` or MCP `submit_vehicle_event`. Both surfaces consume the same JSON Schema.
+
+See also: `modification`, `inspection`, `form-shape`.

--- a/docs/library/reference/dictionary/vision-fillable.md
+++ b/docs/library/reference/dictionary/vision-fillable.md
@@ -1,0 +1,20 @@
+# vision-fillable
+
+**Type:** field annotation in the `get_event_checklist` MCP contract
+**Canonical doc:** `docs/library/reference/encyclopedia/02-observation-model.md#per-kind-structured_data-shape`
+
+`vision_fillable: true` marks a field that an agent can populate from a single photo (or a small set of photos) without needing additional context, tool calls, or user input. The annotation is one-third of the form-shape's Claude-actionable triplet: `vision_fillable`, `context_fillable`, `tool_fillable`. A field can carry multiple flags — `narrative` is both vision-fillable and context-fillable.
+
+Examples of vision-fillable fields:
+- `zones_touched` / `zones_inspected` — the photo shows engine bay, undercarriage, etc.
+- `condition_observations[].severity` — visual assessment of leak severity, rust extent, panel damage.
+- `findings[].system` — which subsystem the photo depicts.
+- `parts[].name` — Claude can identify a visible part.
+- `caption` on a media reference — describe what is visible.
+- `overall_condition` — coarse rollup the agent can render from a walk-around.
+
+Examples of fields that are NOT vision-fillable: `labor_minutes` (must come from user context), `shop_ref` (context), `vin` (must come from a tool lookup or user input), `correction_of` (must come from a history query).
+
+Annotations are guidance, not gates. The JSON Schema validates the result regardless of how the agent populated it; the checklist tells the agent the cheapest path to a valid submission.
+
+See also: `form-shape`, `service`, `inspection`.

--- a/docs/library/reference/encyclopedia/02-observation-model.md
+++ b/docs/library/reference/encyclopedia/02-observation-model.md
@@ -1022,3 +1022,148 @@ The observation model transforms the platform from a vehicle listing database in
 The write layer (Tetris + observationWriter) ensures that truth materialization is safe: gap-fills never regress, conflicts are quarantined, and every write is auditable. The batch ingest pipeline scales observation intake to hundreds per request. The retroactive adoption pattern allows extractors to join the observation system incrementally without breaking their existing functionality.
 
 At 5.7 million observations across 449,747 vehicles from 160 sources, the observation model is the largest vehicle evidence database in the collector car space. Its value compounds: each new observation makes existing observations more valuable through corroboration, contradiction detection, and temporal sequencing.
+
+---
+
+## Per-Kind structured_data Shape
+
+For five years, the shape of `structured_data` was inherited from the source — a BaT listing has its own fields, an auction comment has its own fields, a sale result has its own fields. Each extractor decided what to put in the JSONB column.
+
+That changes when the source is an agent reading a photo. Vision agents without a published form will hallucinate structure — `paint_condition` on one submission, `exterior_paint` on the next, neither composable. The form-shape is the contract that turns Claude's natural-language interpretation into structured testimony.
+
+Each `kind` now has a canonical shape, published as a JSON Schema at `docs/api/schemas/v1/` and consumed by both the REST surface (`POST /v1/events`) and the MCP surface (`submit_vehicle_event`). The schema is enforced at submission time. A second contract — the **event checklist** returned by the `get_event_checklist` MCP tool — is enforced at suggestion time, telling Claude where each field's answer comes from.
+
+> See `docs/library/intellectual/contemplations/the-form-is-the-thing.md` for why this matters.
+
+### The Three Annotations
+
+Every field in every form-shape carries a triplet that tells the agent how to fill it:
+
+| Annotation | Meaning | Example field |
+|---|---|---|
+| `vision_fillable` | Agent can populate from a photo alone. | `zones_touched`, `condition_observations[].severity`, `body.paint_condition` |
+| `context_fillable` | Agent can populate from what the user just said. | `labor_minutes`, `shop_ref`, `narrative` |
+| `tool_fillable` | Agent must call another tool to populate. | `vehicle_ref.vin` (lookup), `correction_of` (history query) |
+
+A field can carry multiple annotations. `narrative` is both vision_fillable (describe what you see) and context_fillable (echo what the user said). The annotations are guidance, not gates — the schema validates the result, not the path.
+
+### Per-Kind Canonical Fields
+
+#### `work_record` — service, modification
+
+Routes from `event_type` `service` (a wrench-time session) and `modification` (an aftermarket change). Source slug `shop` for owner-trust submissions.
+
+| Field | Type | Vision | Context | Tool | Notes |
+|---|---|---|---|---|---|
+| `summary` | string (1–500) | yes | yes | — | Required. 1–2 sentence headline. |
+| `narrative` | string (≤32K) | yes | yes | — | Long-form description. |
+| `zones_touched` | enum array | yes | yes | — | `engine_bay`, `undercarriage`, `interior`, `wheels`, `drivetrain`, `cooling`, `electrical`, `fuel`, `ignition`, `suspension`, `brakes`, `body`, `other`. |
+| `work_performed` | string array | — | yes | — | Discrete actions completed. |
+| `work_planned` | string array | — | yes | — | Actions queued for next session. |
+| `parts[]` | object array | yes | yes | yes | `name`, `manufacturer`, `part_number`, `quantity`, `status` (`needed`/`ordered`/`installed`/`considered_rejected`). |
+| `decisions[]` | object array | — | yes | — | `question`, `outcome`, `reasoning`. |
+| `condition_observations[]` | object array | yes | yes | — | `system` enum, `finding`, `severity` (`info`/`monitor`/`concern`/`critical`). |
+| `labor_minutes` | number | — | yes | — | Wrench time. |
+| `shop_ref` | string | — | yes | — | "NUKE LTD bay 2", "home garage". |
+
+Schema: `docs/api/schemas/v1/service.json`. Modification reuses the service shape with `modification_type` added.
+
+#### `condition` — inspection, condition_assessment
+
+Routes from `event_type` `inspection` (deliberate examination — PPI, walk-around, photo audit) and `condition_assessment` (rolled-up state report). Source slug `agent-submission`. **Closed schema** — `additionalProperties: false` because inspections are checklists.
+
+| Field | Type | Vision | Context | Tool | Notes |
+|---|---|---|---|---|---|
+| `summary` | string (1–500) | yes | yes | — | Required. |
+| `inspection_type` | enum | — | yes | — | `pre_purchase`, `walk_around`, `photo_audit`, `post_work_qc`, `annual_check`, `incident_report`, `other`. |
+| `inspector_role` | enum | — | yes | — | `agent_vision`, `owner_self`, `shop`, `third_party_expert`. |
+| `zones_inspected` | enum array | yes | yes | — | Closed enum aligned with `zones_touched`. |
+| `findings[]` | object array | yes | yes | — | Required, ≥1. Each finding: `system` enum, `finding`, `severity` enum, optional `evidence_photo_ref`. |
+| `overall_condition` | enum | yes | yes | — | `excellent`/`good`/`fair`/`rough`/`project`/`parts_only`. |
+| `deferred_maintenance_minutes` | number | yes | yes | — | Estimated wrench-time backlog. |
+| `photos_referenced` | string array | — | yes | — | Caller-side photo identifiers. |
+
+Schema: `docs/api/schemas/v1/inspection.json`. The closed schema is intentional — checklists do not accept "additional properties" because the checklist IS the contract.
+
+#### `media` — photo, video, document attachment
+
+Not yet a top-level `event_type` in v1; media flows through the envelope's `media[]` array. The substrate shape on `vehicle_observations` for media:
+
+| Field | Type | Vision | Context | Tool | Notes |
+|---|---|---|---|---|---|
+| `media_type` | enum | — | yes | — | `image`, `video`, `audio`, `document`. |
+| `url` | URI | — | yes | — | Publicly addressable resource. |
+| `sha256` | hex string | — | — | yes | Lowercase hex SHA-256, integrity check. |
+| `caption` | string (≤1024) | yes | yes | — | What the agent sees. |
+| `zones_visible` | enum array | yes | — | — | Same enum as `zones_inspected`. |
+
+When v1.1 routes `event_type=media`, the schema lands at `docs/api/schemas/v1/media.json`.
+
+#### `comment` — note
+
+Routes from `event_type` `note`. Source slug `agent-submission`. Minimal by design — notes are the escape hatch when nothing more structured fits.
+
+| Field | Type | Vision | Context | Tool | Notes |
+|---|---|---|---|---|---|
+| `summary` | string (1–280) | yes | yes | — | Required. Short headline. |
+| `narrative` | string (≤32K) | yes | yes | — | Optional longer body. |
+
+Schema: `docs/api/schemas/v1/note.json`.
+
+#### `expense` — receipt, parts purchase
+
+Not yet a top-level `event_type` in v1 (deferred to receipt-bridge work). The substrate shape on `vehicle_observations` for expense:
+
+| Field | Type | Vision | Context | Tool | Notes |
+|---|---|---|---|---|---|
+| `merchant` | string | yes | yes | — | Vendor name (Summit Racing, NAPA, etc.). |
+| `total` | number | yes | yes | — | Total amount, currency assumed USD. |
+| `currency` | ISO-4217 | — | yes | — | Default USD. |
+| `purchased_at` | date-time | yes | yes | — | When the transaction happened. |
+| `line_items[]` | object array | yes | yes | — | `name`, `quantity`, `unit_price`, `total`. |
+| `parts_referenced[]` | string array | yes | yes | — | Parts mentioned, normalized for join with `parts_catalog`. |
+| `payment_method` | enum | yes | yes | — | `cash`, `card`, `check`, `wire`, `other`. |
+| `receipt_image_ref` | string | — | yes | — | Caller-side photo identifier. |
+
+Will be schematized as `docs/api/schemas/v1/expense.json` when receipt → observation bridge ships.
+
+### The get_event_checklist Contract
+
+The `get_event_checklist(event_type)` MCP tool returns a Claude-actionable per-field guide for any event type:
+
+```typescript
+{
+  event_type: "service",
+  fields: [
+    {
+      name: "zones_touched",
+      type: "string[]",
+      required: false,
+      description: "Vehicle subsystems involved in this session.",
+      why_it_matters: "Drives timeline rendering and downstream gap-fill — a session that touched 'cooling' tells the system to weight subsequent cooling-related observations higher.",
+      enum: ["engine_bay", "undercarriage", "interior", "wheels", "drivetrain", "cooling", "electrical", "fuel", "ignition", "suspension", "brakes", "body", "other"],
+      vision_fillable: true,
+      context_fillable: true,
+      tool_fillable: false,
+      example: ["engine_bay", "drivetrain"]
+    },
+    // ... one entry per field in the JSON Schema
+  ]
+}
+```
+
+The data is inlined in the MCP connector — no DB lookup. The checklist is the form-shape's instruction manual: the JSON Schema validates structure, the checklist tells the agent how to produce structure that validates.
+
+### Why Per-Kind Shape, Not Universal Shape
+
+Earlier drafts proposed a single `vehicle_event` JSON Schema with optional fields for everything. That was rejected. A universal shape forces the agent to figure out which fields are relevant; a per-kind shape tells the agent which fields ARE the event. The agent's job is to fill the form, not to design it.
+
+The cost: more schemas to maintain. The benefit: every submission of a given kind has a known shape, and the timeline can render structured details for every event without "see narrative" fallbacks.
+
+### Cross-references
+
+- **Form-shape framing**: `docs/library/intellectual/contemplations/the-form-is-the-thing.md`
+- **External Agent Write API**: Chapter 7 — how the form gets delivered to Claude over REST and MCP.
+- **JSON Schemas**: `docs/api/schemas/v1/{envelope,service,inspection,note}.json`. Future: `modification.json`, `condition_assessment.json`, `media.json`, `expense.json`.
+- **Dictionary entries**: `docs/library/reference/dictionary/{service,inspection,modification,note,condition_assessment,form-shape,vision-fillable}.md`.
+- **MCP tool**: `get_event_checklist` in `supabase/functions/mcp-connector/index.ts`.

--- a/docs/library/reference/encyclopedia/07-external-agent-write-api.md
+++ b/docs/library/reference/encyclopedia/07-external-agent-write-api.md
@@ -18,17 +18,63 @@ Comparable mental models: Plaid for banking data, Stripe for payments, SMTP for 
 
 ## What ships in v1
 
-### Two surfaces, same substrate
+### Founding framing — the form is the thing
 
-External agents reach the write path two ways. Both land in `vehicle_observations` via `ingest-observation`.
+> "It's not just mobile but I should be able to access through Claude on my phone and Claude will submit it for me with its interpretation of what it's seeing and then it's gonna fill in the form shape that we require."
+> — Skylar, 2026-05-02
 
-**REST** — `POST nuke.ag/v1/events` with X-API-Key auth. Documented at `nuke.ag/api/docs` (Redoc) with the spec at `nuke.ag/v1/openapi.json`. Read-back via `GET nuke.ag/v1/events?vin={VIN}`.
+> "We need it to work perfectly for one user and then we will define… the ingestion process, then we start practicing scale."
 
-**MCP** — Tools `submit_vehicle_event`, `get_event_schema`, `verify_vehicle_access` on the `mcp-connector` edge function (reachable via `https://nuke.ag/api/mcp`). Identical envelope to the REST surface; the MCP wraps the REST endpoint internally.
+The session that produced this chapter spent hours on OAuth — token endpoints, magic-link callbacks, two open Anthropic client bugs. Skylar pulled the cord: **the form is the thing. Everything else is plumbing to deliver Claude to it.** This section reorders the chapter accordingly.
+
+### 1. The form-shape is the moat
+
+Vehicles are immutable entities. Observations are testimony. The library has said this for two years (Chapter 2; the `testimony-and-half-lives` and `i-just-know` contemplations). What was missing was a contract that turns a vision agent's natural-language interpretation of a photo into structured testimony.
+
+That contract is the **form-shape**: per-event-type JSON Schemas that Claude reads before it writes. For each event type — `service`, `inspection`, `modification`, `note`, `condition_assessment` — the system publishes:
+
+1. A **JSON Schema** (Draft 2020-12) at `docs/api/schemas/v1/<event_type>.json` that the submission must validate against.
+2. A **checklist** returned by the MCP tool `get_event_checklist(event_type)` annotating every field with `vision_fillable`, `context_fillable`, and `tool_fillable` flags — telling the agent where each field's answer comes from.
+
+A vision agent without a form will hallucinate structure. It will write `paint_condition: "lovely"` in one submission and `exterior_paint: "nice"` in the next. The data lands but does not compose. A vision agent **with** a form has a checklist. It fills the fields. The same fields appear on every submission of the same type. The data composes. The timeline renders structured details, not "see narrative" fallbacks.
+
+The form-shape is also the enforcer of the testimony axiom in the agent era. When the source was a BaT listing, the source defined the structure. When the source is Claude reading a photo, the form-shape IS the structure. See `docs/library/intellectual/contemplations/the-form-is-the-thing.md` for the long-form argument and `docs/library/reference/encyclopedia/02-observation-model.md#per-kind-structured_data-shape` for the per-kind canonical fields.
+
+Per-kind routing into the substrate:
+
+| `event_type` | `observation_kind` | `source_slug` | Schema |
+| --- | --- | --- | --- |
+| `service` | `work_record` | `shop` | `service.json` |
+| `inspection` | `condition` | `agent-submission` | `inspection.json` |
+| `modification` | `work_record` | `agent-submission` | `modification.json` (v1.1) |
+| `condition_assessment` | `condition` | `agent-submission` | `condition_assessment.json` (v1.1) |
+| `note` | `comment` | `agent-submission` | `note.json` |
+
+Reserved but not yet routed: `ownership_change`, `media`. Submissions for those return 400 until a real form-shape exists.
+
+### 2. Two surfaces, same form
+
+External agents reach the write path two ways. Both consume the **same** JSON Schemas and the **same** checklist contracts. Both land in `vehicle_observations` via `ingest-observation`.
+
+**REST** — `POST nuke.ag/v1/events` with X-API-Key auth. Documented at `nuke.ag/api/docs` (Redoc) with the spec at `nuke.ag/v1/openapi.json`. Read-back via `GET nuke.ag/v1/events?vin={VIN}`. The OpenAPI spec references the JSON Schemas at `docs/api/schemas/v1/`.
+
+**MCP** — Tools `submit_vehicle_event`, `get_event_schema`, `get_event_checklist`, `verify_vehicle_access` on the `mcp-connector` edge function (reachable via `https://nuke.ag/api/mcp` and `https://nuke.ag/mcp`). Identical envelope to the REST surface; the MCP wraps the REST endpoint internally and exposes the checklist contract as a first-class tool so claude.ai can pre-flight a submission.
+
+The point: there is one form. Whatever transport, whatever client, whatever auth — the agent fills the same fields and the testimony lands the same way. Anything that varies between surfaces is plumbing.
+
+### 3. Auth is plumbing
+
+Auth is documented because we have to ship it; it is **not** the moat. The bare minimum to deliver Claude to the form:
+
+- **REST surface — X-API-Key.** `_shared/apiKeyAuth.ts` hashes the key, calls `check_api_key_rate_limit` RPC, returns scopes. Issuance UI at `/settings/connected-agents`. Backed by `api_keys`.
+- **MCP surface — OAuth 2.0.** Required because claude.ai's connector spec demands DCR (RFC 7591) and authorization code flow. Endpoints: `/oauth/authorize`, `/oauth/login`, `/oauth/callback`, `/oauth/token`. The Supabase magic-link is the user-facing step. Once the access token is issued, the MCP surface uses it identically to the REST X-API-Key — same scopes, same checks.
+- **Service role.** `Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}` bypasses scope checks. Internal only.
+
+That is everything. Auth gets Claude to the form. The form is what matters.
 
 ### Envelope shape (strict)
 
-The outer envelope is closed; additional properties rejected. The `payload` is loose-but-validated against a per-`event_type` JSON Schema (Draft 2020-12).
+The outer envelope is closed; additional properties rejected. The `payload` is loose-but-validated against a per-`event_type` JSON Schema (Draft 2020-12) — the form-shape from section 1.
 
 ```json
 {
@@ -154,13 +200,18 @@ The envelope includes `auth: { user_id, token_id, scopes }`. This is documentary
 
 ## Cross-references
 
+- **Form-shape framing**: `docs/library/intellectual/contemplations/the-form-is-the-thing.md` — the night Skylar pulled us back to the form.
+- **Per-kind shape spec**: `docs/library/reference/encyclopedia/02-observation-model.md#per-kind-structured_data-shape` — the canonical fields for each `kind`.
 - **The Mustang** is pilot user #1. VIN `6F07C219593`. Vehicle ID `83f6f033-a3c3-4cf4-a85e-a60d2c588838`. Year 1966, make Ford, model Mustang.
 - **OpenAPI spec**: `docs/api/openapi.yaml` (canonical), `nuke_frontend/api/v1/openapi.json` (programmatic mirror).
-- **JSON Schemas**: `docs/api/schemas/v1/{envelope,service,note}.json`.
+- **JSON Schemas**: `docs/api/schemas/v1/{envelope,service,inspection,note}.json`. Future: `modification.json`, `condition_assessment.json`, `media.json`, `expense.json`.
+- **MCP checklist tool**: `get_event_checklist` in `supabase/functions/mcp-connector/index.ts` — returns per-field `vision_fillable`/`context_fillable`/`tool_fillable` annotations.
+- **Dictionary entries**: `docs/library/reference/dictionary/{service,inspection,modification,note,condition_assessment,form-shape,vision-fillable}.md`.
 - **Quickstart for integrators**: `docs/api/QUICKSTART.md` ("4 calls from zero").
 - **Skylar's Claude Desktop setup**: `docs/api/CLAUDE_DESKTOP_SETUP.md`.
+- **Skylar's Claude.ai mobile setup**: `docs/api/CLAUDE_MOBILE_SETUP.md`.
 - **Scope grammar reference**: `supabase/functions/_shared/scopeGrammar.ts` + `scopeGrammar.test.ts` (23 tests).
 - **Trust invariant**: `docs/library/intellectual/contemplations/the-trust-invariant.md` and `.claude/rules/agent-trust-invariants.md`.
 - **Brief**: `docs/external-agent-write-api.md`.
 - **Build plan**: `~/.claude/plans/humble-drifting-backus.md`.
-- **The night the API shipped**: 2026-05-02 → 2026-05-03, multi-team overnight build (4 parallel workstreams). DONE.md captures the timeline.
+- **The night the API shipped**: 2026-05-02 → 2026-05-03, multi-team overnight build (10 parallel workstreams). DONE.md captures the timeline.


### PR DESCRIPTION
## Summary

Per Skylar's correction late on 2026-05-02 — *"the form is the thing. Everything else is plumbing to deliver Claude to it."* — this PR reframes the library's coverage of the External Agent Write API around the form-shape contract instead of leading with OAuth / REST plumbing.

- **Append** to `docs/library/reference/encyclopedia/02-observation-model.md` a new section "Per-Kind structured_data Shape" — canonical fields per `kind` (work_record, condition, media, comment, expense), the `vision_fillable` / `context_fillable` / `tool_fillable` annotation triplet, the `get_event_checklist` MCP contract, references to the JSON Schemas at `docs/api/schemas/v1/`.
- **Rewrite** the "What ships in v1" section of `docs/library/reference/encyclopedia/07-external-agent-write-api.md`. New ordering: (1) the form-shape is the moat — leads with Skylar's verbatim quote as a "Founding framing" callout; (2) two surfaces, same form — REST and MCP consume the same Schemas + checklists; (3) auth is plumbing — OAuth and X-API-Key documented but explicitly not the lead.
- **Add** dictionary entries: `service`, `inspection`, `modification`, `note`, `condition_assessment`, `form-shape`, `vision-fillable`.
- **Add** contemplation `docs/library/intellectual/contemplations/the-form-is-the-thing.md` (~960 words, Skylar's voice — terse, opinionated; frames why a permissive schema isn't enough for vision agents).

No code changes. Library only. Cross-refs added between chapter 02, chapter 07, the contemplation, the dictionary entries, and the JSON Schemas.

## Test plan

- [ ] Markdown renders without broken anchors (chapter 02 ↔ chapter 07 ↔ contemplation cross-refs)
- [ ] Dictionary entries discoverable from `docs/library/reference/dictionary/`
- [ ] No deletions from existing library content (additive only on chapter 02; rewrite only of "What ships in v1" subsection on chapter 07)
- [ ] Voice in `the-form-is-the-thing.md` reads as Skylar's, not corporate-blog

🤖 Generated with [Claude Code](https://claude.com/claude-code)