### PR TITLE
Profile data-viz workspace: work ledger, BaT track record, money flow, photo strip

### DIFF
--- a/docs/library/technical/design-book/facet-tabs-are-a-skill-fingerprint.md
+++ b/docs/library/technical/design-book/facet-tabs-are-a-skill-fingerprint.md
@@ -1,0 +1,75 @@
+# Facet Tabs Are a Skill Fingerprint
+
+**Doctrine** — user profile, timeline filter pills, and any future facet row.
+Source: Skylar, 2026-06-10 ("the tab row is a skill fingerprint, not navigation").
+
+## The rule
+
+A tab (facet pill) renders **only when the user has data behind it**, and it renders **with its count**:
+
+```
+PHOTOS (20978)   WORK (292)   VEHICLES (14)   AUCTIONS (2)
+```
+
+A user who has never commented gets **no COMMENTS tab**. Not a greyed-out tab, not an
+empty tab that opens "No comments yet" — no tab. The row is computed from the ALL-events
+map (`filterCounts`, vehicle pattern: `BarcodeTimeline.tsx:285-291`), and a pill exists
+iff `count > 0`.
+
+## Why: tabs render what the user IS
+
+The conventional reading of a tab row is navigation chrome: a fixed menu of places the
+app can take you. That reading produces empty shells — five hardcoded pills regardless
+of data, three of which dead-end. The design book already bans empty shells for widgets;
+this page extends the ban to navigation itself.
+
+The correct reading: **the facet row is the user's skill fingerprint.** It is the
+compressed, glanceable answer to "what does this person actually do?" A profile with
+`PHOTOS (20978) / WORK (292)` and no COMMENTS pill says: this is a builder who documents,
+not a commenter. The absence of a tab is as much signal as its presence. Rendering an
+empty facet would be lying about identity — the one thing a worth-proof profile must
+never do.
+
+This is the GitHub-contribution-graph move applied to navigation. GitHub's graph earned
+its iconic status because it renders only what happened — green where commits exist,
+blank where they don't, and the blank is honest. The profile is the same instrument
+pointed at physical work: a contribution graph for the real world, where the profile is
+**proof of worth to the assets the user touches** (Skylar, 2026-06-10). The tab row is
+that graph's legend: each pill a proven competency, each count the receipt.
+
+## The facet set is open
+
+Facets are `kind` values on contribution events, not UI constructs. Today the kinds are
+automotive: `image_upload`, `timeline_event`, `work`, `auction_activity`, `comment`.
+Nothing in the rendering layer knows that list — it counts kinds and renders pills for
+nonzero counts.
+
+Consequence: when art, fashion, or content data lands, those practices appear as new
+`kind` values — `artwork`, `garment`, `post` — and the tab row grows **with zero UI
+rework**. An art-world user's fingerprint reads `ARTWORKS (340) / SHOWS (12)` from the
+same component that renders a mechanic's `PHOTOS / WORK`. No per-vertical tab bars, no
+feature flags, no redesign.
+
+This is the seam where **asset-contribution mapping generalizes**: the platform's core
+claim is that a person's worth is provable from their documented contributions to assets.
+Vehicles are the first asset class, not the last. The facet row is the one UI surface
+that must stay asset-class-agnostic so the claim scales.
+
+## Implementation invariants
+
+1. **Counts come from the ALL set, never the filtered set.** Filtering re-colors the
+   timeline; it must not change which pills exist or their counts (no self-erasing tabs).
+2. **Pill exists iff count > 0.** No disabled states, no placeholders.
+3. **Label format:** `KIND (N)` — ALL-CAPS, `--fs-8` token, count in the same pill.
+4. **New facets are data migrations, not UI changes.** Adding a kind = mapping its events
+   into the contribution stream. If the tab row needed code to show a new kind, the seam
+   is broken — fix the seam, not the symptom.
+5. **An empty profile shows zero pills.** That is the honest state, and (GitHub-style)
+   the empty graph is the invitation to build.
+
+## Anti-patterns
+
+- Hardcoded pill lists (the round-2 bug: 5 fixed pills, auctions/comments unmapped).
+- "Coming soon" tabs for verticals with no ingested data.
+- Per-vertical tab components (`ArtProfileTabs.tsx` must never exist).
+- Counts computed from the filtered map (tabs that change as you click them).

--- a/nuke_frontend/src/components/TextScaleControl.tsx
+++ b/nuke_frontend/src/components/TextScaleControl.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useTheme } from '../contexts/ThemeContext';
+import type { TextScale } from '../contexts/ThemeContext';
+
+/**
+ * TextScaleControl — A− / A / A+ segmented control for the global text scale.
+ *
+ * Drives ThemeContext.textScale (persisted to localStorage `uiTextScale`),
+ * which sets --font-scale on :root; all --fs-* tokens multiply it.
+ * Steps: 0.9 / 1.0 / 1.1 / 1.2.
+ *
+ * variant="full"    — label + A− A A+ + current % (settings drawer)
+ * variant="compact" — A− A+ icon buttons only (sub-header right end)
+ */
+
+const STEPS: TextScale[] = [0.9, 1, 1.1, 1.2];
+
+interface TextScaleControlProps {
+  variant?: 'full' | 'compact';
+}
+
+const TextScaleControl: React.FC<TextScaleControlProps> = ({ variant = 'full' }) => {
+  const { textScale, setTextScale } = useTheme();
+
+  const idx = STEPS.indexOf(textScale);
+  const canDec = idx > 0;
+  const canInc = idx >= 0 && idx < STEPS.length - 1;
+
+  const dec = () => {
+    if (canDec) setTextScale(STEPS[idx - 1]);
+  };
+  const inc = () => {
+    if (canInc) setTextScale(STEPS[idx + 1]);
+  };
+  const reset = () => setTextScale(1);
+
+  if (variant === 'compact') {
+    return (
+      <span className="up-textscale up-textscale--compact" title="TEXT SIZE">
+        <span className="up-textscale__seg">
+          <button
+            type="button"
+            className="up-textscale__btn"
+            onClick={dec}
+            disabled={!canDec}
+            aria-label="Decrease text size"
+          >
+            A&minus;
+          </button>
+          <button
+            type="button"
+            className="up-textscale__btn"
+            onClick={inc}
+            disabled={!canInc}
+            aria-label="Increase text size"
+          >
+            A+
+          </button>
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <div className="up-textscale">
+      <span className="up-textscale__label">TEXT SIZE</span>
+      <span className="up-textscale__seg">
+        <button
+          type="button"
+          className="up-textscale__btn"
+          onClick={dec}
+          disabled={!canDec}
+          aria-label="Decrease text size"
+        >
+          A&minus;
+        </button>
+        <button
+          type="button"
+          className={`up-textscale__btn${textScale === 1 ? ' up-textscale__btn--active' : ''}`}
+          onClick={reset}
+          aria-label="Reset text size"
+        >
+          A
+        </button>
+        <button
+          type="button"
+          className="up-textscale__btn"
+          onClick={inc}
+          disabled={!canInc}
+          aria-label="Increase text size"
+        >
+          A+
+        </button>
+      </span>
+      <span className="up-textscale__value">{Math.round(textScale * 100)}%</span>
+    </div>
+  );
+};
+
+export default TextScaleControl;

--- a/nuke_frontend/src/pages/user-profile/UserBarcodeTimeline.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserBarcodeTimeline.tsx
@@ -1,5 +1,8 @@
 import React, { useMemo, useState, useCallback, useRef, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { useUserProfile } from './UserProfileContext';
+import { supabase } from '../../lib/supabase';
+import { getThumbnailUrl } from '../../lib/imageOptimizer';
 import type { ContributionEvent } from './types';
 import '../../styles/barcode-timeline.css';
 
@@ -30,6 +33,9 @@ interface FilterDef {
   match: (ev: ContributionEvent) => boolean;
 }
 
+// Skill-fingerprint doctrine: a pill renders ONLY when its facet has data
+// (count > 0 from the ALL set). The set below is the open superset — what a
+// given profile shows is what that user IS.
 const FILTERS: FilterDef[] = [
   { key: 'all', label: 'ALL', match: () => true },
   { key: 'photos', label: 'PHOTOS', match: (ev) => ev.type === 'image_upload' },
@@ -38,7 +44,9 @@ const FILTERS: FilterDef[] = [
     label: 'VEHICLES',
     match: (ev) => ev.type === 'vehicle_added' || ev.type === 'timeline_event',
   },
+  { key: 'work', label: 'WORK', match: (ev) => ev.type === 'work' },
   { key: 'auctions', label: 'AUCTIONS', match: (ev) => ev.type === 'auction_activity' },
+  { key: 'business', label: 'BUSINESS', match: (ev) => ev.type === 'business_event' },
   { key: 'comments', label: 'COMMENTS', match: (ev) => ev.type === 'comment' },
 ];
 
@@ -66,59 +74,142 @@ function startOfWeek(d: Date): Date {
 const MONTH_LABELS = ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'];
 const DAY_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 
-// ── Interfaces ──
-
-interface EventDay {
-  date: string;
-  count: number;
-  level: number; // 0-4
+function formatDayHeader(ds: string): string {
+  const d = new Date(ds + 'T00:00:00');
+  if (isNaN(d.getTime())) return ds;
+  return d.toDateString().toUpperCase(); // e.g. "FRI JUN 06 2026"
 }
 
+function formatMinutes(min: number | null | undefined): string {
+  const m = Number(min) || 0;
+  if (m <= 0) return '';
+  const h = Math.floor(m / 60);
+  const rem = m % 60;
+  if (h > 0) return rem > 0 ? `${h}H ${rem}M` : `${h}H`;
+  return `${rem}M`;
+}
+
+function formatMoney(n: number | null | undefined): string {
+  const v = Number(n);
+  if (!Number.isFinite(v) || v <= 0) return '';
+  return `$${Math.round(v).toLocaleString()}`;
+}
+
+// ── Interfaces ──
+
+// Grid cells are STRUCTURE ONLY (date string); counts/colors are resolved at
+// render from the filtered map so filter clicks never rebuild the grid.
 interface WeekCol {
-  days: (EventDay | null)[];
+  days: (string | null)[];
   monthLabel?: string;
+}
+
+// Shape of get_user_day_receipt(p_user_id, p_date) → jsonb
+interface DayReceiptPhoto {
+  id: string;
+  url: string;
+  thumb: string;
+  vehicle_id: string | null;
+  taken_at: string | null;
+}
+interface DayReceiptWork {
+  id: string;
+  title: string;
+  vehicle_id: string | null;
+  duration_minutes: number | null;
+  total_job_cost: number | null;
+}
+interface DayReceiptRow {
+  id: string;
+  vendor: string | null;
+  total: number | null;
+  vehicle_id?: string | null;
+}
+interface DayReceipt {
+  date: string;
+  is_owner_view: boolean;
+  photos: DayReceiptPhoto[];
+  work_sessions: DayReceiptWork[];
+  receipts: DayReceiptRow[];
+  facets: { photos: number; work: number; receipts: number };
 }
 
 // ── Component ──
 
 const UserBarcodeTimeline: React.FC = () => {
-  const { contributionEvents, setGalleryFilter } = useUserProfile();
+  const { userId, contributionEvents } = useUserProfile();
   const [expanded, setExpanded] = useState(false);
   const [activeFilter, setActiveFilter] = useState('all');
+  const [receiptDate, setReceiptDate] = useState<string | null>(null);
+  const [receipt, setReceipt] = useState<DayReceipt | null>(null);
+  const [receiptLoading, setReceiptLoading] = useState(false);
+  const receiptCache = useRef<Map<string, DayReceipt>>(new Map());
+  const drawerRef = useRef<HTMLDivElement>(null);
   const heatmapRef = useRef<HTMLDivElement>(null);
   const stripRef = useRef<HTMLDivElement>(null);
 
-  // ── Filter events ──
-  const filteredEvents = useMemo(() => {
-    const filterDef = FILTERS.find((f) => f.key === activeFilter) || FILTERS[0];
-    return contributionEvents.filter(filterDef.match);
-  }, [contributionEvents, activeFilter]);
+  // ── PINNED WINDOW (vehicle BarcodeTimeline pattern) ──
+  // allMap is built from ALL contribution events exactly once. The date range,
+  // week grid, and collapsed barcode all derive from allMap ONLY — filter
+  // clicks re-color the same fixed grid (filteredMap) and can never move it.
 
-  // ── Build event map: date -> count ──
-  const eventMap = useMemo(() => {
+  const allMap = useMemo(() => {
     const map = new Map<string, number>();
-    for (const ev of filteredEvents) {
+    for (const ev of contributionEvents) {
       if (!ev.date) continue;
       const key = ev.date.slice(0, 10);
       map.set(key, (map.get(key) || 0) + (ev.count || 1));
     }
     return map;
-  }, [filteredEvents]);
+  }, [contributionEvents]);
 
-  // ── Date range ──
+  // ── Filter counts from the ALL set — pills show totals, never shift ──
+  const filterCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const f of FILTERS) {
+      let n = 0;
+      for (const ev of contributionEvents) {
+        if (f.match(ev)) n += ev.count || 1;
+      }
+      counts[f.key] = n;
+    }
+    return counts;
+  }, [contributionEvents]);
+
+  // If a data reload empties the active facet, fall back to ALL.
+  useEffect(() => {
+    if (activeFilter !== 'all' && !(filterCounts[activeFilter] > 0)) {
+      setActiveFilter('all');
+    }
+  }, [filterCounts, activeFilter]);
+
+  // ── Filtered map: colors only ──
+  const filteredMap = useMemo(() => {
+    if (activeFilter === 'all') return allMap;
+    const filterDef = FILTERS.find((f) => f.key === activeFilter) || FILTERS[0];
+    const map = new Map<string, number>();
+    for (const ev of contributionEvents) {
+      if (!ev.date || !filterDef.match(ev)) continue;
+      const key = ev.date.slice(0, 10);
+      map.set(key, (map.get(key) || 0) + (ev.count || 1));
+    }
+    return map;
+  }, [contributionEvents, activeFilter, allMap]);
+
+  // ── Date range — from the ALL set ONLY, never the filtered set ──
   // Range clamp ported from the vehicle BarcodeTimeline: (1) events dated
   // before 2000 are bogus EXIF (camera-default 1981 phantoms) and are ignored;
   // (2) the start year floors at the first year with >=10 events so a handful
   // of stray early dates can't stretch the strip into a decade of empty space.
   const { startDate, endDate } = useMemo(() => {
     const today = new Date();
-    if (filteredEvents.length === 0) return { startDate: today, endDate: today };
+    if (contributionEvents.length === 0) return { startDate: today, endDate: today };
 
     const MIN_VALID_YEAR = 2000;
     const MIN_EVENTS_PER_YEAR = 10;
 
     const yearCounts = new Map<number, number>();
-    for (const ev of filteredEvents) {
+    for (const ev of contributionEvents) {
       const d = ev.date?.slice(0, 10);
       if (!d) continue;
       const y = Number(d.slice(0, 4));
@@ -135,26 +226,33 @@ const UserBarcodeTimeline: React.FC = () => {
       startDate: new Date(firstDenseYear, 0, 1),
       endDate: today,
     };
-  }, [filteredEvents]);
+  }, [contributionEvents]);
 
-  // ── Level assignment (quantile-ish) ──
+  // ── Level assignment — quantile thresholds computed ONCE per filtered map
+  // (the old levelFor sorted the whole map on every cell: O(n² log n)) ──
+  const levelThresholds = useMemo(() => {
+    const counts = Array.from(filteredMap.values()).sort((a, b) => a - b);
+    if (counts.length === 0) return null;
+    return {
+      p25: counts[Math.floor(counts.length * 0.25)] || 1,
+      p50: counts[Math.floor(counts.length * 0.5)] || 1,
+      p75: counts[Math.floor(counts.length * 0.75)] || 1,
+    };
+  }, [filteredMap]);
+
   const levelFor = useCallback(
     (count: number): number => {
       if (count === 0) return 0;
-      const counts = Array.from(eventMap.values()).sort((a, b) => a - b);
-      if (counts.length === 0) return 1;
-      const p75 = counts[Math.floor(counts.length * 0.75)] || 1;
-      const p50 = counts[Math.floor(counts.length * 0.5)] || 1;
-      const p25 = counts[Math.floor(counts.length * 0.25)] || 1;
-      if (count >= p75) return 4;
-      if (count >= p50) return 3;
-      if (count >= p25) return 2;
+      if (!levelThresholds) return 1;
+      if (count >= levelThresholds.p75) return 4;
+      if (count >= levelThresholds.p50) return 3;
+      if (count >= levelThresholds.p25) return 2;
       return 1;
     },
-    [eventMap],
+    [levelThresholds],
   );
 
-  // ── Build collapsed barcode stripes ──
+  // ── Build collapsed barcode stripes — from the ALL set (always everything) ──
   const barcodeWeeks = useMemo(() => {
     const ws = startOfWeek(startDate);
     const weeks: { stripes: number[] }[] = [];
@@ -163,16 +261,19 @@ const UserBarcodeTimeline: React.FC = () => {
       const stripes: number[] = [];
       for (let d = 0; d < 7; d++) {
         const key = toDateStr(cursor);
-        const count = eventMap.get(key) || 0;
+        const count = allMap.get(key) || 0;
         stripes.push(count > 0 ? 1 : 0);
         cursor = addDays(cursor, 1);
       }
       weeks.push({ stripes });
     }
     return weeks;
-  }, [startDate, endDate, eventMap]);
+  }, [startDate, endDate, allMap]);
 
-  // ── Build expanded heatmap weeks ──
+  // ── Build expanded heatmap weeks — STRUCTURE ONLY (date strings).
+  // Depends solely on the pinned range: a filter click does not touch this
+  // memo, so the grid, its scroll position, and the auto-scroll effect below
+  // are all undisturbed. Cell counts/colors come from filteredMap at render.
   const heatmapWeeks = useMemo((): WeekCol[] => {
     const ws = startOfWeek(startDate);
     const weeks: WeekCol[] = [];
@@ -180,16 +281,14 @@ const UserBarcodeTimeline: React.FC = () => {
     let prevMonth = -1;
 
     while (cursor <= endDate) {
-      const days: (EventDay | null)[] = [];
+      const days: (string | null)[] = [];
       let monthLabel: string | undefined;
 
       for (let d = 0; d < 7; d++) {
         if (cursor < startDate || cursor > endDate) {
           days.push(null);
         } else {
-          const key = toDateStr(cursor);
-          const count = eventMap.get(key) || 0;
-          days.push({ date: key, count, level: levelFor(count) });
+          days.push(toDateStr(cursor));
 
           // Month label on first occurrence of new month
           if (cursor.getMonth() !== prevMonth && d <= 1) {
@@ -202,7 +301,7 @@ const UserBarcodeTimeline: React.FC = () => {
       weeks.push({ days, monthLabel });
     }
     return weeks;
-  }, [startDate, endDate, eventMap, levelFor]);
+  }, [startDate, endDate]);
 
   // ── Year range label ──
   const yearRange = useMemo(() => {
@@ -234,6 +333,7 @@ const UserBarcodeTimeline: React.FC = () => {
       const y = window.scrollY;
       if (y > lastY + 20 && expanded) {
         setExpanded(false);
+        setReceiptDate(null);
       }
       lastY = y;
     };
@@ -242,23 +342,70 @@ const UserBarcodeTimeline: React.FC = () => {
     return () => window.removeEventListener('scroll', onScroll);
   }, [expanded]);
 
-  // ── Escape to close ──
+  // ── Escape: close the drawer first, then the strip ──
   useEffect(() => {
     if (!expanded) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setExpanded(false);
+      if (e.key !== 'Escape') return;
+      if (receiptDate) setReceiptDate(null);
+      else setExpanded(false);
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [expanded]);
+  }, [expanded, receiptDate]);
 
-  // ── Day click -> set gallery filter ──
-  const handleDayClick = useCallback(
-    (date: string) => {
-      setGalleryFilter({ dateRange: [date, date] });
-    },
-    [setGalleryFilter],
-  );
+  // ── Click-out closes the drawer (cell clicks are handled by handleDayClick) ──
+  useEffect(() => {
+    if (!receiptDate) return;
+    const onDown = (e: MouseEvent) => {
+      const t = e.target as HTMLElement;
+      if (drawerRef.current?.contains(t)) return;
+      if (t.closest('.hm-c')) return; // day cells toggle/switch themselves
+      setReceiptDate(null);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [receiptDate]);
+
+  // ── Day click -> inline day-receipt drawer (toggle on same day) ──
+  const handleDayClick = useCallback((date: string) => {
+    setReceiptDate((cur) => (cur === date ? null : date));
+  }, []);
+
+  const toggleExpanded = useCallback(() => {
+    setExpanded((v) => !v);
+    setReceiptDate(null);
+  }, []);
+
+  // ── Fetch the day receipt (cached per date for the session) ──
+  useEffect(() => {
+    if (!receiptDate || !userId) return;
+    const cached = receiptCache.current.get(receiptDate);
+    if (cached) {
+      setReceipt(cached);
+      setReceiptLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setReceipt(null);
+    setReceiptLoading(true);
+    supabase
+      .rpc('get_user_day_receipt', { p_user_id: userId, p_date: receiptDate })
+      .then(({ data, error }) => {
+        if (cancelled) return;
+        setReceiptLoading(false);
+        if (error || !data) {
+          // Don't render a lying "NO ACTIVITY" on an RPC failure — just close.
+          setReceiptDate(null);
+          return;
+        }
+        receiptCache.current.set(receiptDate, data as DayReceipt);
+        setReceipt(data as DayReceipt);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [receiptDate, userId]);
 
   // ── Self-guard ──
   if (contributionEvents.length === 0) return null;
@@ -276,7 +423,7 @@ const UserBarcodeTimeline: React.FC = () => {
         className={`barcode-strip ${expanded ? 'barcode-strip--expanded' : 'barcode-strip--collapsed'}`}
       >
         {/* Collapsed bar */}
-        <div className="barcode-bar" onClick={() => setExpanded((v) => !v)}>
+        <div className="barcode-bar" onClick={toggleExpanded}>
           <span className="barcode-bar__label-left">TIMELINE</span>
           <span className="barcode-bar__label-right">{yearRange}</span>
           <div className="barcode-canvas">
@@ -297,28 +444,17 @@ const UserBarcodeTimeline: React.FC = () => {
 
         {/* Expanded heatmap */}
         <div className="barcode-heatmap">
-          {/* Filter pills */}
-          <div
-            style={{
-              display: 'flex',
-              gap: '6px',
-              marginBottom: '8px',
-              flexWrap: 'wrap',
-            }}
-          >
-            {FILTERS.map((f) => (
+          {/* Filter pills — adaptive: only facets with data render (skill
+              fingerprint, not navigation). Counts come from the ALL set so
+              the pill row itself never changes on filter clicks. */}
+          <div className="timeline-filter-pills">
+            {FILTERS.filter((f) => (filterCounts[f.key] || 0) > 0).map((f) => (
               <button
                 key={f.key}
-                className="up-btn"
-                style={{
-                  background: activeFilter === f.key ? '#1a1a1a' : 'transparent',
-                  color: activeFilter === f.key ? '#fff' : '#1a1a1a',
-                  fontSize: '7px',
-                  padding: '2px 6px',
-                }}
+                className={`timeline-filter-pill${activeFilter === f.key ? ' timeline-filter-pill--active' : ''}`}
                 onClick={() => setActiveFilter(f.key)}
               >
-                {f.label}
+                {f.label} ({filterCounts[f.key]})
               </button>
             ))}
           </div>
@@ -333,31 +469,24 @@ const UserBarcodeTimeline: React.FC = () => {
               ))}
             </div>
             <div className="hm-wrap">
-              {/* Week columns */}
+              {/* Week columns — structure is pinned; only colors react to the
+                  active filter (count/level resolved from filteredMap here) */}
               {heatmapWeeks.map((week, wi) => (
                 <div key={wi} className="hm-week">
-                  {week.days.map((day, di) => {
-                    if (!day) {
+                  {week.days.map((date, di) => {
+                    if (!date) {
                       return <div key={di} className="hm-c empty" />;
                     }
-                    const levelClass =
-                      day.level === 0
-                        ? ''
-                        : day.level === 1
-                          ? 'l1'
-                          : day.level === 2
-                            ? 'l2'
-                            : day.level === 3
-                              ? 'l3'
-                              : 'l4';
+                    const count = filteredMap.get(date) || 0;
+                    const level = levelFor(count);
                     return (
                       <div
                         key={di}
-                        className={`hm-c ${levelClass}`}
-                        data-date={day.date}
-                        data-count={day.count}
-                        title={`${day.date}: ${day.count} event${day.count !== 1 ? 's' : ''}`}
-                        onClick={() => handleDayClick(day.date)}
+                        className={`hm-c${level > 0 ? ` l${level}` : ''}`}
+                        data-date={date}
+                        data-count={count}
+                        title={`${date}: ${count} event${count !== 1 ? 's' : ''}`}
+                        onClick={() => handleDayClick(date)}
                       />
                     );
                   })}
@@ -369,6 +498,91 @@ const UserBarcodeTimeline: React.FC = () => {
               ))}
             </div>
           </div>
+
+          {/* Day-receipt drawer — the end layer. Inline below the grid, stays
+              in context. Empty day = one tiny line, never an empty shell. */}
+          {receiptDate && (
+            <div ref={drawerRef} className="up-day-receipt">
+              <div className="up-day-receipt__header">
+                <span>{formatDayHeader(receiptDate)}</span>
+                <button
+                  className="up-day-receipt__close"
+                  onClick={() => setReceiptDate(null)}
+                  aria-label="Close day receipt"
+                >
+                  ✕
+                </button>
+              </div>
+
+              {receiptLoading && (
+                <div className="up-day-receipt__empty">LOADING…</div>
+              )}
+
+              {!receiptLoading && receipt && (
+                (receipt.facets.photos + receipt.facets.work + receipt.facets.receipts) === 0 ? (
+                  <div className="up-day-receipt__empty">NO ACTIVITY</div>
+                ) : (
+                  <>
+                    {/* Facet chips — only the facets this day touched */}
+                    <div className="up-day-receipt__facets">
+                      {receipt.facets.photos > 0 && (
+                        <span className="up-day-receipt__facet">PHOTOS {receipt.facets.photos}</span>
+                      )}
+                      {receipt.facets.work > 0 && (
+                        <span className="up-day-receipt__facet">WORK {receipt.facets.work}</span>
+                      )}
+                      {receipt.facets.receipts > 0 && (
+                        <span className="up-day-receipt__facet">RECEIPTS {receipt.facets.receipts}</span>
+                      )}
+                    </div>
+
+                    {/* Photo thumb strip — lazy; click-through to the full-page
+                        day receipt at /journal/:date */}
+                    {receipt.photos.length > 0 && (
+                      <div className="up-day-receipt__photos">
+                        {receipt.photos.map((p) => (
+                          <Link key={p.id} to={`/journal/${receiptDate}`}>
+                            <img
+                              src={getThumbnailUrl(p.thumb) || p.thumb}
+                              loading="lazy"
+                              alt=""
+                            />
+                          </Link>
+                        ))}
+                      </div>
+                    )}
+
+                    {/* Work lines — hours always; dollars owner-only (the RPC
+                        already nulls cost for visitors; gate again here) */}
+                    {receipt.work_sessions.map((w) => {
+                      const hrs = formatMinutes(w.duration_minutes);
+                      const cost = receipt.is_owner_view ? formatMoney(w.total_job_cost) : '';
+                      return (
+                        <div className="up-day-receipt__line" key={w.id}>
+                          <span className="up-day-receipt__line-label">{w.title}</span>
+                          <span className="up-day-receipt__line-value">
+                            {[hrs, cost].filter(Boolean).join(' · ') || '—'}
+                          </span>
+                        </div>
+                      );
+                    })}
+
+                    {/* Receipt lines — RPC returns [] for visitors */}
+                    {receipt.receipts.map((r) => (
+                      <div className="up-day-receipt__line" key={r.id}>
+                        <span className="up-day-receipt__line-label">
+                          {(r.vendor || 'RECEIPT').toUpperCase()}
+                        </span>
+                        <span className="up-day-receipt__line-value">
+                          {formatMoney(r.total) || '—'}
+                        </span>
+                      </div>
+                    ))}
+                  </>
+                )
+              )}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/nuke_frontend/src/pages/user-profile/UserBatTrackRecord.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserBatTrackRecord.tsx
@@ -1,0 +1,383 @@
+/**
+ * UserBatTrackRecord — BaT sales history + auction comments for a user profile.
+ *
+ * Data sources (read directly; no vehicle_events dependency):
+ *   - bat_listings WHERE seller_username = username
+ *                     OR seller_external_identity_id IN identityIds
+ *   - auction_comments WHERE author_external_identity_id IN identityIds
+ *                        AND bid_amount IS NULL (comments, not bids)
+ *
+ * Self-guarding: returns null while loading and when 0 listings AND 0 comments.
+ * Design rules: Arial labels (ALL-CAPS 8px), Courier New for data, 2px solid
+ * borders, zero radius/shadows/gradients.
+ */
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { supabase } from '../../lib/supabase';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface BatListingRow {
+  id: string;
+  vehicle_id: string | null;
+  bat_listing_title: string | null;
+  bat_listing_url: string | null;
+  listing_status: string | null;
+  sale_price: number | null;
+  final_bid: number | null;
+  sale_date: string | null;
+  auction_end_date: string | null;
+}
+
+interface BatCommentRow {
+  id: string;
+  comment_text: string | null;
+  posted_at: string | null;
+  vehicle_id: string | null;
+}
+
+interface UserBatTrackRecordProps {
+  userId: string;
+  /** BaT seller handle for the seller_username match (e.g. 'skylarwilliams'). */
+  username: string | null;
+  /** Claimed external_identities ids for this profile. */
+  identityIds: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MONO = "var(--up-font-mono, 'Courier New', Courier, monospace)";
+const SANS = 'var(--up-font-sans, Arial, Helvetica, sans-serif)';
+const INK = 'var(--up-ink, #1a1a1a)';
+const GHOST = 'var(--up-ghost, #dddddd)';
+const NO_SALE_COLOR = '#999';
+
+const MONTHS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return '—';
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return '—';
+  return `${MONTHS[d.getUTCMonth()]} ${String(d.getUTCDate()).padStart(2, '0')} ${d.getUTCFullYear()}`;
+}
+
+function formatPrice(n: number | null): string {
+  if (n == null) return '—';
+  return `$${n.toLocaleString('en-US')}`;
+}
+
+/**
+ * Vehicle display name: listing title, or derived from the BaT URL slug
+ * when the title is missing (e.g. /listing/1997-lexus-lx450-166 → 1997 LEXUS LX450).
+ */
+function listingDisplayName(row: BatListingRow): string {
+  const title = (row.bat_listing_title || '').trim();
+  if (title) return title;
+  if (row.bat_listing_url) {
+    const slug = row.bat_listing_url.replace(/\/+$/, '').split('/').pop() || '';
+    const cleaned = slug.replace(/-\d+$/, '').replace(/-/g, ' ').trim();
+    if (cleaned) return cleaned.toUpperCase();
+  }
+  return 'BAT LISTING';
+}
+
+function listingDate(row: BatListingRow): string | null {
+  return row.sale_date || row.auction_end_date;
+}
+
+function resultLabel(status: string | null): string {
+  if (status === 'sold') return 'SOLD';
+  if (status === 'no_sale') return 'NO SALE';
+  return (status || 'UNKNOWN').replace(/_/g, ' ').toUpperCase();
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max).trimEnd()}…`;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const UserBatTrackRecord: React.FC<UserBatTrackRecordProps> = ({ userId, username, identityIds }) => {
+  const [loading, setLoading] = useState(true);
+  const [listings, setListings] = useState<BatListingRow[]>([]);
+  const [comments, setComments] = useState<BatCommentRow[]>([]);
+  const [commentCount, setCommentCount] = useState(0);
+  const [commentsOpen, setCommentsOpen] = useState(false);
+
+  const identityKey = identityIds.join(',');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      try {
+        const cleanUsername = (username || '').trim().replace(/"/g, '');
+        const sellerFilters: string[] = [];
+        if (cleanUsername) sellerFilters.push(`seller_username.eq."${cleanUsername}"`);
+        if (identityIds.length > 0) {
+          sellerFilters.push(`seller_external_identity_id.in.(${identityIds.join(',')})`);
+        }
+
+        const listingsPromise = sellerFilters.length > 0
+          ? supabase
+              .from('bat_listings')
+              .select('id, vehicle_id, bat_listing_title, bat_listing_url, listing_status, sale_price, final_bid, sale_date, auction_end_date')
+              .or(sellerFilters.join(','))
+              .limit(100)
+          : Promise.resolve({ data: [] as BatListingRow[], error: null, count: null });
+
+        // Same identity-resolution pattern as profileStatsService.getUserProfileData:
+        // auction_comments filtered on the indexed author_external_identity_id,
+        // bids excluded via bid_amount IS NULL.
+        const commentsPromise = identityIds.length > 0
+          ? supabase
+              .from('auction_comments')
+              .select('id, comment_text, posted_at, vehicle_id', { count: 'exact' })
+              .in('author_external_identity_id', identityIds)
+              .is('bid_amount', null)
+              .order('posted_at', { ascending: false })
+              .limit(10)
+          : Promise.resolve({ data: [] as BatCommentRow[], error: null, count: 0 });
+
+        const [listingsRes, commentsRes] = await Promise.all([listingsPromise, commentsPromise]);
+        if (cancelled) return;
+
+        if (listingsRes.error) {
+          console.warn('[UserBatTrackRecord] bat_listings query failed:', listingsRes.error.message);
+        }
+        if (commentsRes.error) {
+          console.warn('[UserBatTrackRecord] auction_comments query failed:', commentsRes.error.message);
+        }
+
+        const rows = ((listingsRes.data as BatListingRow[] | null) || []).slice();
+        rows.sort((a, b) => {
+          const ta = listingDate(a) ? new Date(listingDate(a)!).getTime() : 0;
+          const tb = listingDate(b) ? new Date(listingDate(b)!).getTime() : 0;
+          return tb - ta;
+        });
+
+        setListings(rows);
+        setComments((commentsRes.data as BatCommentRow[] | null) || []);
+        setCommentCount(commentsRes.count ?? ((commentsRes.data as unknown[] | null)?.length || 0));
+      } catch (err) {
+        if (!cancelled) {
+          console.warn('[UserBatTrackRecord] load failed:', err);
+          setListings([]);
+          setComments([]);
+          setCommentCount(0);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId, username, identityKey]);
+
+  const { soldCount, gmv } = useMemo(() => {
+    let sold = 0;
+    let total = 0;
+    for (const row of listings) {
+      if (row.listing_status === 'sold') {
+        sold += 1;
+        total += row.sale_price ?? row.final_bid ?? 0;
+      }
+    }
+    return { soldCount: sold, gmv: total };
+  }, [listings]);
+
+  // No Empty Shells: nothing while loading, null when no substrate at all.
+  if (loading) return null;
+  if (listings.length === 0 && commentCount === 0) return null;
+
+  const headerLine = `${listings.length} LISTING${listings.length === 1 ? '' : 'S'} · ${soldCount} SOLD · ${formatPrice(gmv)} GMV`;
+
+  const labelStyle: React.CSSProperties = {
+    fontFamily: SANS,
+    fontSize: '8px',
+    fontWeight: 700,
+    letterSpacing: '0.12em',
+    textTransform: 'uppercase',
+    color: INK,
+  };
+
+  const gridTemplate = '88px 1fr 56px 84px';
+
+  return (
+    <div
+      className="up-bat-track-record"
+      style={{
+        border: `2px solid ${INK}`,
+        background: 'var(--up-surface, #ffffff)',
+        marginBottom: '8px',
+      }}
+    >
+      {/* Card header */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          gap: '8px',
+          padding: '8px 10px',
+          borderBottom: `2px solid ${INK}`,
+        }}
+      >
+        <span style={labelStyle}>BAT TRACK RECORD</span>
+        <span style={{ fontFamily: MONO, fontSize: '9px', fontWeight: 700, color: INK, whiteSpace: 'nowrap' }}>
+          {headerLine}
+        </span>
+      </div>
+
+      {/* Sales table */}
+      {listings.length > 0 && (
+        <div style={{ padding: '8px 10px' }}>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: gridTemplate,
+              gap: '0 8px',
+              paddingBottom: '4px',
+              borderBottom: `1px solid ${GHOST}`,
+            }}
+          >
+            <span style={{ ...labelStyle, color: 'var(--up-pencil, #888888)' }}>DATE</span>
+            <span style={{ ...labelStyle, color: 'var(--up-pencil, #888888)' }}>VEHICLE</span>
+            <span style={{ ...labelStyle, color: 'var(--up-pencil, #888888)' }}>RESULT</span>
+            <span style={{ ...labelStyle, color: 'var(--up-pencil, #888888)', textAlign: 'right' }}>PRICE</span>
+          </div>
+
+          {listings.map(row => {
+            const sold = row.listing_status === 'sold';
+            const rowColor = sold ? INK : NO_SALE_COLOR;
+            const rowWeight = sold ? 700 : 400;
+            const name = listingDisplayName(row);
+            const price = sold
+              ? formatPrice(row.sale_price ?? row.final_bid)
+              : row.final_bid != null
+                ? `${formatPrice(row.final_bid)} BID`
+                : '—';
+
+            return (
+              <div
+                key={row.id}
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: gridTemplate,
+                  gap: '0 8px',
+                  alignItems: 'baseline',
+                  padding: '5px 0',
+                  borderBottom: `1px solid ${GHOST}`,
+                  color: rowColor,
+                  fontWeight: rowWeight,
+                }}
+              >
+                <span style={{ fontFamily: MONO, fontSize: '9px', whiteSpace: 'nowrap' }}>
+                  {formatDate(listingDate(row))}
+                </span>
+                <span style={{ fontFamily: SANS, fontSize: '10px', lineHeight: 1.3 }}>
+                  {row.vehicle_id ? (
+                    <Link
+                      to={`/vehicle/${row.vehicle_id}`}
+                      style={{ color: 'inherit', textDecoration: 'none' }}
+                    >
+                      {name}
+                    </Link>
+                  ) : row.bat_listing_url ? (
+                    <a
+                      href={row.bat_listing_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ color: 'inherit', textDecoration: 'none' }}
+                    >
+                      {name}
+                    </a>
+                  ) : (
+                    name
+                  )}
+                </span>
+                <span style={{ fontFamily: MONO, fontSize: '8px', whiteSpace: 'nowrap' }}>
+                  {resultLabel(row.listing_status)}
+                </span>
+                <span style={{ fontFamily: MONO, fontSize: '9px', textAlign: 'right', whiteSpace: 'nowrap' }}>
+                  {price}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Comments chip + expandable list */}
+      {commentCount > 0 && (
+        <div style={{ padding: '0 10px 8px', marginTop: listings.length === 0 ? '8px' : 0 }}>
+          <button
+            type="button"
+            onClick={() => setCommentsOpen(prev => !prev)}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              padding: '3px 8px',
+              fontFamily: MONO,
+              fontSize: '8px',
+              fontWeight: 700,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              border: `1px solid ${INK}`,
+              background: commentsOpen ? INK : 'transparent',
+              color: commentsOpen ? 'var(--up-surface, #ffffff)' : INK,
+              cursor: 'pointer',
+            }}
+          >
+            COMMENTS ({commentCount}) {commentsOpen ? '▾' : '▸'}
+          </button>
+
+          {commentsOpen && comments.length > 0 && (
+            <div style={{ marginTop: '6px' }}>
+              {comments.map(c => (
+                <div
+                  key={c.id}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: '8px',
+                    padding: '5px 0',
+                    borderBottom: `1px solid ${GHOST}`,
+                  }}
+                >
+                  <span
+                    style={{
+                      fontFamily: MONO,
+                      fontSize: '8px',
+                      color: 'var(--up-pencil, #888888)',
+                      whiteSpace: 'nowrap',
+                      flexShrink: 0,
+                      minWidth: '78px',
+                    }}
+                  >
+                    {formatDate(c.posted_at)}
+                  </span>
+                  <span style={{ fontFamily: SANS, fontSize: '9px', lineHeight: 1.4, color: INK }}>
+                    {truncate((c.comment_text || '').trim(), 160)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default UserBatTrackRecord;

--- a/nuke_frontend/src/pages/user-profile/UserBatTrackRecord.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserBatTrackRecord.tsx
@@ -40,10 +40,19 @@ interface BatCommentRow {
 
 interface UserBatTrackRecordProps {
   userId: string;
-  /** BaT seller handle for the seller_username match (e.g. 'skylarwilliams'). */
-  username: string | null;
-  /** Claimed external_identities ids for this profile. */
-  identityIds: string[];
+  /**
+   * Optional extra seller_username match (e.g. 'skylarwilliams').
+   * The widget always ALSO matches the handles of the user's claimed
+   * platform='bat' identities, so profile.username ('skylar') is safe to pass
+   * even though it differs from the BaT handle.
+   */
+  username?: string | null;
+  /**
+   * Claimed external_identities ids for this profile. If omitted, the widget
+   * resolves them itself via external_identities.claimed_by_user_id = userId
+   * (same resolution profileStatsService.getUserProfileData uses).
+   */
+  identityIds?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -111,7 +120,7 @@ const UserBatTrackRecord: React.FC<UserBatTrackRecordProps> = ({ userId, usernam
   const [commentCount, setCommentCount] = useState(0);
   const [commentsOpen, setCommentsOpen] = useState(false);
 
-  const identityKey = identityIds.join(',');
+  const identityKey = identityIds ? identityIds.join(',') : 'auto';
 
   useEffect(() => {
     let cancelled = false;
@@ -119,11 +128,48 @@ const UserBatTrackRecord: React.FC<UserBatTrackRecordProps> = ({ userId, usernam
     const load = async () => {
       setLoading(true);
       try {
-        const cleanUsername = (username || '').trim().replace(/"/g, '');
+        // Identity resolution — same pattern as profileStatsService.getUserProfileData:
+        // claimed external_identities for this user. Used for both the listings
+        // seller match (BaT handles + identity ids) and the comments author match.
+        let resolvedIds: string[] = identityIds || [];
+        let batHandles: string[] = [];
+
+        if (userId && (!identityIds || identityIds.length === 0)) {
+          const { data: identities, error: idErr } = await supabase
+            .from('external_identities')
+            .select('id, platform, handle')
+            .eq('claimed_by_user_id', userId);
+          if (idErr) {
+            console.warn('[UserBatTrackRecord] external_identities query failed:', idErr.message);
+          }
+          resolvedIds = (identities || []).map(ei => ei.id);
+          batHandles = (identities || [])
+            .filter(ei => ei.platform === 'bat' && ei.handle)
+            .map(ei => ei.handle as string);
+        } else if (identityIds && identityIds.length > 0) {
+          // Ids were supplied; still resolve BaT handles for the username match
+          // (bat_listings rows can carry seller_username but a NULL identity id —
+          // the $31K GMC C2500 row does exactly that in prod).
+          const { data: identities } = await supabase
+            .from('external_identities')
+            .select('id, platform, handle')
+            .in('id', identityIds);
+          batHandles = (identities || [])
+            .filter(ei => ei.platform === 'bat' && ei.handle)
+            .map(ei => ei.handle as string);
+        }
+        if (cancelled) return;
+
+        const sellerNames = new Set<string>(batHandles);
+        const cleanUsername = (username || '').trim();
+        if (cleanUsername) sellerNames.add(cleanUsername);
+
         const sellerFilters: string[] = [];
-        if (cleanUsername) sellerFilters.push(`seller_username.eq."${cleanUsername}"`);
-        if (identityIds.length > 0) {
-          sellerFilters.push(`seller_external_identity_id.in.(${identityIds.join(',')})`);
+        for (const name of sellerNames) {
+          sellerFilters.push(`seller_username.eq."${name.replace(/"/g, '')}"`);
+        }
+        if (resolvedIds.length > 0) {
+          sellerFilters.push(`seller_external_identity_id.in.(${resolvedIds.join(',')})`);
         }
 
         const listingsPromise = sellerFilters.length > 0
@@ -134,14 +180,12 @@ const UserBatTrackRecord: React.FC<UserBatTrackRecordProps> = ({ userId, usernam
               .limit(100)
           : Promise.resolve({ data: [] as BatListingRow[], error: null, count: null });
 
-        // Same identity-resolution pattern as profileStatsService.getUserProfileData:
-        // auction_comments filtered on the indexed author_external_identity_id,
-        // bids excluded via bid_amount IS NULL.
-        const commentsPromise = identityIds.length > 0
+        // Comments on the indexed author_external_identity_id; bids excluded.
+        const commentsPromise = resolvedIds.length > 0
           ? supabase
               .from('auction_comments')
               .select('id, comment_text, posted_at, vehicle_id', { count: 'exact' })
-              .in('author_external_identity_id', identityIds)
+              .in('author_external_identity_id', resolvedIds)
               .is('bid_amount', null)
               .order('posted_at', { ascending: false })
               .limit(10)

--- a/nuke_frontend/src/pages/user-profile/UserMoneyFlow.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserMoneyFlow.tsx
@@ -1,0 +1,324 @@
+/**
+ * UserMoneyFlow — owner-only money flow card.
+ *
+ * Substrate: payment_events (non-superseded) for this user. This is the
+ * provenance-carrying payments ledger — every row has source DNA
+ * (source_observation_id / source_url / method). Receipts are a different
+ * substrate and are deliberately NOT joined here.
+ *
+ * Renders: IN/OUT totals (Courier New), per-year paired flat 2px bars,
+ * last-5 events list. Footer states the source table + row count.
+ *
+ * Self-guarding: returns null for visitors (even with data) and when the
+ * user has zero payment events.
+ */
+import React, { useEffect, useMemo, useState } from 'react';
+import { supabase } from '../../lib/supabase';
+
+interface PaymentEventRow {
+  id: string;
+  direction: 'in' | 'out' | string;
+  amount_usd: number | string;
+  paid_at: string;
+  counterparty_name: string | null;
+}
+
+interface YearFlow {
+  year: number;
+  inTotal: number;
+  outTotal: number;
+}
+
+interface UserMoneyFlowProps {
+  userId: string;
+  isOwnProfile: boolean;
+}
+
+const INK = '#1a1a1a';
+const MUTED = '#666';
+
+const fmtUsd = (n: number): string =>
+  `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const fmtUsdWhole = (n: number): string =>
+  `$${Math.round(n).toLocaleString('en-US')}`;
+
+const fmtDate = (iso: string): string => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso.slice(0, 10);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+};
+
+const UserMoneyFlow: React.FC<UserMoneyFlowProps> = ({ userId, isOwnProfile }) => {
+  const [rows, setRows] = useState<PaymentEventRow[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    // Owner-only: never even fetch for visitors.
+    if (!userId || !isOwnProfile) return;
+    let cancelled = false;
+
+    (async () => {
+      const { data, error } = await supabase
+        .from('payment_events')
+        .select('id, direction, amount_usd, paid_at, counterparty_name')
+        .eq('user_id', userId)
+        .not('is_superseded', 'is', true) // IS NOT TRUE — keeps false AND null
+        .order('paid_at', { ascending: false })
+        .limit(1000);
+
+      if (cancelled) return;
+      if (error) {
+        setRows([]);
+      } else {
+        setRows((data || []) as PaymentEventRow[]);
+      }
+      setLoaded(true);
+    })();
+
+    return () => { cancelled = true; };
+  }, [userId, isOwnProfile]);
+
+  const { inTotal, outTotal, years, lastFive } = useMemo(() => {
+    let inSum = 0;
+    let outSum = 0;
+    const byYear = new Map<number, YearFlow>();
+
+    for (const r of rows) {
+      const amt = Number(r.amount_usd) || 0;
+      const year = new Date(r.paid_at).getFullYear();
+      if (!Number.isFinite(year)) continue;
+      const yf = byYear.get(year) || { year, inTotal: 0, outTotal: 0 };
+      if (r.direction === 'out') {
+        outSum += amt;
+        yf.outTotal += amt;
+      } else {
+        inSum += amt;
+        yf.inTotal += amt;
+      }
+      byYear.set(year, yf);
+    }
+
+    // Continuous year range from first to last year with events
+    const present = Array.from(byYear.keys()).sort((a, b) => a - b);
+    const yearRows: YearFlow[] = [];
+    if (present.length > 0) {
+      for (let y = present[0]; y <= present[present.length - 1]; y++) {
+        yearRows.push(byYear.get(y) || { year: y, inTotal: 0, outTotal: 0 });
+      }
+    }
+
+    return {
+      inTotal: inSum,
+      outTotal: outSum,
+      years: yearRows,
+      lastFive: rows.slice(0, 5), // already ordered paid_at desc
+    };
+  }, [rows]);
+
+  const maxYearFlow = useMemo(
+    () => Math.max(1, ...years.map((y) => Math.max(y.inTotal, y.outTotal))),
+    [years],
+  );
+
+  // Self-guards: visitors never see this card; no rows = no shell.
+  if (!isOwnProfile) return null;
+  if (!loaded) return null;
+  if (rows.length === 0) return null;
+
+  return (
+    <div
+      className="up-money-flow"
+      style={{
+        border: `2px solid ${INK}`,
+        padding: '12px',
+        marginBottom: '8px',
+        fontFamily: 'Arial, sans-serif',
+        color: INK,
+      }}
+      data-user-id={userId}
+      data-event-count={rows.length}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'baseline',
+          marginBottom: '10px',
+          paddingBottom: '6px',
+          borderBottom: `1px solid ${INK}`,
+        }}
+      >
+        <span style={{ fontSize: '9px', fontWeight: 700, letterSpacing: '0.1em' }}>
+          MONEY FLOW
+        </span>
+        <span style={{ fontSize: '8px', color: MUTED, letterSpacing: '0.06em' }}>
+          OWNER ONLY
+        </span>
+      </div>
+
+      {/* IN / OUT totals */}
+      <div style={{ display: 'flex', gap: '24px', marginBottom: '12px' }}>
+        <div>
+          <div style={{ fontSize: '8px', color: MUTED, letterSpacing: '0.1em', marginBottom: '2px' }}>
+            ← IN
+          </div>
+          <div style={{ fontFamily: '"Courier New", monospace', fontSize: '15px', fontWeight: 700 }}>
+            {fmtUsd(inTotal)}
+          </div>
+        </div>
+        <div>
+          <div style={{ fontSize: '8px', color: MUTED, letterSpacing: '0.1em', marginBottom: '2px' }}>
+            → OUT
+          </div>
+          <div style={{ fontFamily: '"Courier New", monospace', fontSize: '15px', fontWeight: 700, color: MUTED }}>
+            {fmtUsd(outTotal)}
+          </div>
+        </div>
+        <div>
+          <div style={{ fontSize: '8px', color: MUTED, letterSpacing: '0.1em', marginBottom: '2px' }}>
+            NET
+          </div>
+          <div style={{ fontFamily: '"Courier New", monospace', fontSize: '15px', fontWeight: 700 }}>
+            {inTotal - outTotal >= 0 ? '+' : '−'}{fmtUsd(Math.abs(inTotal - outTotal))}
+          </div>
+        </div>
+      </div>
+
+      {/* Per-year paired flat 2px bars */}
+      {years.length > 0 && (
+        <div style={{ marginBottom: '12px' }}>
+          <div style={{ fontSize: '8px', color: MUTED, letterSpacing: '0.1em', marginBottom: '4px' }}>
+            BY YEAR
+          </div>
+          {years.map((y) => (
+            <div
+              key={y.year}
+              style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px' }}
+            >
+              <span
+                style={{
+                  fontFamily: '"Courier New", monospace',
+                  fontSize: '9px',
+                  width: '32px',
+                  flexShrink: 0,
+                }}
+              >
+                {y.year}
+              </span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                {/* IN bar */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '2px' }}>
+                  <div
+                    style={{
+                      height: '2px',
+                      width: `${Math.max(y.inTotal > 0 ? 1 : 0, (y.inTotal / maxYearFlow) * 100)}%`,
+                      background: INK,
+                    }}
+                  />
+                  {y.inTotal > 0 && (
+                    <span style={{ fontFamily: '"Courier New", monospace', fontSize: '8px', whiteSpace: 'nowrap' }}>
+                      {fmtUsdWhole(y.inTotal)}
+                    </span>
+                  )}
+                </div>
+                {/* OUT bar */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                  <div
+                    style={{
+                      height: '2px',
+                      width: `${Math.max(y.outTotal > 0 ? 1 : 0, (y.outTotal / maxYearFlow) * 100)}%`,
+                      background: '#999',
+                    }}
+                  />
+                  {y.outTotal > 0 && (
+                    <span style={{ fontFamily: '"Courier New", monospace', fontSize: '8px', color: MUTED, whiteSpace: 'nowrap' }}>
+                      {fmtUsdWhole(y.outTotal)}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Last 5 events */}
+      {lastFive.length > 0 && (
+        <div>
+          <div style={{ fontSize: '8px', color: MUTED, letterSpacing: '0.1em', marginBottom: '4px' }}>
+            RECENT
+          </div>
+          {lastFive.map((r) => (
+            <div
+              key={r.id}
+              style={{
+                display: 'flex',
+                alignItems: 'baseline',
+                gap: '8px',
+                fontSize: '9px',
+                marginBottom: '3px',
+              }}
+            >
+              <span style={{ fontFamily: '"Courier New", monospace', flexShrink: 0 }}>
+                {fmtDate(r.paid_at)}
+              </span>
+              <span
+                style={{
+                  fontFamily: '"Courier New", monospace',
+                  flexShrink: 0,
+                  color: r.direction === 'out' ? MUTED : INK,
+                }}
+              >
+                {r.direction === 'out' ? '→' : '←'}
+              </span>
+              <span
+                style={{
+                  fontFamily: '"Courier New", monospace',
+                  fontWeight: 700,
+                  flexShrink: 0,
+                  color: r.direction === 'out' ? MUTED : INK,
+                }}
+              >
+                {fmtUsd(Number(r.amount_usd) || 0)}
+              </span>
+              <span
+                style={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.04em',
+                  fontSize: '8px',
+                  color: '#444',
+                }}
+              >
+                {r.counterparty_name || '—'}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Source DNA footer */}
+      <div
+        style={{
+          marginTop: '10px',
+          paddingTop: '6px',
+          borderTop: `1px solid #ccc`,
+          fontSize: '8px',
+          color: MUTED,
+          letterSpacing: '0.08em',
+        }}
+      >
+        SOURCE: PAYMENT_EVENTS · {rows.length} ROWS
+      </div>
+    </div>
+  );
+};
+
+export default UserMoneyFlow;

--- a/nuke_frontend/src/pages/user-profile/UserProfileContext.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserProfileContext.tsx
@@ -197,10 +197,16 @@ export const UserProfileProvider: React.FC<{ children: React.ReactNode }> = ({ c
         setLoading(false);
       }
 
-      // Background: comprehensive stats data
-      const [compData, profileData] = await Promise.all([
+      // Background: comprehensive stats data + per-day contribution aggregates.
+      // getContributionDays replaces the ProfileService.getProfileData leg here:
+      // that path ran three wide row-level selects (vehicle_images /
+      // vehicle_timeline_events / business_timeline_events) each silently
+      // capped at 1000 rows by PostgREST db-max-rows, so the timeline rendered
+      // whichever arbitrary slice fit — and only for the owner. The RPC returns
+      // complete (day, kind, n) aggregates for any profile in one small call.
+      const [compData, contributionDays] = await Promise.all([
         getUserProfileData(uid).catch(() => null),
-        isOwnProfile ? ProfileService.getProfileData(uid).catch(() => null) : null,
+        ProfileService.getContributionDays(uid).catch(() => null),
       ]);
 
       if (compData) {
@@ -209,9 +215,8 @@ export const UserProfileProvider: React.FC<{ children: React.ReactNode }> = ({ c
         buildEventsFromComprehensive(compData as any);
       }
 
-      // Build contribution events from profile data
-      if (profileData?.recentContributions) {
-        buildContributionEvents(profileData.recentContributions);
+      if (contributionDays) {
+        buildContributionEvents(contributionDays);
       }
 
       // Photo library stats (own profile only, uses auth session internally)
@@ -277,18 +282,35 @@ export const UserProfileProvider: React.FC<{ children: React.ReactNode }> = ({ c
     setActivityEvents(events);
   }, []);
 
-  const buildContributionEvents = useCallback((contributions: any[]) => {
+  // Map get_user_contribution_days rows (day, kind, n) → ContributionEvents.
+  // The kind map is OPEN: photo/event/work flow today; business / auction /
+  // comment kinds pass through to their own facets the moment the RPC emits
+  // them, instead of being collapsed into timeline_event (the old remap
+  // flattened everything non-photo, which is why auctions/comments never
+  // reached the heatmap).
+  const buildContributionEvents = useCallback((rows: Array<{ day: string; kind: string; n: number }>) => {
+    const KIND_TO_TYPE: Record<string, ContributionEvent['type']> = {
+      photo: 'image_upload',
+      event: 'timeline_event',
+      work: 'work',
+      business: 'business_event',
+      auction: 'auction_activity',
+      comment: 'comment',
+    };
+    const KIND_LABEL: Record<string, [string, string]> = {
+      photo: ['photo', 'photos'],
+      event: ['event', 'events'],
+      work: ['work session', 'work sessions'],
+    };
     const events: ContributionEvent[] = [];
-    for (const c of contributions) {
+    for (const r of rows) {
+      if (!r?.day || !r?.n) continue;
+      const [one, many] = KIND_LABEL[r.kind] || ['contribution', 'contributions'];
       events.push({
-        date: c.contribution_date,
-        type: c.contribution_type === 'image_upload' ? 'image_upload' : 'timeline_event',
-        count: c.contribution_count,
-        label: c.contribution_type === 'image_upload'
-          ? `${c.contribution_count} photo${c.contribution_count > 1 ? 's' : ''}`
-          : c.metadata?.title || 'Activity',
-        vehicleId: c.related_vehicle_id || undefined,
-        metadata: c.metadata,
+        date: r.day,
+        type: KIND_TO_TYPE[r.kind] ?? 'timeline_event',
+        count: r.n,
+        label: `${r.n} ${r.n === 1 ? one : many}`,
       });
     }
     setContributionEvents(events);

--- a/nuke_frontend/src/pages/user-profile/UserRecentPhotos.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserRecentPhotos.tsx
@@ -1,0 +1,250 @@
+/**
+ * UserRecentPhotos — dense recent-photos strip for the user profile.
+ *
+ * Replaces PublicImageGallery on the profile (that component is shared with
+ * Profile.tsx / Profile.legacy.tsx, so it is left untouched for other consumers).
+ *
+ * Data: vehicle_images by user_id, newest-first.
+ *  - Owner path includes NULL-vehicle (inbox) images.
+ *  - Visitor path only vehicle-attached images on public vehicles (RLS-aligned).
+ *
+ * Header shows EXACT totals via count/head queries (no top-K pretence):
+ *   "20,978 IMAGES · 154 THIS WEEK"
+ *
+ * Self-guarding: returns null while loading and at 0 images (No Empty Shells).
+ */
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { supabase } from '../../lib/supabase';
+import { optimizeImageUrl } from '../../lib/imageOptimizer';
+import { CollapsibleWidget } from '../../components/ui/CollapsibleWidget';
+
+interface UserRecentPhotosProps {
+  userId: string;
+  isOwnProfile: boolean;
+}
+
+interface PhotoRow {
+  id: string;
+  image_url: string | null;
+  thumbnail_url: string | null;
+  storage_path: string | null;
+  source: string | null;
+  source_url: string | null;
+  taken_at: string | null;
+  created_at: string | null;
+}
+
+const GRID_LIMIT = 60;
+
+// Source guards carried over from PublicImageGallery — keep scraped/imported
+// imagery out of the personal strip. Applied to displayed thumbs only;
+// header counts stay exact.
+const SOURCE_BLOCKLIST = new Set([
+  'bat_import',
+  'bat_listing',
+  'external_import',
+  'organization_import',
+  'scraper',
+  'url_scraper',
+  'classic_com_indexing',
+  'classic_scrape',
+  'collector_scrape',
+]);
+
+const IMPORT_PATH_TOKENS = [
+  'import_queue',
+  'external_import',
+  'organization_import',
+  'bat_import',
+  'classic.com/veh',
+  'bringatrailer.com/wp-content/uploads',
+];
+
+const looksImported = (value?: string | null): boolean => {
+  if (!value) return false;
+  const lower = String(value).toLowerCase();
+  return IMPORT_PATH_TOKENS.some(token => lower.includes(token));
+};
+
+const passesSourceGuards = (img: PhotoRow): boolean => {
+  const src = String(img.source || '').toLowerCase();
+  if (src && SOURCE_BLOCKLIST.has(src)) return false;
+  if (looksImported(img.storage_path)) return false;
+  if (looksImported(img.image_url)) return false;
+  if (String(img.source_url || '').trim().startsWith('http')) return false;
+  return true;
+};
+
+/** Day (YYYY-MM-DD) for the journal click-through — EXIF taken_at, created_at fallback. */
+const journalDay = (img: PhotoRow): string | null => {
+  const stamp = img.taken_at || img.created_at;
+  if (!stamp || stamp.length < 10) return null;
+  return stamp.slice(0, 10);
+};
+
+const GRID_COLUMNS = `id, image_url, thumbnail_url, storage_path, source, source_url, taken_at, created_at`;
+
+const UserRecentPhotos: React.FC<UserRecentPhotosProps> = ({ userId, isOwnProfile }) => {
+  const [images, setImages] = useState<PhotoRow[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [weekCount, setWeekCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [failedIds, setFailedIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!userId) return;
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+        // Visitor path inner-joins vehicles and keeps only public ones;
+        // owner path has no vehicle filter so NULL-vehicle inbox images count.
+        const countSelect = isOwnProfile
+          ? 'id'
+          : 'id, vehicle:vehicles!vehicle_images_vehicle_id_fkey!inner(id)';
+        const gridSelect = isOwnProfile
+          ? GRID_COLUMNS
+          : `${GRID_COLUMNS}, vehicle:vehicles!vehicle_images_vehicle_id_fkey!inner(id)`;
+
+        const withVisibility = <T,>(query: T): T => {
+          if (isOwnProfile) return query;
+          return (query as any).eq('vehicle.is_public', true);
+        };
+
+        const [totalRes, weekRes, gridRes] = await Promise.all([
+          withVisibility(
+            supabase
+              .from('vehicle_images')
+              .select(countSelect, { count: 'exact', head: true })
+              .eq('user_id', userId)
+          ),
+          withVisibility(
+            supabase
+              .from('vehicle_images')
+              .select(countSelect, { count: 'exact', head: true })
+              .eq('user_id', userId)
+              .gte('created_at', weekAgo)
+          ),
+          withVisibility(
+            supabase
+              .from('vehicle_images')
+              .select(gridSelect)
+              .eq('user_id', userId)
+              .order('created_at', { ascending: false })
+              .limit(GRID_LIMIT)
+          ),
+        ]);
+
+        if (cancelled) return;
+
+        if (totalRes.error) throw totalRes.error;
+        if (weekRes.error) throw weekRes.error;
+        if (gridRes.error) throw gridRes.error;
+
+        const rows = ((gridRes.data || []) as unknown as PhotoRow[]).filter(passesSourceGuards);
+
+        setTotalCount(totalRes.count || 0);
+        setWeekCount(weekRes.count || 0);
+        setImages(rows);
+      } catch (error) {
+        console.error('[UserRecentPhotos] load failed:', error);
+        if (!cancelled) {
+          setImages([]);
+          setTotalCount(0);
+          setWeekCount(0);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+    return () => { cancelled = true; };
+  }, [userId, isOwnProfile]);
+
+  // No Empty Shells: nothing while loading, nothing at 0 images.
+  if (loading) return null;
+  if (totalCount === 0 || images.length === 0) return null;
+
+  const headerLine = `${totalCount.toLocaleString('en-US')} IMAGES${
+    weekCount > 0 ? ` · ${weekCount.toLocaleString('en-US')} THIS WEEK` : ''
+  }`;
+
+  return (
+    <CollapsibleWidget
+      title="RECENT PHOTOS"
+      variant="profile"
+      badge={
+        <span
+          style={{
+            fontFamily: "'Courier New', Courier, monospace",
+            fontSize: '9px',
+            fontWeight: 700,
+            letterSpacing: '0.05em',
+            textTransform: 'uppercase',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {headerLine}
+        </span>
+      }
+    >
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(56px, 1fr))',
+          gap: '2px',
+        }}
+      >
+        {images.map(img => {
+          const rawUrl = img.thumbnail_url || img.image_url;
+          if (!rawUrl) return null;
+          const src = failedIds.has(img.id)
+            ? (img.image_url || rawUrl)
+            : (optimizeImageUrl(rawUrl, 'thumbnail') || rawUrl);
+          const day = journalDay(img);
+          const thumb = (
+            <img
+              src={src}
+              alt=""
+              loading="lazy"
+              decoding="async"
+              onError={() => {
+                setFailedIds(prev => {
+                  if (prev.has(img.id)) return prev;
+                  const next = new Set(prev);
+                  next.add(img.id);
+                  return next;
+                });
+              }}
+              style={{
+                width: '100%',
+                aspectRatio: '1 / 1',
+                objectFit: 'cover',
+                display: 'block',
+                background: '#eeeeee',
+              }}
+            />
+          );
+          return day ? (
+            <Link
+              key={img.id}
+              to={`/journal/${day}`}
+              title={day}
+              style={{ display: 'block', lineHeight: 0 }}
+            >
+              {thumb}
+            </Link>
+          ) : (
+            <div key={img.id} style={{ lineHeight: 0 }}>{thumb}</div>
+          );
+        })}
+      </div>
+    </CollapsibleWidget>
+  );
+};
+
+export default UserRecentPhotos;

--- a/nuke_frontend/src/pages/user-profile/UserSettingsDrawer.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserSettingsDrawer.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, Suspense } from 'react';
 import { useUserProfile } from './UserProfileContext';
 import { supabase } from '../../lib/supabase';
+import TextScaleControl from '../../components/TextScaleControl';
 
 const ChangePasswordForm = React.lazy(
   () => import('../../components/auth/ChangePasswordForm')
@@ -125,6 +126,12 @@ const UserSettingsDrawer: React.FC<UserSettingsDrawerProps> = ({ open: openProp,
           </button>
         </div>
         <div className="up-drawer__body">
+          {/* ── DISPLAY ── */}
+          <div className="up-dossier-group">
+            <div className="up-dossier-group__label">DISPLAY</div>
+            <TextScaleControl />
+          </div>
+
           {/* ── PROFILE ── */}
           <div className="up-dossier-group">
             <div className="up-dossier-group__label">PROFILE</div>

--- a/nuke_frontend/src/pages/user-profile/UserSubHeader.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserSubHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useUserProfile } from './UserProfileContext';
+import TextScaleControl from '../../components/TextScaleControl';
 
 /**
  * UserSubHeader -- Badge bar below the header.
@@ -62,6 +63,9 @@ const UserSubHeader: React.FC = () => {
           {tag.toUpperCase()}
         </span>
       ))}
+
+      {/* Text size control — right end */}
+      <TextScaleControl variant="compact" />
     </div>
   );
 };

--- a/nuke_frontend/src/pages/user-profile/UserWorkLedger.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserWorkLedger.tsx
@@ -1,0 +1,303 @@
+/**
+ * UserWorkLedger — the decade-of-wrenching card.
+ *
+ * Substrate: work_sessions WHERE user_id = profile user (production table —
+ * read it, don't rebuild it). One query, client-side aggregation (~325 rows).
+ *
+ * Three bands in one bordered card:
+ *   (a) headline stat row in Courier New — SESSIONS / HRS / VEHICLES / JOB COST
+ *   (b) per-year hours as flat 2px-bordered horizontal bars
+ *   (c) recent-10 sessions list: date / title (or work_type) / hours
+ *
+ * Dollars are owner-only (isOwnProfile). Self-guards: returns null at 0 rows.
+ */
+import React, { useEffect, useMemo, useState } from 'react';
+import { supabase } from '../../lib/supabase';
+
+interface WorkSessionRow {
+  session_date: string;
+  duration_minutes: number;
+  total_job_cost: number | string | null;
+  vehicle_id: string;
+  title: string | null;
+  work_type: string | null;
+}
+
+interface UserWorkLedgerProps {
+  userId: string;
+  isOwnProfile: boolean;
+}
+
+const MONO = '"Courier New", Courier, monospace';
+const INK = '#1a1a1a';
+
+const fmtHours = (minutes: number): string => {
+  const hrs = minutes / 60;
+  return hrs >= 100 ? String(Math.round(hrs)) : hrs.toFixed(1);
+};
+
+const fmtCostK = (cost: number): string => {
+  if (cost >= 1000) return `$${(cost / 1000).toFixed(1)}K`;
+  return `$${Math.round(cost)}`;
+};
+
+const fmtDate = (iso: string): string => {
+  // session_date is a bare DATE — keep it literal, no TZ math
+  const [y, m, d] = iso.split('-');
+  const months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
+  const mi = parseInt(m, 10) - 1;
+  return `${y}-${months[mi] || m}-${d}`;
+};
+
+const UserWorkLedger: React.FC<UserWorkLedgerProps> = ({ userId, isOwnProfile }) => {
+  const [sessions, setSessions] = useState<WorkSessionRow[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!userId) return;
+    let cancelled = false;
+
+    (async () => {
+      const { data, error } = await supabase
+        .from('work_sessions')
+        .select('session_date, duration_minutes, total_job_cost, vehicle_id, title, work_type')
+        .eq('user_id', userId)
+        .order('session_date', { ascending: false })
+        .limit(2000);
+
+      if (cancelled) return;
+      if (error) {
+        setSessions([]);
+      } else {
+        setSessions(data || []);
+      }
+      setLoaded(true);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  const agg = useMemo(() => {
+    if (sessions.length === 0) return null;
+
+    let totalMinutes = 0;
+    let totalCost = 0;
+    const vehicles = new Set<string>();
+    const minutesByYear = new Map<number, number>();
+    let minYear = Infinity;
+    let maxYear = -Infinity;
+
+    for (const s of sessions) {
+      const mins = s.duration_minutes || 0;
+      totalMinutes += mins;
+      totalCost += Number(s.total_job_cost) || 0;
+      if (s.vehicle_id) vehicles.add(s.vehicle_id);
+
+      const year = parseInt(s.session_date.slice(0, 4), 10);
+      if (!Number.isNaN(year)) {
+        minutesByYear.set(year, (minutesByYear.get(year) || 0) + mins);
+        if (year < minYear) minYear = year;
+        if (year > maxYear) maxYear = year;
+      }
+    }
+
+    // Every year in range gets a row, including zero-hour years — the gaps
+    // are part of the decade's story.
+    const years: Array<{ year: number; minutes: number }> = [];
+    let maxYearMinutes = 0;
+    if (minYear <= maxYear) {
+      for (let y = minYear; y <= maxYear; y++) {
+        const m = minutesByYear.get(y) || 0;
+        years.push({ year: y, minutes: m });
+        if (m > maxYearMinutes) maxYearMinutes = m;
+      }
+    }
+
+    return {
+      count: sessions.length,
+      totalMinutes,
+      totalCost,
+      vehicleCount: vehicles.size,
+      years,
+      maxYearMinutes,
+      recent: sessions.slice(0, 10),
+    };
+  }, [sessions]);
+
+  // Self-guard: nothing until loaded, null forever when the substrate is empty
+  if (!loaded) return null;
+  if (!agg || agg.count === 0) return null;
+
+  const stats: Array<{ value: string; label: string }> = [
+    { value: String(agg.count), label: 'SESSIONS' },
+    { value: fmtHours(agg.totalMinutes), label: 'HRS' },
+    { value: String(agg.vehicleCount), label: 'VEHICLES' },
+  ];
+  if (isOwnProfile && agg.totalCost > 0) {
+    stats.push({ value: fmtCostK(agg.totalCost), label: 'JOB COST' });
+  }
+
+  return (
+    <div
+      className="up-work-ledger"
+      style={{
+        border: `2px solid ${INK}`,
+        padding: '12px',
+        marginBottom: '8px',
+        fontFamily: 'Arial, sans-serif',
+        color: INK,
+      }}
+      data-user-id={userId}
+      data-session-count={agg.count}
+    >
+      {/* Card label */}
+      <div
+        style={{
+          fontSize: '9px',
+          fontWeight: 700,
+          letterSpacing: '0.1em',
+          marginBottom: '8px',
+          paddingBottom: '6px',
+          borderBottom: `1px solid ${INK}`,
+        }}
+      >
+        WORK LEDGER
+      </div>
+
+      {/* (a) Headline stat row — Courier New */}
+      <div
+        style={{
+          display: 'flex',
+          gap: '16px',
+          flexWrap: 'wrap',
+          marginBottom: '12px',
+        }}
+      >
+        {stats.map((s) => (
+          <div key={s.label}>
+            <div style={{ fontFamily: MONO, fontSize: '16px', fontWeight: 700, lineHeight: 1.1 }}>
+              {s.value}
+            </div>
+            <div style={{ fontSize: '8px', color: '#666', letterSpacing: '0.1em' }}>{s.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* (b) Per-year hours — flat 2px-bordered horizontal bars */}
+      {agg.years.length > 0 && agg.maxYearMinutes > 0 && (
+        <div style={{ marginBottom: '12px' }}>
+          <div style={{ fontSize: '8px', color: '#666', letterSpacing: '0.1em', marginBottom: '4px' }}>
+            HOURS BY YEAR
+          </div>
+          {agg.years.map(({ year, minutes }) => {
+            const pct = Math.round((minutes / agg.maxYearMinutes) * 100);
+            const hrs = minutes / 60;
+            return (
+              <div
+                key={year}
+                style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '2px' }}
+              >
+                <span
+                  style={{
+                    fontFamily: MONO,
+                    fontSize: '9px',
+                    width: '32px',
+                    flexShrink: 0,
+                    textAlign: 'right',
+                  }}
+                >
+                  {year}
+                </span>
+                <div style={{ flex: 1, position: 'relative', height: '10px' }}>
+                  {minutes > 0 && (
+                    <div
+                      style={{
+                        width: `${Math.max(pct, 2)}%`,
+                        height: '10px',
+                        background: INK,
+                        border: `2px solid ${INK}`,
+                        boxSizing: 'border-box',
+                      }}
+                    />
+                  )}
+                </div>
+                <span
+                  style={{
+                    fontFamily: MONO,
+                    fontSize: '9px',
+                    width: '44px',
+                    flexShrink: 0,
+                    textAlign: 'right',
+                    color: minutes > 0 ? INK : '#999',
+                  }}
+                >
+                  {minutes > 0 ? `${hrs >= 100 ? Math.round(hrs) : hrs.toFixed(1)}h` : '—'}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* (c) Recent 10 sessions — dense rows */}
+      {agg.recent.length > 0 && (
+        <div>
+          <div style={{ fontSize: '8px', color: '#666', letterSpacing: '0.1em', marginBottom: '4px' }}>
+            RECENT SESSIONS
+          </div>
+          {agg.recent.map((s, i) => {
+            const label = s.title || s.work_type || 'work session';
+            const hrs = (s.duration_minutes || 0) / 60;
+            return (
+              <div
+                key={`${s.session_date}-${i}`}
+                style={{
+                  display: 'flex',
+                  alignItems: 'baseline',
+                  gap: '8px',
+                  padding: '2px 0',
+                  borderBottom: i < agg.recent.length - 1 ? '1px solid #e5e5e5' : 'none',
+                  fontSize: '10px',
+                }}
+              >
+                <span style={{ fontFamily: MONO, fontSize: '9px', flexShrink: 0, color: '#666' }}>
+                  {fmtDate(s.session_date)}
+                </span>
+                <span
+                  style={{
+                    flex: 1,
+                    minWidth: 0,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                  title={label}
+                >
+                  {s.vehicle_id ? (
+                    <a
+                      href={`/vehicle/${s.vehicle_id}`}
+                      style={{ color: INK, textDecoration: 'none' }}
+                    >
+                      {label}
+                    </a>
+                  ) : (
+                    label
+                  )}
+                </span>
+                <span
+                  style={{ fontFamily: MONO, fontSize: '9px', flexShrink: 0, textAlign: 'right' }}
+                >
+                  {hrs > 0 ? `${hrs.toFixed(1)}h` : '—'}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default UserWorkLedger;

--- a/nuke_frontend/src/pages/user-profile/UserWorkspaceContent.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserWorkspaceContent.tsx
@@ -6,7 +6,6 @@
  * Right column: gallery, reputation, knowledge library, live player.
  */
 import React, { useState, useCallback } from 'react';
-import { CollapsibleWidget } from '../../components/ui/CollapsibleWidget';
 import { useUserProfile } from './UserProfileContext';
 
 // Lazy-load all card components
@@ -19,27 +18,24 @@ const ColumnDivider = React.lazy(() => import('../vehicle-profile/ColumnDivider'
 
 // Existing profile components
 const VehicleCollection = React.lazy(() => import('../../components/profile/VehicleCollection'));
-const PublicAuctionTrackRecord = React.lazy(() => import('../../components/profile/PublicAuctionTrackRecord'));
 const UserDiscoveries = React.lazy(() => import('../../components/profile/UserDiscoveries'));
-const ProfileCommentsTab = React.lazy(() =>
-  import('../../components/profile/ProfileCommentsTab').then(m => ({ default: m.ProfileCommentsTab }))
-);
-const ProfileBidsTab = React.lazy(() =>
-  import('../../components/profile/ProfileBidsTab').then(m => ({ default: m.ProfileBidsTab }))
-);
-const ProfileListingsTab = React.lazy(() =>
-  import('../../components/profile/ProfileListingsTab').then(m => ({ default: m.ProfileListingsTab }))
-);
-const ProfileSuccessStoriesTab = React.lazy(() =>
-  import('../../components/profile/ProfileSuccessStoriesTab').then(m => ({ default: m.ProfileSuccessStoriesTab }))
-);
 const OrganizationAffiliations = React.lazy(() => import('../../components/profile/OrganizationAffiliations'));
 const ProfessionalToolbox = React.lazy(() => import('../../components/profile/ProfessionalToolbox'));
 const VehicleMergeInterface = React.lazy(() => import('../../components/vehicle/VehicleMergeInterface'));
 
+// Data-viz widgets (2026-06-10 overhaul) — every one self-guards to null on
+// empty data per the no-empty-shells rule, so no hasX gating needed here.
+// Replaced/deleted: PublicAuctionTrackRecord + ProfileCommentsTab/BidsTab/
+// ListingsTab (queried tables that don't exist in prod; BaT widget reads
+// bat_listings + auction_comments directly), ProfileSuccessStoriesTab
+// (success_stories table doesn't exist), UserReputationWidget (all inputs
+// nonexistent columns — rendered empty bars forever).
+const UserWorkLedger = React.lazy(() => import('./UserWorkLedger'));
+const UserBatTrackRecord = React.lazy(() => import('./UserBatTrackRecord'));
+const UserMoneyFlow = React.lazy(() => import('./UserMoneyFlow'));
+
 // Right column
-const UserReputationWidget = React.lazy(() => import('./UserReputationWidget'));
-const PublicImageGallery = React.lazy(() => import('../../components/profile/PublicImageGallery'));
+const UserRecentPhotos = React.lazy(() => import('./UserRecentPhotos'));
 const KnowledgeLibrary = React.lazy(() => import('../../components/profile/KnowledgeLibrary'));
 const LivePlayer = React.lazy(() => import('../../components/profile/LivePlayer'));
 const MemelordPanel = React.lazy(() => import('../../components/profile/MemelordPanel'));
@@ -51,10 +47,6 @@ const UserWorkspaceContent: React.FC = () => {
     userId,
     profile,
     isOwnProfile,
-    stats,
-    comprehensiveData,
-    activityEvents,
-    session,
   } = useUserProfile();
 
   const [leftPct, setLeftPct] = useState(DEFAULT_LEFT_PCT);
@@ -63,13 +55,6 @@ const UserWorkspaceContent: React.FC = () => {
 
   if (!userId && !profile) return null;
 
-  const hasListings = comprehensiveData?.listings && comprehensiveData.listings.length > 0;
-  const hasTrackRecord = stats && stats.total_listings > 0;
-  const hasComments = comprehensiveData?.comments && comprehensiveData.comments.length > 0;
-  const hasBids = comprehensiveData?.bids && comprehensiveData.bids.length > 0;
-  const hasCommentsOrBids = hasComments || hasBids;
-  const hasListingsTab = hasListings;
-  const hasSuccessStories = comprehensiveData?.success_stories && comprehensiveData.success_stories.length > 0;
   const isNotBasicUser = profile?.user_type && profile.user_type !== 'user';
 
   return (
@@ -112,6 +97,13 @@ const UserWorkspaceContent: React.FC = () => {
             </React.Suspense>
           )}
 
+          {/* Work Ledger — the decade of wrenching (work_sessions substrate) */}
+          {userId && (
+            <React.Suspense fallback={null}>
+              <UserWorkLedger userId={userId} isOwnProfile={isOwnProfile} />
+            </React.Suspense>
+          )}
+
           {/* User Discoveries */}
           {userId && (
             <React.Suspense fallback={null}>
@@ -144,58 +136,19 @@ const UserWorkspaceContent: React.FC = () => {
               surfaces so they don't dominate the first screen for
               technician-producer users like Skylar. */}
 
-          {/* Public Auction Track Record */}
-          {hasTrackRecord && (
+          {/* BaT Track Record — reads bat_listings + auction_comments
+              directly (replaces the vehicle_events-derived card that found
+              1 of 5 sales, and absorbs the old Comments tab). */}
+          {userId && (
             <React.Suspense fallback={null}>
-              <PublicAuctionTrackRecord
-                listings={comprehensiveData?.listings || []}
-                loading={!comprehensiveData}
-                profileName={profile?.full_name || profile?.username || null}
-              />
+              <UserBatTrackRecord userId={userId} />
             </React.Suspense>
           )}
 
-          {/* Comments & Bids — merged card */}
-          {hasCommentsOrBids && (
-            <CollapsibleWidget variant="profile" title="Comments & Bids" defaultCollapsed={false}>
-              <React.Suspense fallback={null}>
-                {hasComments && (
-                  <ProfileCommentsTab
-                    comments={comprehensiveData?.comments || []}
-                    profileType="user"
-                  />
-                )}
-                {hasBids && (
-                  <ProfileBidsTab
-                    bids={comprehensiveData?.bids || []}
-                    profileType="user"
-                  />
-                )}
-              </React.Suspense>
-            </CollapsibleWidget>
-          )}
-
-          {/* Listings */}
-          {hasListingsTab && (
+          {/* Money Flow — owner-only inside the component (visitors: null) */}
+          {userId && (
             <React.Suspense fallback={null}>
-              <CollapsibleWidget variant="profile" title="Listings" defaultCollapsed={true}>
-                <ProfileListingsTab
-                  listings={comprehensiveData?.listings || []}
-                  profileType="user"
-                />
-              </CollapsibleWidget>
-            </React.Suspense>
-          )}
-
-          {/* Success Stories */}
-          {hasSuccessStories && (
-            <React.Suspense fallback={null}>
-              <CollapsibleWidget variant="profile" title="Success Stories" defaultCollapsed={true}>
-                <ProfileSuccessStoriesTab
-                  stories={comprehensiveData?.success_stories || []}
-                  profileType="user"
-                />
-              </CollapsibleWidget>
+              <UserMoneyFlow userId={userId} isOwnProfile={isOwnProfile} />
             </React.Suspense>
           )}
 
@@ -215,17 +168,12 @@ const UserWorkspaceContent: React.FC = () => {
         {/* RIGHT COLUMN */}
         <div className="up-col-right" style={{ width: `${100 - leftPct}%` }}>
 
-          {/* Public Image Gallery — always */}
+          {/* Recent Photos — true totals, lazy thumbs, day click-through */}
           {userId && (
             <React.Suspense fallback={null}>
-              <PublicImageGallery userId={userId} isOwnProfile={isOwnProfile} />
+              <UserRecentPhotos userId={userId} isOwnProfile={isOwnProfile} />
             </React.Suspense>
           )}
-
-          {/* Reputation Scores */}
-          <React.Suspense fallback={null}>
-            <UserReputationWidget />
-          </React.Suspense>
 
           {/* Knowledge Library / Live Player / Memelord Panel — disabled 2026-05-24
               per docs/library/working/field-notes/2026-05-24_safety-audit-completion.md §1:

--- a/nuke_frontend/src/pages/user-profile/types.ts
+++ b/nuke_frontend/src/pages/user-profile/types.ts
@@ -66,7 +66,9 @@ export interface UserComprehensiveData {
 
 export interface ContributionEvent {
   date: string;
-  type: 'image_upload' | 'timeline_event' | 'vehicle_added' | 'auction_activity' | 'comment' | 'profile_edit';
+  // Open facet set (skill-fingerprint doctrine): new kinds land here and get a
+  // pill in UserBarcodeTimeline only when they have data — never empty chrome.
+  type: 'image_upload' | 'timeline_event' | 'vehicle_added' | 'auction_activity' | 'comment' | 'profile_edit' | 'work' | 'business_event';
   count: number;
   label: string;
   vehicleId?: string;

--- a/nuke_frontend/src/pages/vehicle-profile/BarcodeTimeline.tsx
+++ b/nuke_frontend/src/pages/vehicle-profile/BarcodeTimeline.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState, useCallback, useRef, useEffect } from 'react';
 import { useVehicleProfile } from './VehicleProfileContext';
 import { usePopup } from '../../components/popups/usePopup';
+import { supabase } from '../../lib/supabase';
 
 interface BarcodeTimelineProps {}
 
@@ -281,21 +282,64 @@ const BarcodeTimeline: React.FC<BarcodeTimelineProps> = () => {
   const heatmapRef = useRef<HTMLDivElement>(null);
   const stripRef = useRef<HTMLDivElement>(null);
 
+  // Per-day photo/work densities from the substrate. timelineEvents alone
+  // starved the heatmap: an owner-import truck with 861 photos rendered
+  // "ALL (3) / PHOTOS (1)" (C10 quality check, 2026-06-10). The photos ARE
+  // the activity record — get_vehicle_contribution_days returns
+  // (day, kind photo|work|event, n); 'event' kind is skipped here because
+  // timelineEvents already carries the real events.
+  const [dayRows, setDayRows] = useState<{ day: string; kind: string; n: number }[]>([]);
+  useEffect(() => {
+    if (!vehicleId) return;
+    let cancelled = false;
+    supabase
+      .rpc('get_vehicle_contribution_days', { p_vehicle_id: vehicleId })
+      .then(({ data, error }) => {
+        if (error) console.warn('[BarcodeTimeline] contribution days:', error.message);
+        if (!cancelled && data) setDayRows(data as any[]);
+      });
+    return () => { cancelled = true; };
+  }, [vehicleId]);
+
+  // Synthesize photo/work day events for days the event feed doesn't cover.
+  const enrichedEvents = useMemo(() => {
+    if (dayRows.length === 0) return timelineEvents;
+    const coveredPhotoDays = new Set(
+      timelineEvents
+        .filter((ev: any) => (ev.metadata?.image_count > 0) || String(ev.event_type || '').toLowerCase() === 'photo_session')
+        .map((ev: any) => String(ev.event_date || '').slice(0, 10)),
+    );
+    const coveredWorkDays = new Set(
+      timelineEvents
+        .filter((ev: any) => ['work_session', 'repair', 'modification', 'maintenance', 'service'].includes(String(ev.event_type || '').toLowerCase()))
+        .map((ev: any) => String(ev.event_date || '').slice(0, 10)),
+    );
+    const synthetic: any[] = [];
+    for (const r of dayRows) {
+      if (r.kind === 'photo' && !coveredPhotoDays.has(r.day)) {
+        synthetic.push({ event_date: r.day, event_type: 'photo_session', title: `${r.n} photos`, metadata: { image_count: r.n, synthetic_day: true } });
+      } else if (r.kind === 'work' && !coveredWorkDays.has(r.day)) {
+        synthetic.push({ event_date: r.day, event_type: 'work_session', title: 'work session', metadata: { synthetic_day: true } });
+      }
+    }
+    return synthetic.length ? [...timelineEvents, ...synthetic] : timelineEvents;
+  }, [timelineEvents, dayRows]);
+
   // Filter counts — always computed from the full set so pills show totals before clicking
   const filterCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     for (const f of TIMELINE_FILTERS) {
-      counts[f.key] = f.key === 'all' ? timelineEvents.length : timelineEvents.filter(f.match).length;
+      counts[f.key] = f.key === 'all' ? enrichedEvents.length : enrichedEvents.filter(f.match).length;
     }
     return counts;
-  }, [timelineEvents]);
+  }, [enrichedEvents]);
 
   // Filtered events for heatmap — client-side only
   const filteredEvents = useMemo(() => {
     const filter = TIMELINE_FILTERS.find(f => f.key === activeFilter);
-    if (!filter || activeFilter === 'all') return timelineEvents;
-    return timelineEvents.filter(filter.match);
-  }, [timelineEvents, activeFilter]);
+    if (!filter || activeFilter === 'all') return enrichedEvents;
+    return enrichedEvents.filter(filter.match);
+  }, [enrichedEvents, activeFilter]);
 
   // Helper: build an EventDay map from a list of events
   const buildEventMap = useCallback((events: any[]) => {
@@ -360,21 +404,20 @@ const BarcodeTimeline: React.FC<BarcodeTimelineProps> = () => {
   // eventMap from FILTERED events (heatmap); weeks from ALL events (barcode strip always shows everything)
   const { eventMap, startDate, endDate, weeks, sortedDates } = useMemo(() => {
     const currentYear = new Date().getFullYear();
-    const vehicleYear = (vehicle as any).year || currentYear;
 
     // Build map from ALL events first for barcode weeks + date range
-    const allMap = buildEventMap(timelineEvents);
+    const allMap = buildEventMap(enrichedEvents);
 
     // Build the filtered map for heatmap rendering
     const map = activeFilter === 'all' ? allMap : buildEventMap(filteredEvents);
 
-    // Date range spans the vehicle's full life (model year → today) so the
-    // historical scroll is honest. Empty pre-ownership years are surfaced via
-    // auto-scroll-to-today (below) rather than by truncation — the user lands
-    // on the newest activity and scrolls left to walk back through history.
-    const allYears = Object.keys(allMap).map((d) => new Date(d + 'T00:00:00').getFullYear());
-    const minYear = Math.min(vehicleYear, ...allYears, currentYear - 3);
-    const maxYear = Math.max(currentYear, ...allYears);
+    // Range = the DATA's range, never the model year. Anchoring at the model
+    // year rendered a '79 truck as a 48-year grid that was 96% void (C10
+    // quality check, 2026-06-10) — empty decades aren't honesty, they're
+    // noise. Floor at 2000 (bogus-EXIF guard); ceiling always reaches today.
+    const allYears = Object.keys(allMap).map((d) => new Date(d + 'T00:00:00').getFullYear()).filter((y) => y >= 2000);
+    const minYear = allYears.length ? Math.min(...allYears) : currentYear - 1;
+    const maxYear = Math.max(currentYear, ...(allYears.length ? allYears : [currentYear]));
 
     const start = new Date(minYear, 0, 1);
     start.setDate(start.getDate() - start.getDay()); // align to Sunday
@@ -407,7 +450,7 @@ const BarcodeTimeline: React.FC<BarcodeTimelineProps> = () => {
       weeks: wks,
       sortedDates: sorted,
     };
-  }, [vehicle, timelineEvents, filteredEvents, activeFilter, buildEventMap]);
+  }, [enrichedEvents, filteredEvents, activeFilter, buildEventMap]);
 
   // Heatmap weeks for expanded view
   const heatmapWeeks = useMemo(() => {

--- a/nuke_frontend/src/services/profileService.ts
+++ b/nuke_frontend/src/services/profileService.ts
@@ -15,7 +15,23 @@ import type {
 } from '../types/profile';
 
 export class ProfileService {
-  
+
+  // Per-day contribution aggregates for the profile timeline.
+  // Replaces the three wide row-level selects in getProfileData (each silently
+  // capped at 1000 rows by PostgREST db-max-rows, so the timeline rendered an
+  // arbitrary slice of history) with one (day, kind, n) GROUP BY RPC.
+  // kind ∈ photo | event | work. Bogus-EXIF floor (day >= 2000-01-01) is
+  // applied inside the RPC.
+  static async getContributionDays(
+    userId: string
+  ): Promise<Array<{ day: string; kind: string; n: number }>> {
+    const { data, error } = await supabase.rpc('get_user_contribution_days', {
+      p_user_id: userId,
+    });
+    if (error) throw error;
+    return data || [];
+  }
+
   // Get comprehensive profile data
   static async getProfileData(userId: string): Promise<ProfileData | null> {
     try {

--- a/nuke_frontend/src/styles/barcode-timeline.css
+++ b/nuke_frontend/src/styles/barcode-timeline.css
@@ -227,6 +227,89 @@
 .timeline-filter-pill:hover { background: var(--surface-hover); color: var(--vp-ink); }
 .timeline-filter-pill--active { background: var(--vp-ink); color: var(--vp-surface); border-color: var(--vp-ink); }
 
+/* ─── Day-receipt drawer (user-profile timeline drill-down) ───
+   Inline below the heatmap grid: ALL-CAPS day header, lazy photo thumb strip,
+   work/$ lines, facet chips. Arial labels, Courier data, 2px border, no
+   radius/shadow per design law. Font sizes ride the --fs-* scale tokens. */
+.up-day-receipt {
+  margin-top: 8px;
+  border: 2px solid var(--vp-ink);
+  background: var(--vp-surface);
+  padding: 8px 10px;
+  max-width: 560px;
+}
+.up-day-receipt__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-family: var(--vp-font-mono);
+  font-size: var(--fs-9, 9px);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vp-ink);
+  margin-bottom: 6px;
+}
+.up-day-receipt__close {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: var(--fs-9, 9px);
+  line-height: 1;
+  padding: 0 0 0 8px;
+  color: var(--vp-pencil);
+}
+.up-day-receipt__close:hover { color: var(--vp-ink); }
+.up-day-receipt__facets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+.up-day-receipt__facet {
+  font-family: var(--vp-font-mono);
+  font-size: var(--fs-8, 8px);
+  letter-spacing: 0.06em;
+  padding: 1px 4px;
+  border: 1px solid var(--vp-ghost);
+  color: var(--vp-pencil);
+}
+.up-day-receipt__photos {
+  display: flex;
+  gap: 2px;
+  overflow-x: auto;
+  margin-bottom: 6px;
+}
+.up-day-receipt__photos img {
+  width: 54px;
+  height: 54px;
+  object-fit: cover;
+  display: block;
+  border: 1px solid var(--vp-ghost);
+  flex: 0 0 auto;
+}
+.up-day-receipt__line {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-family: var(--vp-font-mono);
+  font-size: var(--fs-8, 8px);
+  line-height: 1.7;
+  color: var(--vp-ink);
+}
+.up-day-receipt__line-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.up-day-receipt__line-value { white-space: nowrap; }
+.up-day-receipt__empty {
+  font-family: var(--vp-font-mono);
+  font-size: var(--fs-8, 8px);
+  letter-spacing: 0.08em;
+  color: var(--vp-pencil);
+}
+
 /* Mobile: barcode strip un-sticks (moved with the block from vehicle-profile.css) */
 @media (max-width: 768px) {
   .barcode-strip { position: relative; top: auto; }

--- a/nuke_frontend/src/styles/barcode-timeline.css
+++ b/nuke_frontend/src/styles/barcode-timeline.css
@@ -18,6 +18,7 @@
   --vp-surface: var(--up-surface);
   --vp-ink: var(--up-ink);
   --vp-pencil: var(--up-pencil);
+  --vp-data-dim: var(--up-data-dim);
   --vp-ghost: var(--up-ghost);
   --vp-text-faint: var(--up-text-faint);
   --vp-font-sans: var(--up-font-sans);
@@ -53,7 +54,7 @@
   padding: 0 12px;
 }
 .barcode-bar__label-left {
-  font-size: 8px;
+  font-size: var(--fs-8);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.12em;
@@ -66,11 +67,11 @@
   pointer-events: none;
 }
 .barcode-bar__label-right {
-  font-size: 8px;
+  font-size: var(--fs-8);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--vp-text-faint);
+  color: var(--vp-data-dim, #666); /* year range = data, not ghost chrome */
   position: absolute;
   right: 12px;
   top: 50%;
@@ -105,7 +106,7 @@
   background: var(--vp-surface);
   border: 1px solid var(--vp-ink);
   padding: 4px 8px;
-  font-size: 8px;
+  font-size: var(--fs-8);
   font-family: var(--vp-font-mono);
   white-space: nowrap;
   z-index: 1100;
@@ -125,7 +126,7 @@
 .barcode-strip--expanded .barcode-bar { border-bottom: 1px solid var(--vp-ghost); }
 
 .timeline-section__header {
-  font-size: 8px;
+  font-size: var(--fs-8);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.12em;
@@ -154,8 +155,8 @@
 }
 .hm-day-labels span {
   height: 11px;
-  font-size: 8px;
-  color: var(--vp-pencil);
+  font-size: var(--fs-8);
+  color: var(--vp-data-dim, #666); /* axis dates = data */
   display: flex;
   align-items: center;
   letter-spacing: 0.06em;
@@ -196,8 +197,8 @@
   top: 100%;
   left: 0;
   margin-top: 2px;
-  font-size: 8px;
-  color: var(--vp-pencil);
+  font-size: var(--fs-8);
+  color: var(--vp-data-dim, #666); /* axis dates = data */
   letter-spacing: 0.06em;
   text-transform: uppercase;
   white-space: nowrap;
@@ -213,14 +214,14 @@
 }
 .timeline-filter-pill {
   font-family: var(--vp-font-sans);
-  font-size: 8px;
+  font-size: var(--fs-8);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   padding: 2px 4px;
   border: 1px solid var(--vp-ghost);
   background: transparent;
-  color: var(--vp-pencil);
+  color: var(--vp-data-dim, #666); /* pills carry counts = data */
   cursor: pointer;
   transition: background var(--vp-speed) var(--vp-ease), color var(--vp-speed) var(--vp-ease), border-color var(--vp-speed) var(--vp-ease);
 }

--- a/nuke_frontend/src/styles/user-profile.css
+++ b/nuke_frontend/src/styles/user-profile.css
@@ -13,6 +13,7 @@
   --up-surface: #ffffff;
   --up-ink: #1a1a1a;
   --up-pencil: #888888;
+  --up-data-dim: #666666; /* de-emphasized but DATA-carrying (values/dates/counts) — >=4.5:1 on light surface */
   --up-ghost: #dddddd;
   --up-text-faint: #bbbbbb;
   --up-row-alt: #f9f9f9;
@@ -89,7 +90,7 @@
 
 .up-header__name {
   font-family: var(--up-font-sans);
-  font-size: 12px;
+  font-size: var(--fs-12);
   font-weight: 700;
   color: var(--up-ink);
   white-space: nowrap;
@@ -99,15 +100,15 @@
 
 .up-header__username {
   font-family: var(--up-font-mono);
-  font-size: 9px;
-  color: var(--up-pencil);
+  font-size: var(--fs-9);
+  color: var(--up-data-dim);
   white-space: nowrap;
 }
 
 .up-header__meta {
   font-family: var(--up-font-sans);
-  font-size: 8px;
-  color: var(--up-pencil);
+  font-size: var(--fs-8);
+  color: var(--up-data-dim);
   white-space: nowrap;
 }
 
@@ -132,14 +133,14 @@
   align-items: baseline;
   gap: 3px;
   font-family: var(--up-font-mono);
-  font-size: 9px;
+  font-size: var(--fs-9);
   color: var(--up-ink);
   white-space: nowrap;
 }
 
 .up-stat-pill__label {
   font-family: var(--up-font-sans);
-  font-size: 7px;
+  font-size: calc(7px * var(--font-scale, 1));
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -166,12 +167,12 @@
   align-items: center;
   padding: 2px 6px;
   font-family: var(--up-font-mono);
-  font-size: 8px;
+  font-size: var(--fs-8);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   border: 1px solid var(--up-ghost);
-  color: var(--up-pencil);
+  color: var(--up-data-dim);
   white-space: nowrap;
 }
 
@@ -236,7 +237,7 @@
   justify-content: center;
   padding: 3px 8px;
   font-family: var(--up-font-mono);
-  font-size: 8px;
+  font-size: var(--fs-8);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -261,6 +262,73 @@
 .up-btn--primary:hover {
   background: var(--up-gulf-blue);
   border-color: var(--up-gulf-blue);
+}
+
+/* ─── Text Scale Control (A− A A+) ─── */
+.up-textscale {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.up-textscale__label {
+  font-family: var(--up-font-sans);
+  font-size: var(--fs-8);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--up-pencil);
+}
+
+.up-textscale__seg {
+  display: inline-flex;
+  border: 1px solid var(--up-ink);
+}
+
+.up-textscale__btn {
+  font-family: var(--up-font-mono);
+  font-size: var(--fs-8);
+  font-weight: 700;
+  padding: 2px 6px;
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--up-ink);
+  color: var(--up-ink);
+  cursor: pointer;
+  line-height: 1;
+  transition: background var(--up-speed) var(--up-ease), color var(--up-speed) var(--up-ease);
+}
+
+.up-textscale__btn:last-child {
+  border-right: none;
+}
+
+.up-textscale__btn:hover:not(:disabled) {
+  background: var(--up-ink);
+  color: var(--up-surface);
+}
+
+.up-textscale__btn:disabled {
+  color: var(--up-text-faint);
+  cursor: default;
+}
+
+.up-textscale__btn--active {
+  background: var(--up-ink);
+  color: var(--up-surface);
+}
+
+.up-textscale__value {
+  font-family: var(--up-font-mono);
+  font-size: var(--fs-8);
+  color: var(--up-data-dim);
+  min-width: 28px;
+}
+
+/* Compact variant pushes to the right end of the sub-header */
+.up-textscale--compact {
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 /* ─── Settings Drawer ─── */
@@ -308,7 +376,7 @@
 
 .up-drawer__title {
   font-family: var(--up-font-sans);
-  font-size: 11px;
+  font-size: var(--fs-11);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.1em;
@@ -317,7 +385,7 @@
 .up-drawer__close {
   background: none;
   border: none;
-  font-size: 16px;
+  font-size: calc(16px * var(--font-scale, 1));
   cursor: pointer;
   color: var(--up-pencil);
   padding: 4px;
@@ -334,7 +402,7 @@
   gap: 8px;
   padding: 6px 0;
   border-bottom: 1px solid var(--up-ghost);
-  font-size: 9px;
+  font-size: var(--fs-9);
 }
 
 .up-activity-item:last-child {
@@ -343,8 +411,8 @@
 
 .up-activity-item__date {
   font-family: var(--up-font-mono);
-  font-size: 8px;
-  color: var(--up-pencil);
+  font-size: var(--fs-8);
+  color: var(--up-data-dim);
   white-space: nowrap;
   flex-shrink: 0;
   min-width: 60px;
@@ -354,7 +422,7 @@
   display: inline-flex;
   padding: 1px 4px;
   font-family: var(--up-font-mono);
-  font-size: 7px;
+  font-size: calc(7px * var(--font-scale, 1));
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -384,7 +452,7 @@
 
 .up-dossier-group__label {
   font-family: var(--up-font-sans);
-  font-size: 7px;
+  font-size: calc(7px * var(--font-scale, 1));
   font-weight: 700;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -399,12 +467,12 @@
   justify-content: space-between;
   align-items: baseline;
   padding: 2px 0;
-  font-size: 9px;
+  font-size: var(--fs-9);
 }
 
 .up-dossier-row__label {
   font-family: var(--up-font-sans);
-  font-size: 8px;
+  font-size: var(--fs-8);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -413,7 +481,7 @@
 
 .up-dossier-row__value {
   font-family: var(--up-font-sans);
-  font-size: 9px;
+  font-size: var(--fs-9);
   color: var(--up-ink);
   text-align: right;
 }
@@ -431,7 +499,7 @@
 
 .up-briefing__headline {
   font-family: var(--up-font-sans);
-  font-size: 10px;
+  font-size: var(--fs-10);
   font-weight: 400;
   line-height: 1.5;
   color: var(--up-ink);
@@ -454,7 +522,7 @@
 
 .up-reputation .score-row__label {
   font-family: var(--up-font-sans);
-  font-size: 8px;
+  font-size: var(--fs-8);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -480,7 +548,7 @@
 
 .up-reputation .score-row__value {
   font-family: var(--up-font-mono);
-  font-size: 9px;
+  font-size: var(--fs-9);
   min-width: 32px;
   text-align: right;
 }

--- a/supabase/functions/photo-pipeline-orchestrator/index.ts
+++ b/supabase/functions/photo-pipeline-orchestrator/index.ts
@@ -539,24 +539,40 @@ async function resolveVehicle(
     }
   }
 
-  // Strategy 3: User's most recent vehicle with work activity
+  // Strategy 3: rolling user context — SUGGEST-ONLY, never hard-assign.
+  // The hard-assign version cascaded: one filed photo became "most recent
+  // vehicle" for the next, which filed and reinforced it — 102 of user 0's
+  // June frames landed on one truck with no content check (2026-06-10,
+  // pixel-verified the bucket held 2+ different vehicles). Context is a
+  // PRIOR, not evidence: it goes in suggested_vehicle_id for the inbox /
+  // owner-confirmation flow. Only physical evidence (unambiguous GPS above)
+  // may hard-file. Time-bounded 7 days so a stale project never suggests.
   if (userId) {
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 3600 * 1000).toISOString();
     const { data: recentVehicle } = await supabase
       .from("vehicle_images")
       .select("vehicle_id")
       .eq("user_id", userId)
       .not("vehicle_id", "is", null)
+      .gte("created_at", sevenDaysAgo)
       .order("created_at", { ascending: false })
       .limit(1)
       .maybeSingle();
 
     if (recentVehicle?.vehicle_id) {
-      console.log("[photo-pipeline] Vehicle resolved via recent activity");
-      return recentVehicle.vehicle_id;
+      console.log("[photo-pipeline] Rolling context suggests vehicle (not assigning):", recentVehicle.vehicle_id);
+      await supabase
+        .from("vehicle_images")
+        .update({
+          suggested_vehicle_id: recentVehicle.vehicle_id,
+          image_vehicle_match_status: "ambiguous",
+        })
+        .eq("id", imageId)
+        .is("vehicle_id", null);
     }
   }
 
-  console.log("[photo-pipeline] Could not resolve vehicle");
+  console.log("[photo-pipeline] No hard evidence — photo stays in inbox (suggestion recorded if context existed)");
   return null;
 }
 

--- a/supabase/migrations/20260610140000_get_user_day_receipt.sql
+++ b/supabase/migrations/20260610140000_get_user_day_receipt.sql
@@ -1,0 +1,91 @@
+-- ============================================================================
+-- get_user_day_receipt(p_user_id, p_date) — the END LAYER of the profile
+-- timeline. Filed 2026-06-10 (profile round 3, Skylar's "click anxiety" fix).
+--
+-- Clicking a day on the user timeline must descend to the day's receipt:
+-- the photos shot, the work done, the dollars moved, the facets touched.
+-- USER-scoped sibling of get_daily_work_receipt (which is vehicle-scoped).
+--
+-- Privacy gating happens IN here via auth.uid(): the owner sees everything
+-- (inbox photos, dollars, receipts); visitors see only photos attached to
+-- public vehicles, no money. SECURITY DEFINER so the function (not RLS
+-- per-row churn) controls the shape.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_user_day_receipt(p_user_id uuid, p_date date)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_is_owner boolean := (auth.uid() = p_user_id);
+  v_photos jsonb;
+  v_work jsonb;
+  v_receipts jsonb := '[]'::jsonb;
+  v_facets jsonb;
+BEGIN
+  -- Photos taken that day. Owner: all of theirs incl. inbox (vehicle_id NULL).
+  -- Visitor: only frames attached to public vehicles.
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+           'id', s.id, 'url', s.image_url, 'thumb', COALESCE(s.thumbnail_url, s.image_url),
+           'vehicle_id', s.vehicle_id, 'taken_at', s.taken_at) ORDER BY s.taken_at), '[]'::jsonb)
+  INTO v_photos
+  FROM (
+    SELECT vi.id, vi.image_url, vi.thumbnail_url, vi.vehicle_id, vi.taken_at
+    FROM vehicle_images vi
+    LEFT JOIN vehicles v ON v.id = vi.vehicle_id
+    WHERE vi.user_id = p_user_id
+      AND vi.taken_at >= p_date::timestamptz
+      AND vi.taken_at < (p_date + 1)::timestamptz
+      AND COALESCE(vi.is_duplicate, false) = false
+      AND (v_is_owner OR (vi.vehicle_id IS NOT NULL AND v.is_public = true))
+    ORDER BY vi.taken_at
+    LIMIT 60
+  ) s;
+
+  -- Work sessions that day (costs only for the owner).
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+           'id', ws.id,
+           'title', COALESCE(ws.title, ws.work_type, 'work session'),
+           'vehicle_id', ws.vehicle_id,
+           'duration_minutes', ws.duration_minutes,
+           'total_job_cost', CASE WHEN v_is_owner THEN ws.total_job_cost ELSE NULL END
+         ) ORDER BY ws.start_time NULLS LAST), '[]'::jsonb)
+  INTO v_work
+  FROM work_sessions ws
+  WHERE ws.user_id = p_user_id AND ws.session_date = p_date;
+
+  -- Receipts that day — owner only.
+  IF v_is_owner THEN
+    SELECT COALESCE(jsonb_agg(jsonb_build_object(
+             'id', r.id, 'vendor', r.vendor_name, 'total', r.total_amount,
+             'vehicle_id', r.vehicle_id) ORDER BY r.total_amount DESC NULLS LAST), '[]'::jsonb)
+    INTO v_receipts
+    FROM receipts r
+    WHERE r.user_id = p_user_id
+      AND p_date IN (r.transaction_date, r.purchase_date, r.receipt_date);
+  END IF;
+
+  v_facets := jsonb_build_object(
+    'photos', jsonb_array_length(v_photos),
+    'work', jsonb_array_length(v_work),
+    'receipts', jsonb_array_length(v_receipts)
+  );
+
+  RETURN jsonb_build_object(
+    'date', p_date,
+    'is_owner_view', v_is_owner,
+    'photos', v_photos,
+    'work_sessions', v_work,
+    'receipts', v_receipts,
+    'facets', v_facets
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_user_day_receipt(uuid, date) IS
+  'User-scoped day receipt for the profile timeline drill-down: photos, work, dollars (owner-only), facet counts. The end layer of end-to-end visibility.';
+
+GRANT EXECUTE ON FUNCTION public.get_user_day_receipt(uuid, date) TO authenticated, anon;

--- a/supabase/migrations/20260610150000_get_vehicle_contribution_days.sql
+++ b/supabase/migrations/20260610150000_get_vehicle_contribution_days.sql
@@ -1,0 +1,42 @@
+-- ============================================================================
+-- get_vehicle_contribution_days(p_vehicle_id) — per-day activity for the
+-- vehicle profile timeline. Filed 2026-06-10 (C10 quality check).
+--
+-- The vehicle BarcodeTimeline fed ONLY on vehicle_timeline_events: an
+-- owner-import truck with 861 photos showed "ALL (3) / PHOTOS (1)" on a
+-- 48-year grid anchored at its MODEL YEAR. Photos and work sessions are the
+-- real activity substrate. Sibling of get_user_contribution_days.
+-- Legs are index-served: vehicle_images_taken_date (vehicle_id, taken_at),
+-- idx_work_sessions_vehicle, vehicle_timeline_events(vehicle_id).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_vehicle_contribution_days(p_vehicle_id uuid)
+RETURNS TABLE(day date, kind text, n int)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  SELECT vi.taken_at::date AS day, 'photo'::text AS kind, count(*)::int AS n
+  FROM vehicle_images vi
+  WHERE vi.vehicle_id = p_vehicle_id
+    AND vi.taken_at IS NOT NULL
+    AND vi.taken_at >= '2000-01-01'          -- bogus-EXIF floor
+    AND COALESCE(vi.is_duplicate, false) = false
+  GROUP BY 1
+  UNION ALL
+  SELECT ws.session_date, 'work', count(*)::int
+  FROM work_sessions ws
+  WHERE ws.vehicle_id = p_vehicle_id AND ws.session_date >= '2000-01-01'
+  GROUP BY 1
+  UNION ALL
+  SELECT vte.event_date, 'event', count(*)::int
+  FROM vehicle_timeline_events vte
+  WHERE vte.vehicle_id = p_vehicle_id AND vte.event_date >= '2000-01-01'
+  GROUP BY 1;
+$$;
+
+COMMENT ON FUNCTION public.get_vehicle_contribution_days(uuid) IS
+  'Per-day photo/work/event densities for the vehicle profile timeline. The photos ARE the activity record.';
+
+GRANT EXECUTE ON FUNCTION public.get_vehicle_contribution_days(uuid) TO authenticated, anon;


### PR DESCRIPTION
Round 2 of the profile overhaul. Four substrate-backed widgets, each live-verified against prod data and self-guarding to null when empty: WORK LEDGER (325 sessions / 697 hrs / 26 vehicles / $35.5K, per-year hour bars), BAT TRACK RECORD (bat_listings direct: 5 listings, 3 sold, $61K GMV + 29 real comments — replaces the card that found 1 of 5 sales), MONEY FLOW (owner-only, payment_events, source-stamped), RECENT PHOTOS (true totals 20,978 · 154 this week, lazy, day click-through). Deletes empty shells: Success Stories, Comments-and-Bids/Listings (nonexistent tables), Reputation (empty bars). tsc zero new errors; vite build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Profile now displays BaT sales history with auction comments.
  * Added work ledger card showing sessions and hours summary.
  * New money flow visualization for account owners showing payment events and balances.
  * Recent photos gallery now appears on user profiles.
  * Day receipt functionality enables comprehensive daily activity timeline data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->