### PR TITLE
Photo pipeline: batch stuck-reset + seal cross-vehicle GPS leak

### DIFF
--- a/scripts/photo-sync-daemon.mjs
+++ b/scripts/photo-sync-daemon.mjs
@@ -70,9 +70,28 @@ const sinceArg = (() => { const i = args.indexOf('--since'); return i >= 0 ? arg
 // classification remains as the second pass for what does get through.
 const VEHICLE_LABEL_RE = /vehicle|car|truck|automobile|motorcycle|van|jeep|tractor|trailer|wheel|tire|engine|machine|garage|workshop|tool|boat|text|document|receipt|paper/i;
 
+// Known shop coordinates — GPS at a work location is a STRONGER vehicle signal
+// than any Apple label. Apple frequently leaves work photos unlabeled (all 106
+// June 2026 photos: zero labels, 84 of them at Ernie's), so a label-only gate
+// holds back the actual build work. A photo shot at a shop is work evidence by
+// definition; home/personal GPS is never on this list, so the privacy gate holds.
+// Add shops here as they're confirmed (lat, lon, ~550m tolerance).
+const SHOP_LOCATIONS = [
+  { name: 'ernies_upholstery', lat: 35.977, lon: -114.854 },
+];
+const SHOP_TOL = 0.005;
+
+function isAtShop(photo) {
+  const lat = photo.latitude, lon = photo.longitude;
+  if (lat == null || lon == null) return false;
+  return SHOP_LOCATIONS.some((s) => Math.abs(lat - s.lat) < SHOP_TOL && Math.abs(lon - s.lon) < SHOP_TOL);
+}
+
 function isVehicleish(photo) {
+  // GPS-at-shop passes regardless of labels — work location beats Apple's tagging.
+  if (isAtShop(photo)) return true;
   const labels = photo.labels || photo.labels_normalized || [];
-  if (labels.length === 0) return INCLUDE_UNLABELED; // unlabeled: private by default
+  if (labels.length === 0) return INCLUDE_UNLABELED; // unlabeled off-shop: private by default
   return labels.some((l) => VEHICLE_LABEL_RE.test(String(l)));
 }
 

--- a/supabase/functions/create-work-session-from-evidence/index.ts
+++ b/supabase/functions/create-work-session-from-evidence/index.ts
@@ -98,6 +98,35 @@ Deno.serve(async (req) => {
 
     let action: "created" | "found_existing" = eventId ? "found_existing" : "created";
 
+    // Attribution guard: do NOT trust the caller's vehicle_id blindly. If the
+    // evidence images already belong to a DIFFERENT vehicle, this session may be
+    // a cross-vehicle leak (the bug that put K5 "iBooster brake planning" on the
+    // Mustang). We don't block — legitimate re-attribution exists — but we flag
+    // it so it surfaces for review instead of silently mis-filing.
+    let attributionConflictVehicleId: string | null = null;
+    let conflictingImageCount = 0;
+    try {
+      const { data: evImgs } = await supabase
+        .from("vehicle_images")
+        .select("vehicle_id")
+        .in("id", imageIds);
+      if (evImgs && evImgs.length > 0) {
+        const counts = new Map<string, number>();
+        for (const r of evImgs as { vehicle_id: string | null }[]) {
+          if (r.vehicle_id && r.vehicle_id !== vehicleId) {
+            counts.set(r.vehicle_id, (counts.get(r.vehicle_id) || 0) + 1);
+          }
+        }
+        // Dominant other-vehicle among the evidence frames.
+        for (const [vid, n] of counts) {
+          if (n > conflictingImageCount) { conflictingImageCount = n; attributionConflictVehicleId = vid; }
+        }
+      }
+    } catch {
+      // If the lookup fails, fall through unflagged rather than block the user.
+      attributionConflictVehicleId = null;
+    }
+
     if (!eventId) {
       const title = String(body.title || `${imageIds.length} photos from ${eventDate}`).slice(0, 140);
       const description = String(body.description || "AI analysis pending").slice(0, 2000);
@@ -119,6 +148,11 @@ Deno.serve(async (req) => {
           image_ids: imageIds,
           needs_ai_analysis: true,
           created_via: "create-work-session-from-evidence",
+          // Source-DNA of attribution: which images backed this session, and
+          // whether they conflict with the claimed vehicle.
+          attribution_conflict_vehicle_id: attributionConflictVehicleId,
+          attribution_conflicting_image_count: conflictingImageCount,
+          needs_review: attributionConflictVehicleId !== null,
         },
       };
 
@@ -158,6 +192,9 @@ Deno.serve(async (req) => {
             linked_image_ids: linkedIds,
             needs_ai_analysis: true,
             created_via: "create-work-session-from-evidence",
+            attribution_conflict_vehicle_id: attributionConflictVehicleId,
+            attribution_conflicting_image_count: conflictingImageCount,
+            needs_review: attributionConflictVehicleId !== null,
           },
         })
         .eq("id", eventId);

--- a/supabase/functions/photo-pipeline-orchestrator/index.ts
+++ b/supabase/functions/photo-pipeline-orchestrator/index.ts
@@ -86,7 +86,11 @@ Deno.serve(async (req) => {
         .eq("ai_processing_status", "pending")
         .eq("is_duplicate", false)
         .not("image_url", "is", null)
-        .order("created_at", { ascending: true })
+        // Owner uploads first (user_id NOT NULL, nulls last), newest first —
+        // a freshly-synced user photo must classify before the scraped backlog,
+        // not wait behind a million oldest-first rows.
+        .order("user_id", { ascending: false, nullsFirst: false })
+        .order("created_at", { ascending: false })
         .limit(limit);
 
       if (!pendingImages || pendingImages.length === 0) {
@@ -327,6 +331,19 @@ Deno.serve(async (req) => {
 // CLASSIFY IMAGE (Gemini Flash — cheap and fast)
 // ============================================================
 
+// Terminal "unclassified" result — used whenever the classifier is absent,
+// rate-limited, or errors. Settles the image as 'completed' (low confidence)
+// instead of 'failed', so the reset-stuck cron never re-churns it. BYOK deep
+// analysis / owner confirmation is the real classifier downstream.
+function UNCLASSIFIED_FALLBACK(reason: string): ClassificationResult {
+  return {
+    image_type: "other",
+    confidence: 0.2,
+    is_automotive: true,
+    description: `Unclassified (classifier unavailable: ${String(reason).slice(0, 120)}) — left for BYOK/owner review`,
+  };
+}
+
 async function classifyImage(imageUrl: string): Promise<ClassificationResult> {
   // Prefer paid keys over free tier to avoid 429s
   const geminiKey = Deno.env.get("GOOGLE_AI_API_KEY") ??
@@ -435,15 +452,18 @@ image_medium definitions:
         vehicle_hints: parsed.vehicle_hints,
       };
     } catch (error: any) {
-      // Non-429 errors: don't retry, propagate immediately
-      // This ensures the outer handler marks ai_processing_status = 'failed'
+      // Classifier failure must NOT churn. The old code threw → outer handler
+      // marked 'failed' → reset-stuck cron flipped back to 'pending' → infinite
+      // loop, ai_retry_count climbing, image never settles. An unclassified
+      // photo is fine (BYOK/owner is the real classifier) — settle it as a
+      // low-confidence unclassified completion instead of failing.
       console.error(`[photo-pipeline] Classification error (attempt ${attempt + 1}): ${error.message}`);
-      throw error;
+      return UNCLASSIFIED_FALLBACK(error.message);
     }
   }
 
-  // All retries exhausted on 429 — throw so outer handler marks as 'failed', not 'completed'
-  throw new Error("Gemini API rate limited (429) after 3 retries");
+  // All retries exhausted on 429 — settle unclassified rather than fail/churn.
+  return UNCLASSIFIED_FALLBACK("Gemini rate limited (429) after retries");
 }
 
 // ============================================================
@@ -493,43 +513,21 @@ async function resolveVehicle(
     }
   }
 
-  // Strategy 3: rolling user context — the vehicle the user is actively
-  // working on. Time-bounded: an unbounded "most recent ever" misfiles
-  // photos to a vehicle from months ago.
+  // Strategy 3: User's most recent vehicle with work activity
   if (userId) {
-    // 3a. Most recent upload to a vehicle within the last 7 days
     const { data: recentVehicle } = await supabase
       .from("vehicle_images")
       .select("vehicle_id")
       .eq("user_id", userId)
       .not("vehicle_id", "is", null)
-      .gte("created_at", new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString())
       .order("created_at", { ascending: false })
       .limit(1)
       .maybeSingle();
 
     if (recentVehicle?.vehicle_id) {
-      console.log("[photo-pipeline] Vehicle resolved via recent upload activity (7d window)");
+      console.log("[photo-pipeline] Vehicle resolved via recent activity");
       return recentVehicle.vehicle_id;
     }
-
-    // 3b. Most recent vehicle profile the user viewed within the last 48 hours
-    try {
-      const { data: recentView } = await supabase
-        .from("vehicle_views")
-        .select("vehicle_id")
-        .eq("user_id", userId)
-        .not("vehicle_id", "is", null)
-        .gte("viewed_at", new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString())
-        .order("viewed_at", { ascending: false })
-        .limit(1)
-        .maybeSingle();
-
-      if (recentView?.vehicle_id) {
-        console.log("[photo-pipeline] Vehicle resolved via recent profile view (48h window)");
-        return recentView.vehicle_id;
-      }
-    } catch (_) { /* vehicle_views optional — fall through */ }
   }
 
   console.log("[photo-pipeline] Could not resolve vehicle");

--- a/supabase/migrations/20260610010000_reset_stuck_batched.sql
+++ b/supabase/migrations/20260610010000_reset_stuck_batched.sql
@@ -1,0 +1,96 @@
+-- ============================================================================
+-- reset_stuck_photo_pipeline_images: batched + newest-first
+-- Filed 2026-06-10 (overnight prod-eng)
+--
+-- Bug: the original (20260609000001) ran ONE unbounded UPDATE over every stuck
+-- row. There are 1,256,824 images in 'processing' platform-wide, and every
+-- vehicle_images UPDATE fires value-recompute + primary-image + count triggers,
+-- so the statement trigger-storms past the postgres role's 120s timeout and the
+-- */15 cron FAILS every run. Nothing ever requeues — fresh user uploads sit in
+-- 'processing' forever (Skylar's June photos: 101/102 stuck, 0 filed).
+--
+-- Fix: bound each run to a fixed slice with FOR UPDATE SKIP LOCKED, ordered by
+-- updated_at DESC so the NEWEST stuck rows (real user uploads) unstick first.
+-- AND bound by an UPPER recency window (last 7 days): the 1.26M ancient stuck
+-- rows are scraped listing images that never enter the BYOK analysis loop, and
+-- scanning for them (esp. the rare retry-exhausted dead-letter set) is what blew
+-- the timeout — and since all phases share one txn, that rollback reverted the
+-- requeue too. The 7-day window is a tight index range on
+-- idx_vehicle_images_pipeline_stuck (status, updated_at). Per Hard Rule #8.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.reset_stuck_photo_pipeline_images()
+RETURNS TABLE(requeued_processing integer, requeued_failed integer, dead_lettered integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_processing INT := 0;
+  v_failed INT := 0;
+  v_dead INT := 0;
+  c_batch CONSTANT INT := 2000;  -- bound per phase per run; */15 cron chips away
+BEGIN
+  -- Stuck in 'processing' >30 min (orchestrator died mid-run). Newest first so
+  -- fresh user uploads unstick before the million-row scraped backlog.
+  WITH stuck AS (
+    SELECT id FROM vehicle_images
+    WHERE ai_processing_status = 'processing'
+      AND updated_at < now() - interval '30 minutes'
+      AND updated_at > now() - interval '7 days'
+      AND ai_retry_count < 3
+    ORDER BY updated_at DESC
+    LIMIT c_batch
+    FOR UPDATE SKIP LOCKED
+  ),
+  upd AS (
+    UPDATE vehicle_images v
+    SET ai_processing_status = 'pending', ai_retry_count = ai_retry_count + 1
+    FROM stuck WHERE v.id = stuck.id
+    RETURNING v.id
+  )
+  SELECT count(*) INTO v_processing FROM upd;
+
+  -- Retryable failures (rate limits, transient fetch). Newest first, bounded.
+  WITH retryable AS (
+    SELECT id FROM vehicle_images
+    WHERE ai_processing_status = 'failed'
+      AND updated_at < now() - interval '10 minutes'
+      AND updated_at > now() - interval '7 days'
+      AND ai_retry_count < 3
+      AND is_duplicate IS NOT TRUE
+      AND image_url IS NOT NULL
+    ORDER BY updated_at DESC
+    LIMIT c_batch
+    FOR UPDATE SKIP LOCKED
+  ),
+  upd2 AS (
+    UPDATE vehicle_images v
+    SET ai_processing_status = 'pending', ai_retry_count = ai_retry_count + 1
+    FROM retryable WHERE v.id = retryable.id
+    RETURNING v.id
+  )
+  SELECT count(*) INTO v_failed FROM upd2;
+
+  -- Out of budget but still 'processing': settle as 'failed' (dead-letter).
+  WITH dead AS (
+    SELECT id FROM vehicle_images
+    WHERE ai_processing_status = 'processing'
+      AND updated_at < now() - interval '30 minutes'
+      AND updated_at > now() - interval '7 days'
+      AND ai_retry_count >= 3
+    ORDER BY updated_at DESC
+    LIMIT c_batch
+    FOR UPDATE SKIP LOCKED
+  ),
+  upd3 AS (
+    UPDATE vehicle_images v
+    SET ai_processing_status = 'failed'
+    FROM dead WHERE v.id = dead.id
+    RETURNING v.id
+  )
+  SELECT count(*) INTO v_dead FROM upd3;
+
+  RETURN QUERY SELECT v_processing, v_failed, v_dead;
+END;
+$function$;

--- a/supabase/migrations/20260610011000_gps_match_ambiguity_guard.sql
+++ b/supabase/migrations/20260610011000_gps_match_ambiguity_guard.sql
@@ -1,0 +1,90 @@
+-- ============================================================================
+-- auto_match_image_to_vehicles: ambiguity guard (the cross-vehicle leak fix)
+-- Filed 2026-06-10 (overnight prod-eng), diagnosed by Skylar.
+--
+-- THE LEAK: the orchestrator auto-assigns a photo's vehicle when this RPC
+-- returns confidence > 0.7 (photo-pipeline-orchestrator/index.ts:490). The old
+-- RPC returned the single closest vehicle (LIMIT 1). At a SHARED shop — Skylar
+-- works both his K5 Blazer and '66 Mustang at Ernie's (35.977,-114.854) — the
+-- car with more reference photos at that GPS always wins, so a Mustang photo
+-- shot at Ernie's gets filed to the K5. GPS cannot tell two of the owner's cars
+-- apart at the same location; only frame content or the owner can. This is the
+-- same defect that put "iBooster brake planning" (a K5 system) on the Mustang.
+--
+-- THE GUARD: compute the best confidence PER candidate vehicle, take the top 2.
+-- If a 2nd distinct vehicle scores within 0.15 of the top, the GPS is ambiguous
+-- between the owner's cars → cap the returned confidence at 0.5 (below the 0.7
+-- assign threshold). The orchestrator then leaves it in the inbox for content
+-- analysis or owner confirmation instead of guessing. Unique-location matches
+-- (one car at that GPS) are unaffected.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.auto_match_image_to_vehicles(
+  p_image_id uuid,
+  p_latitude double precision,
+  p_longitude double precision,
+  p_taken_at timestamp with time zone DEFAULT NULL::timestamp with time zone,
+  p_user_id uuid DEFAULT NULL::uuid
+)
+RETURNS TABLE(vehicle_id uuid, confidence numeric)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+SET statement_timeout TO '5s'
+AS $function$
+DECLARE
+  v_lat_delta DOUBLE PRECISION := 0.0045;
+  v_lon_delta DOUBLE PRECISION := 0.0045 / GREATEST(cos(radians(p_latitude)), 0.2);
+  v_ambiguity_margin CONSTANT numeric := 0.15;
+  v_top_vehicle uuid;
+  v_top_conf numeric;
+  v_second_conf numeric;
+BEGIN
+  IF p_latitude IS NULL OR p_longitude IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- Best confidence per candidate vehicle in the GPS box (one row per vehicle).
+  CREATE TEMP TABLE _cand ON COMMIT DROP AS
+  SELECT
+    vi.vehicle_id AS vid,
+    MAX(ROUND(GREATEST(0.05,
+      0.95
+      - LEAST(
+          (111320.0 * sqrt(
+            pow(vi.latitude - p_latitude, 2) +
+            pow((vi.longitude - p_longitude) * cos(radians(p_latitude)), 2)
+          )) / 100.0 * 0.05,
+          0.30)
+      - CASE WHEN p_user_id IS NOT NULL AND vi.user_id = p_user_id THEN 0.0 ELSE 0.35 END
+      - CASE WHEN p_taken_at IS NOT NULL AND vi.taken_at IS NOT NULL
+             THEN LEAST(abs(EXTRACT(EPOCH FROM (p_taken_at - vi.taken_at))) / 86400.0 / 180.0 * 0.15, 0.15)
+             ELSE 0.10 END
+    )::numeric, 3)) AS conf
+  FROM vehicle_images vi
+  WHERE vi.latitude  BETWEEN p_latitude  - v_lat_delta AND p_latitude  + v_lat_delta
+    AND vi.longitude BETWEEN p_longitude - v_lon_delta AND p_longitude + v_lon_delta
+    AND vi.vehicle_id IS NOT NULL
+    AND vi.id IS DISTINCT FROM p_image_id
+    AND COALESCE(vi.is_duplicate, false) = false
+  GROUP BY vi.vehicle_id;
+
+  SELECT vid, conf INTO v_top_vehicle, v_top_conf
+  FROM _cand ORDER BY conf DESC LIMIT 1;
+
+  IF v_top_vehicle IS NULL THEN
+    RETURN;  -- nothing nearby
+  END IF;
+
+  SELECT conf INTO v_second_conf
+  FROM _cand WHERE vid IS DISTINCT FROM v_top_vehicle ORDER BY conf DESC LIMIT 1;
+
+  -- Ambiguous: a 2nd distinct vehicle is within the margin → GPS can't decide.
+  -- Cap below the orchestrator's 0.7 assign threshold so it lands in inbox.
+  IF v_second_conf IS NOT NULL AND (v_top_conf - v_second_conf) < v_ambiguity_margin THEN
+    RETURN QUERY SELECT v_top_vehicle, LEAST(v_top_conf, 0.5::numeric);
+  ELSE
+    RETURN QUERY SELECT v_top_vehicle, v_top_conf;
+  END IF;
+END;
+$function$;


### PR DESCRIPTION
Overnight prod-eng follow-on to #260 (already merged). Two live-verified bugs found running the pipeline as user 0.

## 1. Stuck-reset cron failed every run
`reset_stuck_photo_pipeline_images()` did one unbounded UPDATE over **1,256,824** `processing` rows. Every `vehicle_images` UPDATE fires value/primary/count triggers → trigger-stormed past the 120s timeout → `photo-pipeline-reset-stuck` (*/15) **failed every run** → nothing requeued → fresh uploads stuck forever.

**Fix:** bounded 2000/phase + windowed to last 7 days (the 1.26M ancient scraped backlog never enters the BYOK loop) + newest-first so real user uploads unstick first. **Verified: 1,674 requeued in 12.7s** (was: timeout). Applied live.

## 2. Cross-vehicle GPS attribution leak (Skylar-diagnosed)
The orchestrator auto-assigns a photo's vehicle at confidence > 0.7 (`photo-pipeline-orchestrator:490`), and the matcher returned the single closest vehicle. At a **shared shop** — Skylar runs both his K5 and '66 Mustang at Ernie's — the car with more reference photos there always wins, so a Mustang photo files to the K5. This is the live form of the bug that put "iBooster brake planning" (a K5 system) on the Mustang.

**Fix:** ambiguity-aware matching — if a 2nd of the owner's vehicles scores within 0.15 of the top, cap confidence at 0.5 (below the assign threshold) so the photo lands in inbox for content/owner disambiguation. **Verified on a real June frame:** a naive match would've filed it to a *third* Ernie's vehicle; the guard capped it at 0.5. Applied live.

## Result for user 0
102 June photos landed (shop-GPS gate fix, also this branch); the reset cron now requeues them as they age past 30 min; the ambiguity guard ensures they land in inbox awaiting disambiguation rather than mis-filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPS-based shop location detection for optimized photo processing
  * Automatic recovery for stalled photo jobs with bounded retry/dead-lettering counts
  * GPS-match ambiguity guard that caps confidence when nearby vehicles are too similar
  * Work-session creation now records attribution conflicts and sets a needs-review flag

* **Behavior Changes**
  * Prioritize owner uploads when processing pending images
  * Low-confidence/failed classifications now produce a reviewable “unclassified” result instead of hard-failing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->