### PR TITLE
WS-2: OAuth server hardening — telemetry, absolute form actions, JWT alignment

### DIFF
--- a/docs/api/CLAUDE_MOBILE_SETUP.md
+++ b/docs/api/CLAUDE_MOBILE_SETUP.md
@@ -49,13 +49,76 @@ Plus 40 other read tools and the cockpit/projection tools.
 
 If you attach the iPhone photo to the message, Claude can read the image and then call `submit_vehicle_event` with a structured payload describing the work. The photo upload tool (`submit_vehicle_photo`) is on the next-session list — for now photos can be referenced as URLs, not directly base64-uploaded through MCP.
 
-## Troubleshooting
+## Telemetry — when something goes wrong
+
+Every endpoint logs a structured JSON line. Tail in real time:
+
+```bash
+supabase functions logs oauth-server --tail 2>/dev/null | jq 'select(.event)' \
+  || open "https://supabase.com/dashboard/project/qkgaybvrernstplzjaam/functions/oauth-server/logs"
+```
+
+Events (in flow order): `oauth_authorization_server_metadata`, `oauth_register`, `oauth_register_ok`, `oauth_authorize`, `oauth_login`, `oauth_login_session_created`, `oauth_login_magic_link_sent`, `oauth_callback`, `oauth_callback_fragment_fallback`, `oauth_callback_finish`, `oauth_finish_code_issued`, `oauth_token`, `oauth_token_authorization_code`, `oauth_token_pkce_mismatch`, `oauth_token_issued`, `oauth_token_refresh`, `oauth_handler_error`.
+
+Hard rule: **secrets are never logged in plaintext** — only their lengths via `_len` fields (e.g. `code_len`, `access_token_len`, `code_verifier_len`).
+
+If you see `oauth_authorize` → `oauth_login` but no `oauth_callback`, the user never clicked the magic link (or closed the webview). If you see `oauth_callback` → `oauth_token_pkce_mismatch`, the verifier the client sent doesn't S256-hash to the stored challenge — usually because Claude.ai started a new session and lost state.
+
+## Pre-flight test
+
+Before debugging on the live phone, run the end-to-end test against the deployed function:
+
+```bash
+dotenvx run -- bash scripts/test-oauth-flow.sh
+```
+
+DCR → authorize → login → seed authorization code → token exchange → JWT validate (and a refresh-token + replay-protection check). Exits 0 on green. Failure messages are specific (PKCE mismatch? form-action regression? JWT alignment? metadata 404?), so you know what to fix before tapping the connector.
+
+## Troubleshooting — server-side
 
 - **"Connect" button does nothing / connector says it's already pending:** force-quit the app, reopen, try again. Mobile sometimes caches an in-flight OAuth state.
 - **Magic link email never arrives:** check that the email you entered matches your NUKE account. The link is valid for 15 minutes.
 - **Magic link clicks land on a "session not found" page:** session expired (15 min). Restart the connector flow.
 - **Tools appear but writes return 401:** the connector lost its token. Disconnect + reconnect.
 - **Tools appear and writes return 403:** the OAuth flow issued a token without `events:write` scope. Disconnect + reconnect; the consent flow defaults to `events:write events:read`.
+
+## Troubleshooting — known Claude.ai client-side OAuth bugs
+
+These are defects in the **Claude.ai client**, not in NUKE's server. NUKE's `scripts/test-oauth-flow.sh` will pass green even when these symptoms are present, because the bugs occur in how Claude.ai consumes the OAuth result, not in how NUKE produces it. Until Anthropic ships fixes, use the workarounds below.
+
+### Bug A — OAuth completes but Bearer token never sent
+
+- **Tracking:** [`anthropics/claude-code#46140`](https://github.com/anthropics/claude-code/issues/46140) — "OAuth completes but Bearer token never sent"
+- **Symptom:** Magic-link click → "Connection complete" page in Claude.ai → connector toggle stays gray, tools never appear in chat. `supabase functions logs oauth-server` shows `oauth_token_issued`, but `mcp-connector` logs show no Bearer header on subsequent tool calls.
+- **Root cause (client-side):** Claude.ai successfully completes the token exchange but fails to attach the `Authorization: Bearer <token>` header to subsequent MCP requests. The token is sitting in the client but never reaches the resource server.
+- **Workarounds:**
+  1. **Force a re-discovery.** Settings → Connectors → remove NUKE → force-quit the app (iOS swipe-up, Android recent-apps swipe) → reopen → re-add `https://nuke.ag/mcp`. The token-attachment glitch tends to happen on stale connector records.
+  2. **Prime via desktop browser.** Add the connector at `claude.ai/settings/connectors` on a desktop browser, complete OAuth there, then verify mobile picks up the token. Some users report desktop "primes" mobile.
+  3. **Verify server-side.** Run `dotenvx run -- bash scripts/test-oauth-flow.sh` — green means the server is fine and the bug is purely client-side.
+  4. **Fall back to Claude Desktop + X-API-Key.** Until Anthropic ships the fix, use `docs/api/CLAUDE_DESKTOP_SETUP.md` (X-API-Key path) on macOS — that path doesn't depend on Bearer attachment.
+
+### Bug B — OAuth authentication fails on claude.ai web — no requests reach the server
+
+- **Tracking:** [`anthropics/claude-ai-mcp#8`](https://github.com/anthropics/claude-ai-mcp/issues/8) — "OAuth authentication fails on claude.ai web — no requests reach server"
+- **Symptom:** Click "Authorize" on claude.ai web → redirected back to claude.ai with a generic auth error → `supabase functions logs oauth-server` shows **zero** `oauth_authorize` events for the time window. The authorization endpoint isn't even hit.
+- **Root cause (client-side):** The Claude.ai web client occasionally skips the well-known discovery step entirely or stops after a CORS preflight, never issuing the actual `/oauth/authorize` GET. Web-specific.
+- **Workarounds:**
+  1. **Try the mobile app instead.** Same connector URL on iOS/Android Claude.ai usually works even when web does not — the bug is web-specific.
+  2. **Hard-refresh the Connectors page.** Cmd-Shift-R / Ctrl-Shift-R. Web client state can get stuck in a cached failed-discovery state.
+  3. **Verify discovery is reachable.** From a terminal:
+     ```bash
+     curl -s https://nuke.ag/.well-known/oauth-authorization-server | jq .issuer
+     curl -s https://nuke.ag/.well-known/oauth-protected-resource     | jq .resource
+     ```
+     Both must return JSON (not HTML, not 404). If they don't, the Vercel rewrite to `oauth-server` is broken — fix in `nuke_frontend/vercel.json`. If they do return correctly, blame is on the Claude.ai web client.
+  4. **Use Claude Desktop + X-API-Key.** Same fallback as Bug A.
+
+### Server-side defenses already in place
+
+- Form action on `/oauth/authorize` is the **absolute URL** `https://nuke.ag/oauth/login` — defensive against webview base resolution quirks (also the symptom space of #8).
+- Fragment-token shim in `/oauth/callback` (for Supabase magic links that put the token in `#access_token=`) likewise uses the **absolute URL** `https://nuke.ag/oauth/callback-finish`.
+- Structured per-event logging at every endpoint, secret-length only — so we can read the logs even when the client is silent.
+- `scripts/test-oauth-flow.sh` smoke-tests the whole chain, including JWT round-trip via `supabase.auth.getUser()`, replay-protection on used codes, and absolute-form-action regression.
 
 ## What's stored where
 

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
     "taxonomy:retrigger": "tsx scripts/retrigger-normalization.ts",
     "taxonomy:vin-decode": "tsx scripts/mass-vin-decode.ts",
     "test:invoice-cashflow": "tsx scripts/integration/test-invoice-cashflow.ts",
+    "test:oauth-flow": "dotenvx run -- bash scripts/test-oauth-flow.sh",
     "test:phone-otp": "tsx scripts/test-phone-otp.ts",
     "test:vision-fill": "dotenvx run -f .env -f .env.local -- tsx scripts/test-vision-fill-loop.ts",
     "trickle-backfill-images": "tsx scripts/trickle-backfill-images.ts",

--- a/scripts/test-oauth-flow.sh
+++ b/scripts/test-oauth-flow.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# scripts/test-oauth-flow.sh
+#
+# End-to-end OAuth 2.0 PKCE flow test for the NUKE oauth-server edge function.
+# Bypasses Vercel rewrites by hitting Supabase directly:
+#   ${VITE_SUPABASE_URL}/functions/v1/oauth-server/<route>
+#
+# What this proves:
+#   1. /oauth/register issues a client_id (DCR / RFC 7591)
+#   2. /oauth/authorize renders the email-input HTML form
+#   3. /oauth/login starts a magic-link session and writes oauth_login_sessions
+#   4. We seed the magic-link completion (insert authorization code + mark
+#      session completed) — Skylar's email click is not automatable
+#   5. /oauth/token exchanges code+verifier for an access_token (PKCE S256)
+#   6. supabase.auth.getUser(access_token) accepts the issued JWT — the JWT
+#      issuer/aud/secret alignment is correct
+#
+# Exits 0 on full green; 1 with a specific diagnostic on first failure.
+#
+# Usage: dotenvx run -- bash scripts/test-oauth-flow.sh
+#
+# Required env (loaded via dotenvx from .env):
+#   VITE_SUPABASE_URL
+#   SUPABASE_SERVICE_ROLE_KEY
+#   SUPABASE_JWT_SECRET
+#   SUPABASE_URL (= VITE_SUPABASE_URL)
+#
+# Hard rule: this script never DELETEs from oauth_clients, oauth_login_sessions,
+# or oauth_authorization_codes (testimony for OAuth flow forensics). It only
+# inserts and reads.
+
+set -u
+
+# ── Pretty output ────────────────────────────────────────────────────────────
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[0;33m'; CYAN=$'\033[0;36m'; NC=$'\033[0m'
+pass() { echo "${GREEN}PASS${NC}  $*"; }
+fail() { echo "${RED}FAIL${NC}  $*"; exit 1; }
+info() { echo "${CYAN}····${NC}  $*"; }
+warn() { echo "${YELLOW}WARN${NC}  $*"; }
+
+# ── Env preflight ────────────────────────────────────────────────────────────
+: "${VITE_SUPABASE_URL:?VITE_SUPABASE_URL not set — run via 'dotenvx run --'}"
+: "${SUPABASE_SERVICE_ROLE_KEY:?SUPABASE_SERVICE_ROLE_KEY not set}"
+: "${SUPABASE_JWT_SECRET:?SUPABASE_JWT_SECRET not set}"
+
+# Skylar's user_id (locked-in caller arg per WS-2 spec).
+export SKYLAR_USER_ID="${SKYLAR_USER_ID:-0b9f107a-d124-49de-9ded-94698f63c1c4}"
+export SKYLAR_EMAIL="${SKYLAR_EMAIL:-shkylar@gmail.com}"
+
+OAUTH_BASE="${VITE_SUPABASE_URL%/}/functions/v1/oauth-server"
+SR_KEY="$SUPABASE_SERVICE_ROLE_KEY"
+
+info "OAUTH_BASE = $OAUTH_BASE"
+info "user_id    = $SKYLAR_USER_ID"
+
+# ── Step 0: JWT round-trip preflight ────────────────────────────────────────
+# Mint an access_token using oauth-server's exact algorithm and validate it via
+# supabase.auth.getUser. If this fails, the issuer/aud/secret are misaligned
+# and Claude.ai's bearer tokens won't authenticate against mcp-connector.
+info "Step 0: JWT round-trip — mint with SUPABASE_JWT_SECRET, validate via supabase.auth.getUser"
+
+ROUNDTRIP_RESULT="$(node --input-type=module -e "
+import crypto from 'node:crypto';
+const secret = process.env.SUPABASE_JWT_SECRET;
+const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+const userId = process.env.SKYLAR_USER_ID;
+const email  = process.env.SKYLAR_EMAIL;
+
+const b64url = (b) => Buffer.from(b).toString('base64')
+  .replace(/=+$/,'').replace(/\+/g,'-').replace(/\//g,'_');
+
+const header  = { alg: 'HS256', typ: 'JWT' };
+const now = Math.floor(Date.now()/1000);
+const payload = {
+  aud: 'authenticated',
+  role: 'authenticated',
+  sub: userId,
+  email,
+  iss: \`\${supabaseUrl}/auth/v1\`,
+  iat: now,
+  exp: now + 60*60,
+  nuke_oauth: { scopes: ['events:read','events:write'], source: 'oauth-server' },
+};
+const enc = (o) => b64url(JSON.stringify(o));
+const signing = enc(header)+'.'+enc(payload);
+const sig = crypto.createHmac('sha256', secret).update(signing).digest();
+const token = signing+'.'+b64url(sig);
+
+const res = await fetch(\`\${supabaseUrl}/auth/v1/user\`, {
+  headers: {
+    'Authorization': 'Bearer '+token,
+    'apikey': process.env.SUPABASE_SERVICE_ROLE_KEY,
+  },
+});
+const body = await res.text();
+let parsed; try { parsed = JSON.parse(body); } catch { parsed = body; }
+console.log(JSON.stringify({
+  http: res.status,
+  resolved_user_id: parsed && parsed.id || null,
+  expected_user_id: userId,
+  match: !!(parsed && parsed.id === userId),
+  iss_used: payload.iss,
+  body_preview: typeof parsed === 'string' ? parsed.slice(0,200) : null,
+  err: typeof parsed === 'object' && parsed && parsed.msg || null,
+}));
+" 2>&1)"
+NODE_EXIT=$?
+
+if [ $NODE_EXIT -ne 0 ]; then
+  echo "$ROUNDTRIP_RESULT"
+  fail "Node JWT mint/verify script exited $NODE_EXIT"
+fi
+
+RT_HTTP=$(echo "$ROUNDTRIP_RESULT" | jq -r '.http // empty')
+RT_MATCH=$(echo "$ROUNDTRIP_RESULT" | jq -r '.match // false')
+RT_ISS=$(echo "$ROUNDTRIP_RESULT" | jq -r '.iss_used // empty')
+RT_RESOLVED=$(echo "$ROUNDTRIP_RESULT" | jq -r '.resolved_user_id // empty')
+
+if [ "$RT_HTTP" != "200" ] || [ "$RT_MATCH" != "true" ]; then
+  echo "$ROUNDTRIP_RESULT" | jq .
+  fail "JWT round-trip failed. http=$RT_HTTP resolved=$RT_RESOLVED iss=$RT_ISS — Supabase rejected our token. Check SUPABASE_JWT_SECRET alignment and iss claim."
+fi
+pass "JWT round-trip (iss=$RT_ISS, resolved user_id=$RT_RESOLVED)"
+
+# ── PKCE generation (S256) ──────────────────────────────────────────────────
+# Generate a code_verifier (43-128 chars, [A-Z][a-z][0-9]-._~) and the matching
+# S256 code_challenge.
+PKCE_PAIR="$(node --input-type=module -e "
+import crypto from 'node:crypto';
+const b64url = (b) => Buffer.from(b).toString('base64')
+  .replace(/=+$/,'').replace(/\+/g,'-').replace(/\//g,'_');
+const verifier = b64url(crypto.randomBytes(32));
+const challenge = b64url(crypto.createHash('sha256').update(verifier).digest());
+console.log(JSON.stringify({verifier, challenge}));
+")"
+CODE_VERIFIER=$(echo "$PKCE_PAIR" | jq -r '.verifier')
+CODE_CHALLENGE=$(echo "$PKCE_PAIR" | jq -r '.challenge')
+
+# ── Step 1: DCR ─────────────────────────────────────────────────────────────
+info "Step 1: POST /oauth/register (Dynamic Client Registration)"
+
+REDIRECT_URI="https://example.test/oauth-test/$RANDOM"
+DCR_RESP="$(curl -s -o /tmp/oauth-test-dcr.json -w '%{http_code}' \
+  -X POST "$OAUTH_BASE/oauth/register" \
+  -H "Authorization: Bearer $SR_KEY" \
+  -H "content-type: application/json" \
+  -d "{\"client_name\":\"ws2-test-$$\",\"redirect_uris\":[\"$REDIRECT_URI\"],\"grant_types\":[\"authorization_code\",\"refresh_token\"],\"response_types\":[\"code\"],\"token_endpoint_auth_method\":\"none\",\"scope\":\"events:write events:read\"}")"
+
+if [ "$DCR_RESP" != "201" ]; then
+  cat /tmp/oauth-test-dcr.json
+  fail "DCR expected 201, got $DCR_RESP"
+fi
+CLIENT_ID=$(jq -r '.client_id' /tmp/oauth-test-dcr.json)
+[ -n "$CLIENT_ID" ] && [ "$CLIENT_ID" != "null" ] || fail "DCR returned no client_id"
+pass "DCR → client_id=$CLIENT_ID"
+
+# ── Step 2: GET /oauth/authorize ────────────────────────────────────────────
+info "Step 2: GET /oauth/authorize (expect HTML form)"
+
+STATE="ws2teststate$RANDOM"
+AUTHZ_URL="$OAUTH_BASE/oauth/authorize?client_id=$CLIENT_ID&redirect_uri=$(node -e 'console.log(encodeURIComponent(process.argv[1]))' "$REDIRECT_URI")&response_type=code&scope=events%3Awrite+events%3Aread&state=$STATE&code_challenge=$CODE_CHALLENGE&code_challenge_method=S256"
+
+AUTHZ_HTTP="$(curl -s -o /tmp/oauth-test-authz.html -w '%{http_code}' \
+  -H "Authorization: Bearer $SR_KEY" \
+  "$AUTHZ_URL")"
+
+if [ "$AUTHZ_HTTP" != "200" ]; then
+  head -c 500 /tmp/oauth-test-authz.html
+  fail "/oauth/authorize expected 200, got $AUTHZ_HTTP"
+fi
+
+# Verify form action is absolute (form-action audit per WS-2 task 1).
+if grep -qF 'action="https://nuke.ag/oauth/login"' /tmp/oauth-test-authz.html; then
+  pass "Authorize HTML rendered, form action is ABSOLUTE (https://nuke.ag/oauth/login)"
+elif grep -qF 'action="/oauth/login"' /tmp/oauth-test-authz.html; then
+  fail "Authorize form action is RELATIVE — Claude.ai webview may resolve against wrong base. Fix oauth-server/index.ts."
+else
+  warn "Authorize HTML rendered but form action attribute not found — manual review needed"
+fi
+
+# ── Step 3: POST /oauth/login (start magic-link session) ────────────────────
+info "Step 3: POST /oauth/login (expect 200 'check email' page)"
+
+OAUTH_PARAMS_JSON=$(jq -nc \
+  --arg cid "$CLIENT_ID" \
+  --arg ru "$REDIRECT_URI" \
+  --arg s "events:write events:read" \
+  --arg st "$STATE" \
+  --arg cc "$CODE_CHALLENGE" \
+  '{client_id:$cid, redirect_uri:$ru, scope:$s, state:$st, code_challenge:$cc, code_challenge_method:"S256"}')
+OAUTH_PARAMS_ENC=$(node -e 'console.log(encodeURIComponent(process.argv[1]))' "$OAUTH_PARAMS_JSON")
+
+LOGIN_HTTP="$(curl -s -o /tmp/oauth-test-login.html -w '%{http_code}' \
+  -X POST "$OAUTH_BASE/oauth/login" \
+  -H "Authorization: Bearer $SR_KEY" \
+  -H "content-type: application/x-www-form-urlencoded" \
+  --data-urlencode "email=$SKYLAR_EMAIL" \
+  --data-urlencode "oauth_params=$OAUTH_PARAMS_JSON")"
+
+# 200 means the session was inserted and a magic-link send was attempted.
+# Skylar's SMTP / generateLink config may or may not actually deliver email.
+if [ "$LOGIN_HTTP" != "200" ]; then
+  head -c 500 /tmp/oauth-test-login.html
+  fail "/oauth/login expected 200, got $LOGIN_HTTP"
+fi
+if ! grep -qi "check your email" /tmp/oauth-test-login.html; then
+  warn "Login HTML did not include 'check your email' — the page changed shape; verify manually"
+else
+  pass "Login HTML rendered ('check your email')"
+fi
+
+# ── Step 4: Seed magic-link completion ──────────────────────────────────────
+# We can't click Skylar's email. Instead, find the most recent oauth_login_sessions
+# row for this client_id+email and insert an authorization code that ties to it.
+# This is exactly what /oauth/callback's finishCallback() does on real magic-link click.
+info "Step 4: Seed authorization code (simulating magic-link click)"
+
+PG_REST="$VITE_SUPABASE_URL/rest/v1"
+
+SESSION_ROW="$(curl -s \
+  -H "Authorization: Bearer $SR_KEY" \
+  -H "apikey: $SR_KEY" \
+  "$PG_REST/oauth_login_sessions?client_id=eq.$CLIENT_ID&email=eq.$SKYLAR_EMAIL&order=created_at.desc&limit=1")"
+
+SESSION_ID=$(echo "$SESSION_ROW" | jq -r '.[0].session_id // empty')
+SESSION_REDIRECT=$(echo "$SESSION_ROW" | jq -r '.[0].redirect_uri // empty')
+SESSION_CHALLENGE=$(echo "$SESSION_ROW" | jq -r '.[0].code_challenge // empty')
+SESSION_SCOPE=$(echo "$SESSION_ROW" | jq -r '.[0].scope // empty')
+
+if [ -z "$SESSION_ID" ] || [ "$SESSION_ID" = "null" ]; then
+  echo "$SESSION_ROW"
+  fail "No oauth_login_sessions row found for client_id=$CLIENT_ID, email=$SKYLAR_EMAIL"
+fi
+
+if [ "$SESSION_CHALLENGE" != "$CODE_CHALLENGE" ]; then
+  fail "Session row code_challenge mismatch: stored=$SESSION_CHALLENGE expected=$CODE_CHALLENGE"
+fi
+
+# Generate an authorization code (32 random bytes hex) and insert it.
+AUTH_CODE=$(node -e "console.log(require('node:crypto').randomBytes(32).toString('hex'))")
+EXPIRES_AT=$(node -e "console.log(new Date(Date.now()+10*60*1000).toISOString())")
+
+INSERT_RESP="$(curl -s -o /tmp/oauth-test-codeins.json -w '%{http_code}' \
+  -X POST "$PG_REST/oauth_authorization_codes" \
+  -H "Authorization: Bearer $SR_KEY" \
+  -H "apikey: $SR_KEY" \
+  -H "content-type: application/json" \
+  -H "Prefer: return=representation" \
+  -d "$(jq -nc \
+    --arg code "$AUTH_CODE" \
+    --arg cid "$CLIENT_ID" \
+    --arg uid "$SKYLAR_USER_ID" \
+    --arg ru "$SESSION_REDIRECT" \
+    --arg sc "$SESSION_SCOPE" \
+    --arg cc "$SESSION_CHALLENGE" \
+    --arg exp "$EXPIRES_AT" \
+    '{code:$code, client_id:$cid, user_id:$uid, redirect_uri:$ru, scope:$sc, code_challenge:$cc, code_challenge_method:"S256", expires_at:$exp}')")"
+
+if [ "$INSERT_RESP" != "201" ]; then
+  cat /tmp/oauth-test-codeins.json
+  fail "oauth_authorization_codes insert expected 201, got $INSERT_RESP"
+fi
+
+# Mark login session completed (idempotent).
+curl -s -o /dev/null \
+  -X PATCH "$PG_REST/oauth_login_sessions?session_id=eq.$SESSION_ID" \
+  -H "Authorization: Bearer $SR_KEY" \
+  -H "apikey: $SR_KEY" \
+  -H "content-type: application/json" \
+  -d "$(jq -nc --arg uid "$SKYLAR_USER_ID" --arg ts "$(date -u +%FT%TZ)" '{user_id:$uid, completed_at:$ts}')"
+
+pass "Authorization code seeded (session_id=$SESSION_ID, code_len=${#AUTH_CODE})"
+
+# ── Step 5: POST /oauth/token (PKCE exchange) ───────────────────────────────
+info "Step 5: POST /oauth/token (authorization_code grant + PKCE)"
+
+TOKEN_HTTP="$(curl -s -o /tmp/oauth-test-token.json -w '%{http_code}' \
+  -X POST "$OAUTH_BASE/oauth/token" \
+  -H "Authorization: Bearer $SR_KEY" \
+  -H "content-type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=authorization_code" \
+  --data-urlencode "code=$AUTH_CODE" \
+  --data-urlencode "client_id=$CLIENT_ID" \
+  --data-urlencode "redirect_uri=$REDIRECT_URI" \
+  --data-urlencode "code_verifier=$CODE_VERIFIER")"
+
+if [ "$TOKEN_HTTP" != "200" ]; then
+  cat /tmp/oauth-test-token.json
+  fail "/oauth/token expected 200, got $TOKEN_HTTP"
+fi
+
+ACCESS_TOKEN=$(jq -r '.access_token' /tmp/oauth-test-token.json)
+REFRESH_TOKEN=$(jq -r '.refresh_token' /tmp/oauth-test-token.json)
+TOKEN_TYPE=$(jq -r '.token_type' /tmp/oauth-test-token.json)
+EXPIRES_IN=$(jq -r '.expires_in' /tmp/oauth-test-token.json)
+
+[ -n "$ACCESS_TOKEN" ] && [ "$ACCESS_TOKEN" != "null" ] || fail "Token response missing access_token"
+[ "$TOKEN_TYPE" = "Bearer" ] || fail "Token response token_type expected Bearer, got $TOKEN_TYPE"
+pass "Token exchanged (access_token len=${#ACCESS_TOKEN}, expires_in=$EXPIRES_IN)"
+
+# ── Step 6: Validate access_token via supabase.auth.getUser ────────────────
+info "Step 6: Validate access_token via Supabase /auth/v1/user"
+
+VALIDATE_RESP="$(curl -s -o /tmp/oauth-test-user.json -w '%{http_code}' \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "apikey: $SR_KEY" \
+  "$VITE_SUPABASE_URL/auth/v1/user")"
+
+if [ "$VALIDATE_RESP" != "200" ]; then
+  cat /tmp/oauth-test-user.json
+  fail "supabase.auth.getUser rejected our access_token (http=$VALIDATE_RESP) — JWT alignment broken"
+fi
+
+RESOLVED_ID=$(jq -r '.id' /tmp/oauth-test-user.json)
+RESOLVED_EMAIL=$(jq -r '.email' /tmp/oauth-test-user.json)
+if [ "$RESOLVED_ID" != "$SKYLAR_USER_ID" ]; then
+  fail "JWT validates but sub=$RESOLVED_ID does not match expected $SKYLAR_USER_ID"
+fi
+pass "Access token validated (user_id=$RESOLVED_ID, email=$RESOLVED_EMAIL)"
+
+# ── Step 7: Refresh-token grant smoke test ──────────────────────────────────
+info "Step 7: POST /oauth/token (refresh_token grant)"
+
+REFRESH_HTTP="$(curl -s -o /tmp/oauth-test-refresh.json -w '%{http_code}' \
+  -X POST "$OAUTH_BASE/oauth/token" \
+  -H "Authorization: Bearer $SR_KEY" \
+  -H "content-type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=refresh_token" \
+  --data-urlencode "refresh_token=$REFRESH_TOKEN" \
+  --data-urlencode "client_id=$CLIENT_ID")"
+
+if [ "$REFRESH_HTTP" != "200" ]; then
+  cat /tmp/oauth-test-refresh.json
+  fail "/oauth/token refresh expected 200, got $REFRESH_HTTP"
+fi
+NEW_ACCESS=$(jq -r '.access_token' /tmp/oauth-test-refresh.json)
+[ -n "$NEW_ACCESS" ] && [ "$NEW_ACCESS" != "null" ] || fail "Refresh response missing access_token"
+pass "Refresh-token grant issued new access_token (len=${#NEW_ACCESS})"
+
+# ── Step 8: Replay protection — reusing code must fail ──────────────────────
+info "Step 8: Replay attack — reusing same code must fail with invalid_grant"
+
+REPLAY_HTTP="$(curl -s -o /tmp/oauth-test-replay.json -w '%{http_code}' \
+  -X POST "$OAUTH_BASE/oauth/token" \
+  -H "Authorization: Bearer $SR_KEY" \
+  -H "content-type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=authorization_code" \
+  --data-urlencode "code=$AUTH_CODE" \
+  --data-urlencode "client_id=$CLIENT_ID" \
+  --data-urlencode "redirect_uri=$REDIRECT_URI" \
+  --data-urlencode "code_verifier=$CODE_VERIFIER")"
+REPLAY_ERR=$(jq -r '.error // empty' /tmp/oauth-test-replay.json)
+if [ "$REPLAY_HTTP" = "400" ] && [ "$REPLAY_ERR" = "invalid_grant" ]; then
+  pass "Code-reuse rejected (http=400 invalid_grant)"
+else
+  warn "Replay test unexpected: http=$REPLAY_HTTP error=$REPLAY_ERR (expected 400 invalid_grant)"
+fi
+
+# ── Step 9: Metadata endpoints ──────────────────────────────────────────────
+info "Step 9: /.well-known/oauth-authorization-server discovery"
+
+META_HTTP="$(curl -s -o /tmp/oauth-test-meta.json -w '%{http_code}' \
+  -H "Authorization: Bearer $SR_KEY" \
+  "$OAUTH_BASE/.well-known/oauth-authorization-server")"
+[ "$META_HTTP" = "200" ] || fail "Metadata endpoint http=$META_HTTP"
+META_ISSUER=$(jq -r '.issuer' /tmp/oauth-test-meta.json)
+[ "$META_ISSUER" = "https://nuke.ag" ] || fail "Metadata issuer=$META_ISSUER expected https://nuke.ag"
+pass "Authorization-server metadata advertised (issuer=$META_ISSUER)"
+
+echo
+echo "${GREEN}All checks passed.${NC} Tested client_id=$CLIENT_ID; session_id=$SESSION_ID."
+echo "Note: oauth_clients / oauth_login_sessions / oauth_authorization_codes rows are KEPT (testimony)."
+exit 0

--- a/supabase/functions/oauth-server/index.ts
+++ b/supabase/functions/oauth-server/index.ts
@@ -34,6 +34,7 @@ const REVOCATION_ENDPOINT = `${ISSUER}/oauth/revoke`;
 const RESOURCE_METADATA_ENDPOINT = `${ISSUER}/.well-known/oauth-protected-resource`;
 const LOGIN_ENDPOINT = `${ISSUER}/oauth/login`;
 const CALLBACK_ENDPOINT = `${ISSUER}/oauth/callback`;
+const CALLBACK_FINISH_ENDPOINT = `${ISSUER}/oauth/callback-finish`;
 const MCP_RESOURCE = `${ISSUER}/mcp`;
 
 const SCOPES_SUPPORTED = ["events:read", "events:write", "events:write:all", "read", "write"];
@@ -101,6 +102,25 @@ function getEnv(name: string): string {
   return v;
 }
 
+// Structured telemetry. Hard rule: NEVER log secrets in plaintext.
+// For secrets (code, access_token, refresh_token, code_verifier) log lengths only via maskLen().
+// Tail with: supabase functions logs oauth-server --tail | jq 'select(.event)'
+function logEvent(event: string, fields: Record<string, unknown> = {}): void {
+  try {
+    console.log(JSON.stringify({
+      event,
+      timestamp: new Date().toISOString(),
+      ...fields,
+    }));
+  } catch {
+    console.log(JSON.stringify({ event, timestamp: new Date().toISOString(), log_serialize_error: true }));
+  }
+}
+
+function maskLen(v: string | null | undefined): number {
+  return typeof v === "string" ? v.length : 0;
+}
+
 function makeServiceClient() {
   return createClient(getEnv("SUPABASE_URL"), getEnv("SUPABASE_SERVICE_ROLE_KEY"), {
     auth: { persistSession: false, autoRefreshToken: false },
@@ -108,8 +128,17 @@ function makeServiceClient() {
 }
 
 // HMAC key for signing Supabase-compatible JWTs.
+//
+// The signing secret MUST be the same secret Supabase Auth uses to sign its own JWTs,
+// so that supabase.auth.getUser(token) accepts our tokens. In .env this lives under
+// SUPABASE_JWT_SECRET. In deployed edge-function secrets we have to use a non-SUPABASE_
+// prefixed name (Supabase CLI blocks setting SUPABASE_* secrets), so we look up
+// JWT_SIGNING_SECRET first and fall back to SUPABASE_JWT_SECRET for local-dev convenience.
+// The two MUST hold the same value — set via:
+//   dotenvx run -- bash -c 'supabase secrets set JWT_SIGNING_SECRET="$SUPABASE_JWT_SECRET"'
 async function hmacKey(): Promise<CryptoKey> {
-  const secret = getEnv("SUPABASE_JWT_SECRET");
+  const secret = Deno.env.get("JWT_SIGNING_SECRET") ?? Deno.env.get("SUPABASE_JWT_SECRET");
+  if (!secret) throw new Error("Missing env: JWT_SIGNING_SECRET (or SUPABASE_JWT_SECRET for local dev)");
   return crypto.subtle.importKey(
     "raw",
     new TextEncoder().encode(secret),
@@ -149,6 +178,7 @@ async function mintRefreshToken(userId: string, clientId: string): Promise<strin
 // ── Route: GET /.well-known/oauth-authorization-server ───────────────────────
 
 function handleAuthServerMetadata(): Response {
+  logEvent("oauth_authorization_server_metadata");
   return jsonResp({
     issuer: ISSUER,
     authorization_endpoint: AUTHORIZATION_ENDPOINT,
@@ -167,6 +197,7 @@ function handleAuthServerMetadata(): Response {
 // ── Route: GET /.well-known/oauth-protected-resource ─────────────────────────
 
 function handleResourceMetadata(): Response {
+  logEvent("oauth_protected_resource_metadata");
   return jsonResp({
     resource: MCP_RESOURCE,
     authorization_servers: [ISSUER],
@@ -192,8 +223,17 @@ async function handleDcr(req: Request): Promise<Response> {
   try {
     body = await req.json();
   } catch {
+    logEvent("oauth_register", { ok: false, reason: "invalid_json" });
     return jsonResp({ error: "invalid_client_metadata", error_description: "Body must be valid JSON" }, 400);
   }
+  logEvent("oauth_register", {
+    client_name: body.client_name ?? null,
+    redirect_uris_count: Array.isArray(body.redirect_uris) ? body.redirect_uris.length : 0,
+    grant_types: body.grant_types ?? null,
+    token_endpoint_auth_method: body.token_endpoint_auth_method ?? "none",
+    scope: body.scope ?? null,
+    user_agent: req.headers.get("user-agent") ?? null,
+  });
 
   const redirectUris = Array.isArray(body.redirect_uris) ? body.redirect_uris.filter((u) => typeof u === "string") : [];
   if (redirectUris.length === 0) {
@@ -263,6 +303,17 @@ async function handleAuthorize(req: Request): Promise<Response> {
   const codeChallenge = params.get("code_challenge") ?? "";
   const codeChallengeMethod = params.get("code_challenge_method") ?? "S256";
 
+  logEvent("oauth_authorize", {
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: responseType,
+    scope,
+    state_len: maskLen(state),
+    code_challenge_len: maskLen(codeChallenge),
+    code_challenge_method: codeChallengeMethod,
+    user_agent: req.headers.get("user-agent") ?? null,
+  });
+
   if (!clientId) return errorPage("missing client_id");
   if (!redirectUri) return errorPage("missing redirect_uri");
   if (responseType !== "code") return redirectError(redirectUri, state, "unsupported_response_type");
@@ -313,7 +364,7 @@ async function handleAuthorize(req: Request): Promise<Response> {
     <div class="meta">
       <span class="pill">scope</span> ${scope.split(" ").map((s) => `<code>${s}</code>`).join(" ")}
     </div>
-    <form method="post" action="/oauth/login">
+    <form method="post" action="${LOGIN_ENDPOINT}">
       <label for="email">Your NUKE email</label>
       <input id="email" name="email" type="email" required autocomplete="email" placeholder="you@example.com" />
       <input type="hidden" name="oauth_params" value="${params2}" />
@@ -345,6 +396,11 @@ function redirectError(redirectUri: string, state: string, error: string, descri
 // ── Route: POST /oauth/login (initiates magic link) ──────────────────────────
 
 async function handleLogin(req: Request): Promise<Response> {
+  logEvent("oauth_login", {
+    content_type: req.headers.get("content-type") ?? null,
+    user_agent: req.headers.get("user-agent") ?? null,
+    referer: req.headers.get("referer") ?? null,
+  });
   const ct = req.headers.get("content-type") ?? "";
   let email = "";
   let oauthParamsStr = "";
@@ -369,6 +425,13 @@ async function handleLogin(req: Request): Promise<Response> {
   }
 
   const sessionId = randomToken(24);
+  logEvent("oauth_login_session_created", {
+    session_id: sessionId,
+    email_domain: email.split("@")[1] ?? null,
+    client_id: oauthParams.client_id ?? null,
+    redirect_uri: oauthParams.redirect_uri ?? null,
+    code_challenge_len: maskLen(oauthParams.code_challenge),
+  });
   const supabase = makeServiceClient();
   const { error: insErr } = await supabase.from("oauth_login_sessions").insert({
     session_id: sessionId,
@@ -405,6 +468,8 @@ async function handleLogin(req: Request): Promise<Response> {
   // Best-effort: also call signInWithOtp. Idempotent enough.
   await supabase.auth.signInWithOtp({ email, options: { emailRedirectTo: callbackUrl } }).catch(() => null);
 
+  logEvent("oauth_login_magic_link_sent", { session_id: sessionId });
+
   return htmlResp(`<!doctype html><meta charset="utf-8"><title>Check your email</title>
     <body style="font-family: Arial, sans-serif; max-width: 420px; margin: 80px auto; padding: 24px; border: 2px solid #111;">
     <h1 style="font-size: 14px; letter-spacing: 2px; text-transform: uppercase;">Check your email</h1>
@@ -418,6 +483,13 @@ async function handleLogin(req: Request): Promise<Response> {
 async function handleCallback(req: Request): Promise<Response> {
   const url = new URL(req.url);
   const sessionId = url.searchParams.get("session") ?? "";
+  logEvent("oauth_callback", {
+    session_id: sessionId || null,
+    has_access_token: !!url.searchParams.get("access_token"),
+    has_token_hash: !!(url.searchParams.get("token_hash") ?? url.searchParams.get("token")),
+    has_code: !!url.searchParams.get("code"),
+    user_agent: req.headers.get("user-agent") ?? null,
+  });
   if (!sessionId) return errorPage("missing session id");
 
   // Supabase magic link redirect appends #access_token=...&refresh_token=... as URL fragment.
@@ -454,6 +526,7 @@ async function handleCallback(req: Request): Promise<Response> {
   // back to /oauth/callback-finish. Supabase magic-link redirects often put the token in
   // the fragment.
   if (!userId) {
+    logEvent("oauth_callback_fragment_fallback", { session_id: sessionId });
     return htmlResp(`<!doctype html><meta charset="utf-8"><title>Finishing login</title>
 <body style="font-family: Arial, sans-serif; max-width: 420px; margin: 80px auto; padding: 24px; border: 2px solid #111;">
 <h1 style="font-size: 14px; letter-spacing: 2px; text-transform: uppercase;">Finishing login</h1>
@@ -469,7 +542,8 @@ async function handleCallback(req: Request): Promise<Response> {
   const u = new URL(location.href);
   u.hash = "";
   const params = new URLSearchParams({ session: ${JSON.stringify(sessionId)}, access_token });
-  const res = await fetch("/oauth/callback-finish?" + params.toString(), { method: "POST" });
+  // Absolute URL — defensive against webview base resolution quirks (anthropics/claude-ai-mcp#8).
+  const res = await fetch("${CALLBACK_FINISH_ENDPOINT}?" + params.toString(), { method: "POST" });
   if (res.redirected) { location.href = res.url; return; }
   if (res.ok) {
     const j = await res.json().catch(() => ({}));
@@ -488,6 +562,10 @@ async function handleCallbackFinish(req: Request): Promise<Response> {
   const url = new URL(req.url);
   const sessionId = url.searchParams.get("session") ?? "";
   const accessToken = url.searchParams.get("access_token") ?? "";
+  logEvent("oauth_callback_finish", {
+    session_id: sessionId || null,
+    access_token_len: maskLen(accessToken),
+  });
   if (!sessionId || !accessToken) return jsonResp({ error: "missing params" }, 400);
   const supabase = makeServiceClient();
   const { data: u } = await supabase.auth.getUser(accessToken);
@@ -525,6 +603,14 @@ async function finishCallback(sessionId: string, userId: string): Promise<Respon
   redir.searchParams.set("code", code);
   if (sess.state) redir.searchParams.set("state", sess.state);
 
+  logEvent("oauth_finish_code_issued", {
+    session_id: sessionId,
+    user_id: userId,
+    client_id: sess.client_id,
+    code_len: maskLen(code),
+    redirect_uri: sess.redirect_uri,
+  });
+
   // For browser flow: redirect. For fetch-based polling, return JSON with redirect URL.
   return new Response(JSON.stringify({ redirect: redir.toString() }), {
     status: 200,
@@ -535,6 +621,10 @@ async function finishCallback(sessionId: string, userId: string): Promise<Respon
 // ── Route: POST /oauth/token ─────────────────────────────────────────────────
 
 async function handleToken(req: Request): Promise<Response> {
+  logEvent("oauth_token", {
+    content_type: req.headers.get("content-type") ?? null,
+    user_agent: req.headers.get("user-agent") ?? null,
+  });
   const ct = req.headers.get("content-type") ?? "";
   let body: Record<string, string> = {};
   if (ct.includes("application/x-www-form-urlencoded")) {
@@ -554,6 +644,13 @@ async function handleToken(req: Request): Promise<Response> {
 
 async function handleTokenAuthCode(body: Record<string, string>): Promise<Response> {
   const { code, client_id, redirect_uri, code_verifier } = body;
+  logEvent("oauth_token_authorization_code", {
+    grant_type: "authorization_code",
+    client_id: client_id ?? null,
+    redirect_uri: redirect_uri ?? null,
+    code_len: maskLen(code),
+    code_verifier_len: maskLen(code_verifier),
+  });
   if (!code || !client_id || !redirect_uri || !code_verifier) {
     return jsonResp({ error: "invalid_request", error_description: "Missing required parameters" }, 400);
   }
@@ -569,6 +666,12 @@ async function handleTokenAuthCode(body: Record<string, string>): Promise<Respon
   // PKCE verification.
   const expected = await base64UrlSha256(code_verifier);
   if (expected !== row.code_challenge) {
+    logEvent("oauth_token_pkce_mismatch", {
+      client_id,
+      code_verifier_len: maskLen(code_verifier),
+      expected_len: maskLen(expected),
+      stored_challenge_len: maskLen(row.code_challenge),
+    });
     return jsonResp({ error: "invalid_grant", error_description: "PKCE verification failed" }, 400);
   }
 
@@ -585,6 +688,16 @@ async function handleTokenAuthCode(body: Record<string, string>): Promise<Respon
 
   await supabase.from("oauth_clients").update({ last_used_at: new Date().toISOString() }).eq("client_id", client_id);
 
+  logEvent("oauth_token_issued", {
+    grant_type: "authorization_code",
+    client_id,
+    user_id: row.user_id,
+    scopes,
+    access_token_len: maskLen(accessToken),
+    refresh_token_len: maskLen(refreshToken),
+    expires_in: ACCESS_TOKEN_TTL_SECONDS,
+  });
+
   return jsonResp({
     access_token: accessToken,
     token_type: "Bearer",
@@ -596,6 +709,11 @@ async function handleTokenAuthCode(body: Record<string, string>): Promise<Respon
 
 async function handleTokenRefresh(body: Record<string, string>): Promise<Response> {
   const { refresh_token, client_id } = body;
+  logEvent("oauth_token_refresh", {
+    grant_type: "refresh_token",
+    client_id: client_id ?? null,
+    refresh_token_len: maskLen(refresh_token),
+  });
   if (!refresh_token) return jsonResp({ error: "invalid_request", error_description: "refresh_token required" }, 400);
 
   const key = await hmacKey();
@@ -616,6 +734,16 @@ async function handleTokenRefresh(body: Record<string, string>): Promise<Respons
   const accessToken = await mintAccessToken(String(payload.sub), email, scopes);
   const refreshNew = await mintRefreshToken(String(payload.sub), String(payload.cid));
 
+  logEvent("oauth_token_issued", {
+    grant_type: "refresh_token",
+    client_id: String(payload.cid),
+    user_id: String(payload.sub),
+    scopes,
+    access_token_len: maskLen(accessToken),
+    refresh_token_len: maskLen(refreshNew),
+    expires_in: ACCESS_TOKEN_TTL_SECONDS,
+  });
+
   return jsonResp({
     access_token: accessToken,
     token_type: "Bearer",
@@ -628,6 +756,7 @@ async function handleTokenRefresh(body: Record<string, string>): Promise<Respons
 // ── Route: POST /oauth/revoke ────────────────────────────────────────────────
 
 async function handleRevoke(_req: Request): Promise<Response> {
+  logEvent("oauth_revoke");
   // Stateless tokens — true revocation requires a denylist. Stub for spec compliance.
   return jsonResp({}, 200);
 }
@@ -673,6 +802,7 @@ Deno.serve(async (req) => {
     return jsonResp({ error: "not_found", path: route }, 404);
   } catch (e) {
     console.error("[oauth-server] handler error:", e);
+    logEvent("oauth_handler_error", { path, error_message: e instanceof Error ? e.message : String(e) });
     return jsonResp({ error: "server_error", error_description: e instanceof Error ? e.message : String(e) }, 500);
   }
 });


### PR DESCRIPTION
## Summary

Hardens tonight's `/oauth/*` server so Claude.ai mobile walks through cleanly, adds structured logging for diagnosis, and documents the two known Claude.ai client-side OAuth bugs.

- **Structured telemetry** at every endpoint via `logEvent()`. Secrets logged as **lengths only** (never plaintext). Events: `oauth_register`, `oauth_authorize`, `oauth_login`, `oauth_login_session_created`, `oauth_login_magic_link_sent`, `oauth_callback`, `oauth_callback_fragment_fallback`, `oauth_callback_finish`, `oauth_finish_code_issued`, `oauth_token_authorization_code`, `oauth_token_pkce_mismatch`, `oauth_token_issued`, `oauth_token_refresh`, `oauth_handler_error`.
- **Absolute form action** on `/oauth/authorize` (`https://nuke.ag/oauth/login`) and absolute fetch URL in the fragment-shim of `/oauth/callback` — defensive against Claude.ai webview base-URL resolution quirks (anthropics/claude-ai-mcp#8).
- **JWT alignment confirmed.** Tokens minted with `iss=${SUPABASE_URL}/auth/v1` are accepted by `supabase.auth.getUser()`. Round-trip verified end-to-end. Refactored secret read to `JWT_SIGNING_SECRET` (with `SUPABASE_JWT_SECRET` fallback for local dev) — Supabase CLI blocks setting `SUPABASE_*`-prefixed secrets, so deployed function reads from the un-prefixed name with the same value. **No key rotation.**
- **`scripts/test-oauth-flow.sh`** (npm `test:oauth-flow`): end-to-end DCR → authorize → login → seed-code → token → JWT-validate → refresh → replay-protection → metadata. Exits 0 green; 1 with specific failure mode.
- **`docs/api/CLAUDE_MOBILE_SETUP.md`**: appended troubleshooting for anthropics/claude-code#46140 ("OAuth completes but Bearer token never sent") and anthropics/claude-ai-mcp#8 ("OAuth fails on web — no requests reach server"). Each: symptom, root cause, concrete workarounds.

## Test plan

- [x] `dotenvx run -- bash scripts/test-oauth-flow.sh` → all 9 steps green against the deployed function
- [x] JWT round-trip via `supabase.auth.getUser()` returns the expected `user_id`
- [x] Form action HTML asserted as absolute (Step 2 of test script)
- [x] Replay-attack on used code returns `400 invalid_grant` (Step 8)
- [x] Refresh-token grant issues new access_token (Step 7)
- [ ] On mobile (post-merge): tap connector at `claude.ai/settings/connectors`, paste `https://nuke.ag/mcp`, complete magic-link flow

## Hard constraints honored

- No DELETEs from `oauth_clients`, `oauth_login_sessions`, `oauth_authorization_codes` (testimony preserved)
- No JWT signing key rotation
- Secrets never logged in plaintext
- Telemetry is purely additive (no behavior change to existing endpoints other than logging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)