### PR TITLE
fix(rls): payment_events owner-read — Money Flow was silently null for everyone

### DIFF
--- a/supabase/migrations/20260611011500_payment_events_owner_read.sql
+++ b/supabase/migrations/20260611011500_payment_events_owner_read.sql
@@ -1,0 +1,14 @@
+-- ============================================================================
+-- payment_events: owner-read RLS policy. Filed 2026-06-11.
+--
+-- RLS was ENABLED with ZERO policies — every client SELECT returned nothing,
+-- including the owner's. The profile MONEY FLOW widget (reads as the
+-- signed-in user) silently rendered null even for user 0. Money is the most
+-- private substrate: exactly one policy — you read your own rows. Writes
+-- remain service-role-only (no INSERT/UPDATE/DELETE policies).
+-- ============================================================================
+
+DROP POLICY IF EXISTS payment_events_owner_read ON payment_events;
+CREATE POLICY payment_events_owner_read ON payment_events
+  FOR SELECT TO authenticated
+  USING (user_id = auth.uid());


### PR DESCRIPTION
RLS enabled with zero policies = all client reads denied, owner included. One owner-read policy, applied live, migration committed. Money Flow renders on next profile load.