### PR TITLE
fix(vehicle-profile): stop crash + schema-drift cleanup + 500 fix + perf

### DIFF
--- a/nuke_frontend/src/components/images/ImageGallery.tsx
+++ b/nuke_frontend/src/components/images/ImageGallery.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { supabase } from '../../lib/supabase';
 import { fetchVehicleImages } from '../../lib/fetchVehicleImages';
 import { ImageUploadService } from '../../services/imageUploadService';
@@ -289,6 +289,8 @@ const ImageGallery = ({
   const [allImages, setAllImages] = useState<any[]>([]);
   const [displayedImages, setDisplayedImages] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  // Dedup user_tools loads across auth-state churn (Supabase fires INITIAL_SESSION on subscribe).
+  const loadedToolsForUserRef = useRef<string | null>(null);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lightboxOpen, setLightboxOpen] = useState(false);
@@ -470,21 +472,25 @@ const ImageGallery = ({
       setLoading(true);
       try {
         // Load images from database
-        const { data: images, error } = await supabase
+        // Chained .or() with not.in.("a","b") syntax was producing PostgREST 500s.
+        // Fetch + filter client-side; result set is bounded by vehicle_id.
+        const { data: rawImages, error } = await supabase
           .from('vehicle_images')
           .select('*')
           .eq('vehicle_id', vehicleId)
-          // Quarantine/duplicate rows should never appear in standard galleries
-          .or('is_duplicate.is.null,is_duplicate.eq.false')
-          // Hide AI-detected mismatched/unrelated images
-          .or('image_vehicle_match_status.is.null,image_vehicle_match_status.not.in.("mismatch","unrelated")')
-          // Vision gate: only approved or legacy-NULL images appear in the gallery.
-          .or('vision_gate_status.is.null,vision_gate_status.eq.approved')
           .order('position', { ascending: true })
           .order('created_at', { ascending: true });
 
         if (error) throw error;
-        setAllImages(applyQuarantinePolicy(images || []));
+        const images = (rawImages || []).filter((r: any) => {
+          if (r?.is_duplicate === true) return false;
+          const mvms = r?.image_vehicle_match_status;
+          if (mvms === 'mismatch' || mvms === 'unrelated') return false;
+          const vgs = r?.vision_gate_status;
+          if (vgs != null && vgs !== 'approved') return false;
+          return true;
+        });
+        setAllImages(applyQuarantinePolicy(images));
         setVehicleMeta(vehicleMeta || null);
       } catch {
         setVehicleMeta(null);
@@ -1678,8 +1684,11 @@ const ImageGallery = ({
       if (session?.user?.id) {
         // Any logged in user can create tags - you can adjust this logic as needed
         setCanCreateTags(true);
-        // Load user's tool inventory
-        loadUserTools(session.user.id);
+        // Load user's tool inventory (dedup by userId)
+        if (loadedToolsForUserRef.current !== session.user.id) {
+          loadedToolsForUserRef.current = session.user.id;
+          loadUserTools(session.user.id);
+        }
       }
     };
 
@@ -1689,7 +1698,10 @@ const ImageGallery = ({
       setSession(session);
       setCanCreateTags(!!session?.user?.id);
       if (session?.user?.id) {
-        loadUserTools(session.user.id);
+        if (loadedToolsForUserRef.current !== session.user.id) {
+          loadedToolsForUserRef.current = session.user.id;
+          loadUserTools(session.user.id);
+        }
       }
     });
 

--- a/nuke_frontend/src/components/vehicle/DataValidationPopup.tsx
+++ b/nuke_frontend/src/components/vehicle/DataValidationPopup.tsx
@@ -47,53 +47,7 @@ const DataValidationPopup: React.FC<DataValidationPopupProps> = ({
       setLoading(true);
       const sources: ValidationSource[] = [];
 
-      // 0. VIN-specific: include conclusive, cited sources from data_validation_sources
-      if (fieldName === 'vin') {
-        const { data: vinSources, error: vinSourcesError } = await supabase
-          .from('data_validation_sources')
-          .select('id, source_type, source_image_id, source_url, confidence_score, extraction_method, verification_notes, created_at')
-          .eq('vehicle_id', vehicleId)
-          .eq('data_field', 'vin')
-          .order('confidence_score', { ascending: false })
-          .order('created_at', { ascending: false });
-
-        if (vinSourcesError) {
-          const status = (vinSourcesError as any)?.status;
-          const message = String((vinSourcesError as any)?.message || '');
-          // If migration/table isn't deployed yet, PostgREST returns 404. Ignore silently.
-          if (!(status === 404 || message.includes('404'))) {
-            throw vinSourcesError;
-          }
-        }
-
-        if (vinSources && vinSources.length > 0) {
-          const imageIds = vinSources.map((v: any) => v.source_image_id).filter(Boolean) as string[];
-          const imageUrlById = new Map<string, string>();
-          if (imageIds.length > 0) {
-            const { data: images } = await supabase
-              .from('vehicle_images')
-              .select('id, thumbnail_url, medium_url, image_url')
-              .in('id', imageIds);
-            images?.forEach((img: any) => {
-              imageUrlById.set(img.id, img.thumbnail_url || img.medium_url || img.image_url);
-            });
-          }
-
-          vinSources.forEach((v: any) => {
-            const imgUrl = v.source_image_id ? imageUrlById.get(v.source_image_id) : undefined;
-            sources.push({
-              validation_source: v.source_type || 'unknown_source',
-              confidence_score: typeof v.confidence_score === 'number' ? v.confidence_score : 0,
-              source_url: imgUrl || v.source_url || undefined,
-              notes: [
-                v.extraction_method ? `Method: ${v.extraction_method}` : null,
-                v.verification_notes ? v.verification_notes : null
-              ].filter(Boolean).join(' • '),
-              created_at: v.created_at
-            });
-          });
-        }
-      }
+      // 0. VIN-specific proofs feature unavailable (data_validation_sources table not deployed)
 
       // 1. Get ownership verifications (title, registration uploads)
       const { data: ownershipDocs } = await supabase

--- a/nuke_frontend/src/components/vehicle/VehicleCommentsCard.tsx
+++ b/nuke_frontend/src/components/vehicle/VehicleCommentsCard.tsx
@@ -323,6 +323,7 @@ export const VehicleCommentsCard: React.FC<VehicleCommentsCardProps> = ({
   };
 
   const renderCommentText = (text: string) => {
+    if (!text) return null;
     // Parse markdown-style meme references: [meme:Title](url)
     const memeRegex = /\[meme:([^\]]+)\]\(([^)]+)\)/g;
     const parts: React.ReactNode[] = [];
@@ -491,6 +492,7 @@ export const VehicleCommentsCard: React.FC<VehicleCommentsCardProps> = ({
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
             {visibleComments.map((comment) => {
+              if (!comment) return null;
               const displayDate = comment.posted_at || comment.created_at;
               // Check if this is a bid - either comment_type is 'bid' OR bid_amount is set
               const type = String(comment.comment_type || '').toLowerCase();
@@ -672,7 +674,7 @@ export const VehicleCommentsCard: React.FC<VehicleCommentsCardProps> = ({
                           </div>
                         ) : (
                           <>
-                            {renderCommentText(comment.comment_text)}
+                            {renderCommentText(comment.comment_text ?? '')}
                             {/* Show media URLs for Instagram/Facebook comments */}
                             {comment.media_urls && comment.media_urls.length > 0 && (
                               <div style={{ marginTop: '8px', display: 'flex', flexWrap: 'wrap', gap: '4px' }}>

--- a/nuke_frontend/src/components/wiring/harnessConstants.ts
+++ b/nuke_frontend/src/components/wiring/harnessConstants.ts
@@ -235,6 +235,29 @@ export const LOCATION_ZONES = [
   { value: 'roof', label: 'Roof' },
 ];
 
+// Canonical zone color palette. Re-exported via wiringTheme.ts.
+// Previously duplicated inline in WiringPlan.tsx and FormboardView.tsx.
+export const ZONE_COLORS: Record<string, string> = {
+  engine_bay: '#cc2222',
+  firewall:   '#cc6600',
+  dash:       '#2266cc',
+  doors:      '#8822cc',
+  rear:       '#22aa44',
+  underbody:  '#666666',
+  roof:       '#778899',
+  interior:   '#44bbcc',
+};
+
+export const ZONE_LABELS: Record<string, string> = Object.fromEntries(
+  LOCATION_ZONES.map(z => [z.value, z.label]),
+);
+
+// Canonical segment-key helper for harness graph edges.
+// Stable, order-independent key for an unordered pair of node ids.
+export function segmentKey(a: string, b: string): string {
+  return a < b ? `${a}::${b}` : `${b}::${a}`;
+}
+
 // Section type colors (defaults)
 export const SECTION_COLORS: Record<string, string> = {
   engine: '#d13438',

--- a/nuke_frontend/src/components/wiring/useOverlayCompute.ts
+++ b/nuke_frontend/src/components/wiring/useOverlayCompute.ts
@@ -1,13 +1,18 @@
 // useOverlayCompute.ts — React hook for real-time harness computation
 // Recomputes on every manifest change. No API calls. Instant.
 
-import { useMemo, useCallback, useRef, useState } from 'react';
+import { useMemo, useCallback, useRef, useState, useEffect } from 'react';
 import { computeOverlay, computeDelta, type ManifestDevice, type OverlayResult, type OverlayDelta } from './overlayCompute';
 import { computeTerminations, summarizeTerminationReadiness } from './terminationCompute';
 
 export function useOverlayCompute(initialDevices: ManifestDevice[] = []) {
   const [devices, setDevices] = useState<ManifestDevice[]>(initialDevices);
   const previousResult = useRef<OverlayResult | null>(null);
+
+  // Sync internal state when the source manifest array changes (async fetch lands)
+  useEffect(() => {
+    setDevices(initialDevices);
+  }, [initialDevices]);
 
   // Compute overlay — memoized, only recalculates when devices change
   const result = useMemo(() => computeOverlay(devices), [devices]);

--- a/nuke_frontend/src/hooks/useVINProofs.ts
+++ b/nuke_frontend/src/hooks/useVINProofs.ts
@@ -40,6 +40,11 @@ export function useVINProofs(vehicleId: string | undefined) {
       return;
     }
 
+    // data_validation_sources table is not deployed; short-circuit until feature lands.
+    setSummary(null);
+    setLoading(false);
+    return;
+
     async function loadProofs() {
       try {
         // Canonical VIN proof table: data_validation_sources (vin proofs should always cite a source)

--- a/nuke_frontend/src/hooks/useValuationIntel.ts
+++ b/nuke_frontend/src/hooks/useValuationIntel.ts
@@ -45,12 +45,6 @@ export const useValuationIntel = (vehicleId: string | null): ValuationIntelResul
           .limit(1)
           .maybeSingle();
 
-        const componentsPromise = supabase
-          .from('vehicle_valuations_components')
-          .select('*')
-          .eq('vehicle_id', vehicleId)
-          .order('estimated_value', { ascending: false, nulls: 'last' });
-
         const readinessPromise = supabase
           .from('financial_readiness_snapshots')
           .select('*')
@@ -59,23 +53,20 @@ export const useValuationIntel = (vehicleId: string | null): ValuationIntelResul
           .limit(1)
           .maybeSingle();
 
-        const [{ data: valuationRow, error: valuationError }, { data: componentRows, error: componentsError }, { data: readinessRow, error: readinessError }] =
-          await Promise.all([valuationPromise, componentsPromise, readinessPromise]);
+        const [{ data: valuationRow, error: valuationError }, { data: readinessRow, error: readinessError }] =
+          await Promise.all([valuationPromise, readinessPromise]);
 
         if (!isMounted) return;
 
         if (valuationError) {
           throw valuationError;
         }
-        if (componentsError) {
-          throw componentsError;
-        }
         if (readinessError) {
           console.warn('[useValuationIntel] readiness snapshot unavailable:', readinessError.message);
         }
 
         setValuation(valuationRow || null);
-        setComponents(componentRows || []);
+        setComponents(Array.isArray(valuationRow?.components) ? valuationRow.components : []);
         setReadiness(readinessRow || null);
         setRefreshedAt(new Date().toISOString());
       } catch (err: any) {

--- a/nuke_frontend/src/hooks/useVehiclePermissions.ts
+++ b/nuke_frontend/src/hooks/useVehiclePermissions.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { OwnershipService } from '../services/ownershipService';
 
 interface VehiclePermissions {
@@ -26,11 +26,18 @@ export const useVehiclePermissions = (
     loading: true
   });
 
+  // Dedup permission checks against repeated emissions of the same vehicleId+userId pair.
+  const lastCheckedRef = useRef<string | null>(null);
+
   useEffect(() => {
     if (!session?.user || !vehicleId) {
       setPermissions(prev => ({ ...prev, loading: false }));
       return;
     }
+
+    const key = `${vehicleId}:${session.user.id}`;
+    if (lastCheckedRef.current === key) return;
+    lastCheckedRef.current = key;
 
     const checkPermissions = async () => {
       try {

--- a/nuke_frontend/src/lib/fetchVehicleImages.ts
+++ b/nuke_frontend/src/lib/fetchVehicleImages.ts
@@ -20,25 +20,15 @@ export async function fetchVehicleImages<T = any>(
   let from = 0;
 
   while (true) {
-    let query = supabase
+    // Chained .or() with not.in.("a","b") was producing PostgREST 500s.
+    // Server-side filters that work cleanly stay; the OR-chain filters move client-side.
+    const query = supabase
       .from('vehicle_images')
       .select(selectClause)
       .eq('vehicle_id', vehicleId)
       .not('is_document', 'is', true)
       .not('is_duplicate', 'is', true)
-      .not('image_url', 'is', null);
-
-    if (options.includeMismatchFilter) {
-      query = query.or('image_vehicle_match_status.is.null,image_vehicle_match_status.not.in.("mismatch","unrelated")');
-    }
-
-    // Vision gate: hide images the agent hasn't approved yet.
-    // - NULL = legacy row (pre-2026-05-03), wait for retroactive review pass; show for now
-    // - 'approved' = agent confirmed vehicle content + correct attribution
-    // - 'pending' / 'rejected_*' / 'review_needed' = withhold from gallery
-    query = query.or('vision_gate_status.is.null,vision_gate_status.eq.approved');
-
-    query = query
+      .not('image_url', 'is', null)
       .order('is_primary', { ascending: false })
       .order('position', { ascending: true, nullsFirst: false })
       .order('created_at', { ascending: true })
@@ -47,10 +37,21 @@ export async function fetchVehicleImages<T = any>(
     const { data, error } = await query;
     if (error) throw error;
 
-    const batch = (data || []) as T[];
-    rows.push(...batch);
+    const rawBatch = (data || []) as any[];
+    const filtered = rawBatch.filter((r: any) => {
+      if (options.includeMismatchFilter) {
+        const mvms = r?.image_vehicle_match_status;
+        if (mvms === 'mismatch' || mvms === 'unrelated') return false;
+      }
+      const vgs = r?.vision_gate_status;
+      if (vgs != null && vgs !== 'approved') return false;
+      return true;
+    }) as T[];
+    rows.push(...filtered);
 
-    if (batch.length < PAGE_SIZE) break;
+    // Pagination break MUST use raw page size — filtering can drop rows but the
+    // next page may still have unfiltered ones.
+    if (rawBatch.length < PAGE_SIZE) break;
     from += PAGE_SIZE;
   }
 

--- a/nuke_frontend/src/pages/WiringPlan.tsx
+++ b/nuke_frontend/src/pages/WiringPlan.tsx
@@ -10,7 +10,7 @@ import { supabase } from '../lib/supabase';
 import type { ManifestDevice, WireSpec } from '../components/wiring/overlayCompute';
 import { useOverlayCompute } from '../components/wiring/useOverlayCompute';
 import { DeviceDetailPanel } from '../components/wiring/DeviceDetailPanel';
-import { FormboardView } from '../components/wiring/FormboardView';
+import { FormboardCanvas } from '../components/wiring/FormboardCanvas';
 import { SchematicView } from '../components/wiring/SchematicView';
 import { HarnessView3D } from '../components/wiring/HarnessView3D';
 import { DataView } from '../components/wiring/DataView';
@@ -391,7 +391,14 @@ export default function WiringPlan() {
       <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
         {/* All views stay mounted but hidden for camera persistence */}
         <div style={{ position: 'absolute', inset: 0, display: activeTab === 'formboard' ? 'block' : 'none' }}>
-          <FormboardView {...viewProps} cameraRef={cameraRefs.current.formboard} />
+          <FormboardCanvas
+            vehicleId={vehicleId || ''}
+            devices={overlay.devices}
+            selectedDeviceId={selectedDeviceId}
+            onSelectDevice={(id) => id ? handleDeviceClick(id) : handleDeselect()}
+            drcMap={drc.drcMap}
+            mode="formboard"
+          />
         </div>
         <div style={{ position: 'absolute', inset: 0, display: activeTab === 'schematics' ? 'block' : 'none' }}>
           <SchematicView {...viewProps} cameraRef={cameraRefs.current.schematics} />

--- a/nuke_frontend/src/pages/WiringPlan.tsx
+++ b/nuke_frontend/src/pages/WiringPlan.tsx
@@ -4,19 +4,34 @@
 // Hosts DeviceDetailPanel (right-side), CommandPalette (overlay)
 // Keyboard shortcuts: 1-5 tabs, F fit, Esc deselect, Cmd+K search
 
-import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
+import React, { Suspense, useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import type { ManifestDevice, WireSpec } from '../components/wiring/overlayCompute';
 import { useOverlayCompute } from '../components/wiring/useOverlayCompute';
 import { DeviceDetailPanel } from '../components/wiring/DeviceDetailPanel';
-import { FormboardCanvas } from '../components/wiring/FormboardCanvas';
-import { SchematicView } from '../components/wiring/SchematicView';
-import { HarnessView3D } from '../components/wiring/HarnessView3D';
-import { DataView } from '../components/wiring/DataView';
 import { CommandPalette } from '../components/wiring/CommandPalette';
-import { TopologyView } from '../components/wiring/TopologyView';
 import { useDRC } from '../components/wiring/useDRC';
+
+// Tab views are lazy-loaded so initial paint only pays for the active tab.
+// The 3D tab pulls Three.js (~2.7MB), schematics/data/topology each have their
+// own weight, and formboard is the 2,552-line WHMA-A-620 build — eager-loading
+// all five was the cause of slow first-paint.
+const FormboardCanvas = React.lazy(() =>
+  import('../components/wiring/FormboardCanvas').then(m => ({ default: m.FormboardCanvas })),
+);
+const SchematicView = React.lazy(() =>
+  import('../components/wiring/SchematicView').then(m => ({ default: m.SchematicView })),
+);
+const HarnessView3D = React.lazy(() =>
+  import('../components/wiring/HarnessView3D').then(m => ({ default: m.HarnessView3D })),
+);
+const DataView = React.lazy(() =>
+  import('../components/wiring/DataView').then(m => ({ default: m.DataView })),
+);
+const TopologyView = React.lazy(() =>
+  import('../components/wiring/TopologyView').then(m => ({ default: m.TopologyView })),
+);
 
 // ── Design tokens ─────────────────────────────────────────────────────
 const C = {
@@ -388,40 +403,57 @@ export default function WiringPlan() {
       </div>
 
       {/* ── View Container ── */}
+      {/* Only the active tab is mounted. Camera state lives in cameraRefs (outside
+          React tree) so it survives unmount/remount. */}
       <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
-        {/* All views stay mounted but hidden for camera persistence */}
-        <div style={{ position: 'absolute', inset: 0, display: activeTab === 'formboard' ? 'block' : 'none' }}>
-          <FormboardCanvas
-            vehicleId={vehicleId || ''}
-            devices={overlay.devices}
-            selectedDeviceId={selectedDeviceId}
-            onSelectDevice={(id) => id ? handleDeviceClick(id) : handleDeselect()}
-            drcMap={drc.drcMap}
-            mode="formboard"
-          />
-        </div>
-        <div style={{ position: 'absolute', inset: 0, display: activeTab === 'schematics' ? 'block' : 'none' }}>
-          <SchematicView {...viewProps} cameraRef={cameraRefs.current.schematics} />
-        </div>
-        <div style={{ position: 'absolute', inset: 0, display: activeTab === '3d' ? 'block' : 'none' }}>
-          <HarnessView3D {...viewProps} />
-        </div>
-        <div style={{ position: 'absolute', inset: 0, display: activeTab === 'data' ? 'block' : 'none' }}>
-          <DataView {...viewProps} overlay={overlay} />
-        </div>
-        <div style={{ position: 'absolute', inset: 0, display: activeTab === 'topology' ? 'block' : 'none' }}>
-          <TopologyView
-            devices={overlay.devices}
-            wires={overlay.result.wires}
-            result={overlay.result}
-            selectedDeviceId={selectedDeviceId}
-            selectedDeviceIds={selectedDeviceIds}
-            selectedWireId={selectedWireId}
-            onDeviceClick={(id, e) => handleDeviceClick(id, e.shiftKey)}
-            onWireClick={handleWireClick}
-            drcMap={drc.drcMap}
-          />
-        </div>
+        <Suspense fallback={
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: C.muted, fontFamily: "'Courier New', monospace", fontSize: 11 }}>
+            LOADING VIEW...
+          </div>
+        }>
+          {activeTab === 'formboard' && (
+            <div style={{ position: 'absolute', inset: 0 }}>
+              <FormboardCanvas
+                vehicleId={vehicleId || ''}
+                devices={overlay.devices}
+                selectedDeviceId={selectedDeviceId}
+                onSelectDevice={(id) => id ? handleDeviceClick(id) : handleDeselect()}
+                drcMap={drc.drcMap}
+                mode="formboard"
+              />
+            </div>
+          )}
+          {activeTab === 'schematics' && (
+            <div style={{ position: 'absolute', inset: 0 }}>
+              <SchematicView {...viewProps} cameraRef={cameraRefs.current.schematics} />
+            </div>
+          )}
+          {activeTab === '3d' && (
+            <div style={{ position: 'absolute', inset: 0 }}>
+              <HarnessView3D {...viewProps} />
+            </div>
+          )}
+          {activeTab === 'data' && (
+            <div style={{ position: 'absolute', inset: 0 }}>
+              <DataView {...viewProps} overlay={overlay} />
+            </div>
+          )}
+          {activeTab === 'topology' && (
+            <div style={{ position: 'absolute', inset: 0 }}>
+              <TopologyView
+                devices={overlay.devices}
+                wires={overlay.result.wires}
+                result={overlay.result}
+                selectedDeviceId={selectedDeviceId}
+                selectedDeviceIds={selectedDeviceIds}
+                selectedWireId={selectedWireId}
+                onDeviceClick={(id, e) => handleDeviceClick(id, e.shiftKey)}
+                onWireClick={handleWireClick}
+                drcMap={drc.drcMap}
+              />
+            </div>
+          )}
+        </Suspense>
 
         {/* ── Detail Panel (slides in from right) ── */}
         <DeviceDetailPanel

--- a/nuke_frontend/src/pages/vehicle-profile/loadVehicleData.ts
+++ b/nuke_frontend/src/pages/vehicle-profile/loadVehicleData.ts
@@ -96,98 +96,93 @@ export async function selectBestHeroImage(
   vehicleId: string,
   supabase: any,
   primaryImageUrl?: string | null,
+  prefetchedImages?: any[],
 ): Promise<HeroImageResult | null> {
   try {
-    // Attempt 0: explicit is_primary wins unconditionally.
-    // With contain mode as default, any orientation works — the full image is always visible.
-    const { data: primaryRows, error: primaryErr } = await supabase
-      .from('vehicle_images')
-      .select('image_url, medium_url, large_url, photo_quality_score, zone_confidence, vehicle_zone, exif_data, taken_at, position, angle, ai_detected_angle')
-      .eq('vehicle_id', vehicleId)
-      .eq('is_primary', true)
-      .not('is_document', 'is', true)
-      .not('is_duplicate', 'is', true)
-      .limit(1);
+    // Coalesce the prior 4 sequential queries into one round-trip.
+    // Strategy: pull a generous candidate window ordered by (is_primary, quality, ai recency),
+    // then apply the same priority logic client-side. If the caller already has the image list,
+    // skip the network call entirely.
+    let candidates: any[] | null = null;
 
-    if (!primaryErr && primaryRows && primaryRows.length > 0) {
-      return buildHeroResult(primaryRows[0]);
+    if (prefetchedImages && prefetchedImages.length > 0) {
+      candidates = prefetchedImages;
+    } else {
+      const { data, error } = await supabase
+        .from('vehicle_images')
+        .select(
+          'image_url, medium_url, large_url, photo_quality_score, zone_confidence, vehicle_zone, exif_data, taken_at, position, angle, ai_detected_angle, source, is_primary, is_document, is_duplicate, image_vehicle_match_status, ai_processing_status, created_at'
+        )
+        .eq('vehicle_id', vehicleId)
+        .order('is_primary', { ascending: false, nullsFirst: false })
+        .order('photo_quality_score', { ascending: false, nullsFirst: false })
+        .order('created_at', { ascending: false, nullsFirst: false })
+        .limit(60);
+
+      if (error) {
+        console.warn('[selectBestHeroImage] query error:', error);
+      }
+      candidates = data || null;
     }
 
-    // Attempt 1: front-facing exterior zones with completed AI processing
-    // Only trust images where match_status is explicitly 'match' or from trusted sources
-    const { data: frontImages, error: frontErr } = await supabase
-      .from('vehicle_images')
-      .select('image_url, medium_url, large_url, photo_quality_score, zone_confidence, vehicle_zone, exif_data, taken_at, position, angle, ai_detected_angle, source')
-      .eq('vehicle_id', vehicleId)
-      .eq('ai_processing_status', 'completed')
-      .or('image_vehicle_match_status.is.null,image_vehicle_match_status.not.in.("mismatch","unrelated")')
-      .in('vehicle_zone', ['ext_front', 'ext_front_driver', 'ext_front_passenger'])
-      .order('photo_quality_score', { ascending: false })
-      .limit(20);
+    if (!candidates || candidates.length === 0) {
+      if (primaryImageUrl) return { url: primaryImageUrl, meta: {} };
+      return null;
+    }
 
-    if (!frontErr && frontImages && frontImages.length > 0) {
-      // Prefer images from trusted sources (bat_import_mirrored, user_upload) over
-      // unverified bulk imports (iphoto, photo_auto_sync, drop-folder) which may
-      // contain photos from different vehicles.
-      const trustedSources = new Set(['bat_import_mirrored', 'bat_import', 'user_upload', 'manual']);
-      const scored = frontImages.map((img: any) => {
+    // Filter out documents/duplicates and mismatch-flagged rows
+    const usable = candidates.filter((img: any) => {
+      if (img?.is_document === true) return false;
+      if (img?.is_duplicate === true) return false;
+      const mvms = img?.image_vehicle_match_status;
+      if (mvms === 'mismatch' || mvms === 'unrelated') return false;
+      return true;
+    });
+
+    if (usable.length === 0) {
+      if (primaryImageUrl) return { url: primaryImageUrl, meta: {} };
+      return null;
+    }
+
+    // Priority 0: explicit primary
+    const primary = usable.find((img: any) => img?.is_primary === true);
+    if (primary) return buildHeroResult(primary);
+
+    const trustedSources = new Set(['bat_import_mirrored', 'bat_import', 'user_upload', 'manual']);
+    const frontZones = new Set(['ext_front', 'ext_front_driver', 'ext_front_passenger']);
+
+    // Priority 1: front-facing exterior, AI completed
+    const fronts = usable.filter(
+      (img: any) => img?.ai_processing_status === 'completed' && frontZones.has(img?.vehicle_zone)
+    );
+    if (fronts.length > 0) {
+      const scored = fronts.map((img: any) => {
         const base = scoreHeroCandidate(img, { frontExterior: true });
         const trusted = trustedSources.has(img.source) ? 50 : 0;
-        return { ...img, _score: base + trusted };
+        return { img, score: base + trusted };
       });
-      scored.sort((a: any, b: any) => b._score - a._score);
-      return buildHeroResult(scored[0]);
+      scored.sort((a, b) => b.score - a.score);
+      return buildHeroResult(scored[0].img);
     }
 
-    // Attempt 2: any zone, but still prefer true "money shot" exterior candidates
-    const { data: anyImages, error: anyErr } = await supabase
-      .from('vehicle_images')
-      .select('image_url, medium_url, large_url, photo_quality_score, zone_confidence, vehicle_zone, exif_data, taken_at, position, angle, ai_detected_angle, source')
-      .eq('vehicle_id', vehicleId)
-      .not('photo_quality_score', 'is', null)
-      .or('image_vehicle_match_status.is.null,image_vehicle_match_status.not.in.("mismatch","unrelated")')
-      .order('photo_quality_score', { ascending: false })
-      .limit(40);
-
-    if (!anyErr && anyImages && anyImages.length > 0) {
-      const trustedSources = new Set(['bat_import_mirrored', 'bat_import', 'user_upload', 'manual']);
-      const scored = anyImages.map((img: any) => {
+    // Priority 2: any zone with a quality score
+    const scored2 = usable
+      .filter((img: any) => img?.photo_quality_score != null)
+      .map((img: any) => {
         const base = scoreHeroCandidate(img);
         const trusted = trustedSources.has(img.source) ? 50 : 0;
-        return { ...img, _score: base + trusted };
+        return { img, score: base + trusted };
       });
-      scored.sort((a: any, b: any) => b._score - a._score);
-      return buildHeroResult(scored[0]);
+    if (scored2.length > 0) {
+      scored2.sort((a, b) => b.score - a.score);
+      return buildHeroResult(scored2[0].img);
     }
 
-    // Attempt 2.5: any non-document, non-duplicate image (no AI filtering)
-    const { data: anyImage, error: anyImageErr } = await supabase
-      .from('vehicle_images')
-      .select('image_url, medium_url, large_url, exif_data, taken_at')
-      .eq('vehicle_id', vehicleId)
-      .not('is_document', 'is', true)
-      .not('is_duplicate', 'is', true)
-      .or('image_vehicle_match_status.is.null,image_vehicle_match_status.not.in.("mismatch","unrelated")')
-      .order('is_primary', { ascending: false })
-      .order('created_at', { ascending: false })
-      .limit(1);
-
-    if (!anyImageErr && anyImage && anyImage.length > 0) {
-      return buildHeroResult(anyImage[0]);
-    }
-
-    // Attempt 3: fall back to primary_image_url
-    if (primaryImageUrl) {
-      return { url: primaryImageUrl, meta: {} };
-    }
-
-    return null;
+    // Priority 3: any usable image (candidates are already ordered by is_primary, quality, created_at)
+    return buildHeroResult(usable[0]);
   } catch (err) {
     console.warn('[selectBestHeroImage] error:', err);
-    // Non-fatal — fall back to primary
-    if (primaryImageUrl) {
-      return { url: primaryImageUrl, meta: {} };
-    }
+    if (primaryImageUrl) return { url: primaryImageUrl, meta: {} };
     return null;
   }
 }

--- a/nuke_frontend/src/pages/vehicle-profile/loadVehicleImages.ts
+++ b/nuke_frontend/src/pages/vehicle-profile/loadVehicleImages.ts
@@ -44,26 +44,28 @@ export async function loadVehicleImagesImpl({
 
   // Load images from database first
   try {
-    const { data: imageRecords, error } = await supabase
+    // NOTE: Chained `.or()` calls combined with `.not.in.("a","b")` syntax were producing
+    // PostgREST 500s (server-side timeout / planner failure). Bounded to vehicle_id, the
+    // result set is small enough to fetch + filter client-side without measurable cost.
+    const { data: rawImageRecords, error } = await supabase
       .from('vehicle_images')
-      // Keep payload lean to reduce DB load/timeouts; we only need URLs + ordering fields here.
-      .select('id, vehicle_id, image_url, thumbnail_url, medium_url, variants, is_primary, is_document, position, created_at, storage_path')
+      .select('id, vehicle_id, image_url, thumbnail_url, medium_url, variants, is_primary, is_document, is_duplicate, image_vehicle_match_status, vision_gate_status, position, created_at, storage_path')
       .eq('vehicle_id', vehicle.id)
-      // Legacy rows may have is_document = NULL; treat that as "not a document"
-      .not('is_document', 'is', true) // Filter out documents - they belong in a separate section
-      // Quarantine/duplicate rows should never appear in standard galleries
-      .or('is_duplicate.is.null,is_duplicate.eq.false')
-      // Hide AI-detected mismatched/unrelated images (wrong vehicle or not a vehicle photo)
-      .or('image_vehicle_match_status.is.null,image_vehicle_match_status.not.in.("mismatch","unrelated")')
-      // Vision gate: hide images that haven't been agent-classified yet, or that the agent
-      // rejected as personal / misattributed. Legacy rows (NULL) stay visible — they wait
-      // for the retroactive review pass.
-      .or('vision_gate_status.is.null,vision_gate_status.eq.approved')
       .order('is_primary', { ascending: false })
-        // IMPORTANT: NULL positions should sort LAST (older backfills didn't set position).
         .order('position', { ascending: true, nullsFirst: false })
-        // For un-positioned rows, show in chronological insert order (stable, matches source list order better than DESC).
         .order('created_at', { ascending: true });
+
+    const imageRecords = Array.isArray(rawImageRecords)
+      ? rawImageRecords.filter((r: any) => {
+          if (r?.is_document === true) return false;
+          if (r?.is_duplicate === true) return false;
+          const mvms = r?.image_vehicle_match_status;
+          if (mvms === 'mismatch' || mvms === 'unrelated') return false;
+          const vgs = r?.vision_gate_status;
+          if (vgs != null && vgs !== 'approved') return false;
+          return true;
+        })
+      : null;
 
     if (error) {
       console.error('❌ Error loading vehicle images from database:', error);

--- a/nuke_frontend/src/services/referenceDocumentService.ts
+++ b/nuke_frontend/src/services/referenceDocumentService.ts
@@ -71,6 +71,7 @@ export class ReferenceDocumentService {
     userId: string,
     options: DocumentUploadOptions
   ): Promise<ReferenceDocument> {
+    throw new Error('Reference documents feature is not deployed');
     try {
       const { file, document_type, title, description, auto_index = true, ...metadata } = options;
 
@@ -145,6 +146,7 @@ export class ReferenceDocumentService {
     fileUrl: string,
     userId: string
   ): Promise<void> {
+    throw new Error('Reference documents feature is not deployed');
     try {
       // Determine which indexing function to use based on document type
       if (documentType === 'parts_catalog') {
@@ -190,6 +192,7 @@ export class ReferenceDocumentService {
    * Get user's reference documents
    */
   static async getUserDocuments(userId: string, includePublic = false): Promise<ReferenceDocument[]> {
+    return [];
     try {
       const query = supabase
         .from('reference_documents')
@@ -215,6 +218,7 @@ export class ReferenceDocumentService {
    * Get public reference documents
    */
   static async getPublicDocuments(userId?: string): Promise<ReferenceDocument[]> {
+    return [];
     try {
       const { data, error } = await supabase
         .from('reference_documents')
@@ -234,6 +238,7 @@ export class ReferenceDocumentService {
    * Get documents linked to a vehicle
    */
   static async getVehicleDocuments(vehicleId: string): Promise<ReferenceDocument[]> {
+    return [];
     try {
       // Preferred: RPC (lets the backend choose the right joins + ordering).
       // Cache missing-RPC environments (per-host) to avoid repeated 404/PGRST202 spam.
@@ -336,6 +341,7 @@ export class ReferenceDocumentService {
     linkType: 'owner' | 'public' | 'shared' = 'owner',
     notes?: string
   ): Promise<void> {
+    throw new Error('Reference documents feature is not deployed');
     try {
       const { error } = await supabase
         .from('vehicle_reference_documents')
@@ -367,6 +373,7 @@ export class ReferenceDocumentService {
     documentId: string,
     vehicleId: string
   ): Promise<void> {
+    throw new Error('Reference documents feature is not deployed');
     try {
       const { error } = await supabase
         .from('vehicle_reference_documents')
@@ -385,6 +392,7 @@ export class ReferenceDocumentService {
    * Delete a reference document
    */
   static async deleteDocument(documentId: string, userId: string): Promise<void> {
+    throw new Error('Reference documents feature is not deployed');
     try {
       // Get document to find file path
       const { data: doc, error: docError } = await supabase
@@ -429,6 +437,7 @@ export class ReferenceDocumentService {
     userId: string,
     updates: Partial<ReferenceDocument>
   ): Promise<ReferenceDocument> {
+    throw new Error('Reference documents feature is not deployed');
     try {
       const { data, error } = await supabase
         .from('reference_documents')
@@ -453,6 +462,7 @@ export class ReferenceDocumentService {
     documentId: string,
     statType: 'view' | 'download' | 'bookmark'
   ): Promise<void> {
+    return;
     try {
       await supabase.rpc('increment_document_stat', {
         p_document_id: documentId,


### PR DESCRIPTION
## Summary
- **Stops the hard crash** in `VehicleCommentsCard` (null on `.map`) that was hitting AuthErrorBoundary and killing the vehicle profile page tree.
- **Silences 5 schema-drift PGRST205 404s** from queries against tables that no longer exist in the prod DB (`reference_documents`, `vehicle_reference_documents`, `data_validation_sources`, `vehicle_valuations_components`, `vin_proofs`).
- **Fixes the 2x server 500s** on the profile page — chained `.or()` filters with `not.in.("a","b")` syntax against `vehicle_images` were timing out / failing the PostgREST planner. Replaced with one bounded query + client-side filter.
- **Perf wins:** hero image picker 4→1 queries; `ImageGallery` `loadUserTools` no longer fires 3×; `useVehiclePermissions` no longer fires 2×.
- Bundles wiring branch's prior commits (formboard tab swap, lazy-load tab views, useOverlayCompute sync, harnessConstants exports) — they're already on this branch and need to land too.

## Why
The vehicle profile is the most important page on nuke.ag — where users actually view their data. It's been bleeding crashes + schema drift for months. Browser console on a real profile showed the hard crash, five 404s, two 500s, and redundant fetches. Verified table-existence against the live DB (project `qkgaybvrernstplzjaam`) before any rename/strangle decision; the dead tables really are gone, so the right move is short-circuit the dead queries rather than try to map columns into the surviving tables (which have different shapes).

## Test plan
- [ ] Open `https://nuke.ag/vehicle/e08bf694-970f-4cbe-8a74-8715158a0f2e` after deploy; confirm:
  - [ ] No `Cannot read properties of null (reading 'length')` error in console
  - [ ] No AuthErrorBoundary catch
  - [ ] Zero PGRST205 404s for the 5 dead tables
  - [ ] Zero 500s on `vehicle_images` queries
  - [ ] `[useVehiclePermissions] Status:` logs ONCE per page load (not twice)
  - [ ] `Loaded N tools for user` logs ONCE (not three times)
- [ ] Regression: load 2-3 other vehicle profiles (a BaT-imported one, the 1995 Suburban, the K5) to verify no behavior change in image gallery / hero selection.
- [ ] Wiring tab regression: load `/wiring/:vehicleId`, switch through tabs, confirm Formboard + Schematics tabs render and overlay compute still triggers on manifest fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vehicle image loading reliability by moving filtering to client-side, avoiding server errors.
  * Fixed comment rendering to handle missing or empty text gracefully.

* **New Features**
  * Optimized Wiring Plan performance with lazy-loaded tab views.

* **Changes**
  * VIN-specific validation proofs feature is unavailable.
  * Reference documents feature is disabled.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sss97133/nuke/pull/255)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->