### PR TITLE
feat(substrate): source-data-reorg steps 2-4 — image delete paths closed, provenance view, existence_tier

### DIFF
--- a/nuke_frontend/src/pages/PersonalPhotoLibrary.tsx
+++ b/nuke_frontend/src/pages/PersonalPhotoLibrary.tsx
@@ -299,7 +299,7 @@ export const PersonalPhotoLibrary: React.FC = () => {
   };
 
   const handleDelete = async () => {
-    if (!confirm(`Delete ${selectedPhotos.size} photos?`)) return;
+    if (!confirm(`Remove ${selectedPhotos.size} photos from your library? (Hidden, not destroyed — recoverable.)`)) return;
     try {
       await PersonalPhotoLibraryService.deletePhotos(Array.from(selectedPhotos));
       setSelectedPhotos(new Set());

--- a/nuke_frontend/src/services/imageUploadService.ts
+++ b/nuke_frontend/src/services/imageUploadService.ts
@@ -752,46 +752,55 @@ export class ImageUploadService {
   }
 
   /**
-   * Auto-match an unorganized image to vehicles using GPS, date, and filename
-   * This runs in the background after upload if vehicleId was not provided
+   * Auto-match an unorganized image to vehicles using GPS proximity.
+   * Runs in the background after upload if vehicleId was not provided.
+   *
+   * Calls the 5-arg GPS overload of auto_match_image_to_vehicles (the
+   * ambiguity-guard version, migration 20260610011000). The legacy 4-arg
+   * overload (filename-LIKE scorer) was dropped in migration
+   * 20260611040000_close_destructive_paths.sql.
    */
   private static async autoMatchImage(imageId: string, userId: string): Promise<void> {
     try {
-      // Use the database function for efficient matching
-      const { data: matches, error } = await supabase
-        .rpc('auto_match_image_to_vehicles', {
-          p_image_id: imageId,
-          p_max_gps_distance_meters: 50,
-          p_max_date_difference_days: 30,
-          p_min_confidence: 0.5
-        });
+      // The GPS overload needs the image's coordinates — fetch them first.
+      const { data: img } = await supabase
+        .from('vehicle_images')
+        .select('latitude, longitude, taken_at')
+        .eq('id', imageId)
+        .maybeSingle();
 
-      if (error) {
-        console.warn('Auto-match RPC failed, falling back to client-side matching:', error);
-        // Fallback to client-side matching
+      let bestMatch: { vehicle_id: string; confidence: number } | null = null;
+      let matchReason = 'gps_proximity';
+
+      if (img?.latitude != null && img?.longitude != null) {
+        const { data: matches, error } = await supabase.rpc('auto_match_image_to_vehicles', {
+          p_image_id: imageId,
+          p_latitude: img.latitude,
+          p_longitude: img.longitude,
+          p_taken_at: img.taken_at,
+          p_user_id: userId
+        });
+        if (error) {
+          console.warn('Auto-match RPC failed, falling back to client-side matching:', error);
+        } else if (matches && matches.length > 0) {
+          bestMatch = matches[0];
+        }
+      }
+
+      // Fallback: client-side matcher for no-GPS images or RPC failure.
+      if (!bestMatch) {
         const { ImageVehicleMatcher } = await import('./imageVehicleMatcher');
         const match = await ImageVehicleMatcher.matchImage(imageId, { userId });
         if (match && match.vehicleId) {
-          // SAFETY: do not auto-apply; only store suggestion.
-          await supabase
-            .from('vehicle_images')
-            .update({
-              suggested_vehicle_id: match.vehicleId,
-              updated_at: new Date().toISOString()
-            })
-            .eq('id', imageId);
-          console.log(`✅ Suggested match for image ${imageId}: vehicle ${match.vehicleId} (confidence: ${(match.confidence * 100).toFixed(0)}%)`);
+          bestMatch = { vehicle_id: match.vehicleId, confidence: match.confidence };
+          matchReason = 'client_side_matcher';
         }
-        return;
       }
 
-      if (!matches || matches.length === 0) {
+      if (!bestMatch) {
         console.log(`No auto-match found for image ${imageId}`);
         return;
       }
-
-      // Get the best match (highest confidence)
-      const bestMatch = matches[0];
 
       // SAFETY: never auto-assign vehicle_id based on heuristic matching.
       // This prevents cross-vehicle contamination; we only store a suggestion for review.
@@ -808,8 +817,7 @@ export class ImageUploadService {
         return;
       }
 
-      console.log(`✅ Suggested match for image ${imageId}: vehicle ${bestMatch.vehicle_id} (confidence: ${(bestMatch.confidence * 100).toFixed(0)}%)`);
-      console.log('Match reasons:', bestMatch.match_reasons);
+      console.log(`✅ Suggested match for image ${imageId}: vehicle ${bestMatch.vehicle_id} (confidence: ${(bestMatch.confidence * 100).toFixed(0)}%, via ${matchReason})`);
 
       // Notify UI that image was matched
       if (typeof window !== 'undefined') {
@@ -818,7 +826,7 @@ export class ImageUploadService {
             imageId,
             vehicleId: bestMatch.vehicle_id,
             confidence: bestMatch.confidence,
-            reasons: bestMatch.match_reasons
+            reasons: [matchReason]
           }
         }));
       }

--- a/nuke_frontend/src/services/personalPhotoLibraryService.ts
+++ b/nuke_frontend/src/services/personalPhotoLibraryService.ts
@@ -550,17 +550,28 @@ export class PersonalPhotoLibraryService {
   }
 
   /**
-   * Delete photos from personal library
+   * Remove photos from the personal library inbox.
+   *
+   * TRUST INVARIANT: vehicle_images is testimony — never hard-deleted
+   * (.claude/rules/agent-trust-invariants.md). "Delete" from the inbox means
+   * organization_status='ignored': the photo leaves every library surface but
+   * the row, its EXIF/GPS, and attribution lineage survive. Reversible by
+   * setting organization_status back to 'unorganized'. DELETE on
+   * vehicle_images is also revoked from authenticated/anon at the DB layer
+   * (migration 20260611040000_close_destructive_paths.sql).
    */
   static async deletePhotos(imageIds: string[]): Promise<number> {
     const { data, error } = await supabase
       .from('vehicle_images')
-      .delete()
+      .update({
+        organization_status: 'ignored',
+        updated_at: new Date().toISOString()
+      })
       .in('id', imageIds)
       .select('id');
 
     if (error) {
-      console.error('Error deleting photos:', error);
+      console.error('Error ignoring photos:', error);
       throw error;
     }
 

--- a/scripts/backfill-existence-tier.sh
+++ b/scripts/backfill-existence-tier.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# ============================================================================
+# vehicles.existence_tier backfill — Source Data Reorg campaign, step 4.
+# See docs/plans/2026-06-11_source-data-reorg-campaign.md and migration
+# 20260611040200_vehicles_existence_tier.sql for the tier definitions.
+#
+# TWO PHASES, because the vehicles table carries 26 UPDATE triggers:
+#
+#   PHASE A (default, runs now) — COMPUTE tiers into
+#   public.existence_tier_staging via batched read-only INSERT..SELECT.
+#   Zero writes to vehicles: no trigger fires, no updated_at /
+#   last_activity_at churn, no completion-queue storm. 256 uuid-prefix id
+#   ranges (~3.5K rows each; read+insert-elsewhere — db-safety's 1,000-row
+#   cap targets UPDATE/DELETE on hot tables), pg_sleep(0.1) between, 110s
+#   statement_timeout, lock-cascade tripwire. Idempotent upsert — safe to
+#   re-run any time.
+#
+#   PHASE B (--copy, GATED) — copy staging.tier into vehicles.existence_tier.
+#   This is an UPDATE on vehicles and therefore fires the trigger pile.
+#   Measured 2026-06-10: with triggers live, ONE 1,000-row batch exceeds the
+#   110s statement_timeout (trigger_update_vehicle_status runs
+#   calculate_vehicle_data_completeness + upserts vehicle_status_metadata
+#   PER ROW), and a full run would corrupt operational signals platform-wide
+#   (updated_at + last_activity_at bumped on all 910K rows, 910K
+#   completion-recompute enqueues). The integrity triggers (VIN uniqueness,
+#   taxonomy, normalize) are all column-scoped (UPDATE OF vin/...) and do
+#   NOT fire for an existence_tier-only update — so suspending triggers for
+#   the copy session changes nothing for integrity — but per-session trigger
+#   suspension (session_replication_role=replica) needs explicit owner
+#   sanction. Until then --copy refuses unless NUKE_TIER_COPY_SANCTIONED=1.
+#   The durable alternative: scope the churn triggers
+#   (trigger_update_vehicle_status, update_vehicle_completion,
+#   vehicles_search_vector_trigger, vehicles_update_timestamp) to their
+#   relevant columns — the same disease as the 18-trigger vehicle_images
+#   write storm in .claude/ISSUES.md — then run --copy with triggers live.
+#
+# existence_tier is OPERATIONAL classification (recomputable) — no testimony
+# value is altered in either phase.
+#
+# Usage (from repo root):
+#   dotenvx run -f .env -f .env.supabase -- bash scripts/backfill-existence-tier.sh           # phase A
+#   NUKE_TIER_COPY_SANCTIONED=1 dotenvx run -f .env -f .env.supabase -- \
+#     bash scripts/backfill-existence-tier.sh --copy                                          # phase B
+# ============================================================================
+set -euo pipefail
+
+PGHOST="${NUKE_PGHOST:-aws-0-us-west-1.pooler.supabase.com}"
+PGPORT="${NUKE_PGPORT:-5432}"
+PGUSER="${NUKE_PGUSER:-postgres.qkgaybvrernstplzjaam}"
+PGDB="${NUKE_PGDB:-postgres}"
+
+
+export PGPASSWORD="${SUPABASE_DB_PASSWORD:?SUPABASE_DB_PASSWORD required (run under dotenvx)}"
+export PGOPTIONS="-c statement_timeout=110s"
+
+PSQL=(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDB" -X -t -A -v ON_ERROR_STOP=1)
+
+WORKDIR="${NUKE_TIER_WORKDIR:-/tmp/existence-tier-run}"
+rm -rf "$WORKDIR" && mkdir -p "$WORKDIR"
+BOUNDS="$WORKDIR/bounds.txt"
+BATCHSQL="$WORKDIR/batches.sql"
+RUNLOG="$WORKDIR/run.log"
+
+TIER_CASE="CASE
+      WHEN v.deleted_at IS NOT NULL OR v.merged_into_vehicle_id IS NOT NULL THEN 'dead'
+      WHEN v.user_id IS NOT NULL OR v.uploaded_by IS NOT NULL OR v.owner_id IS NOT NULL
+           OR EXISTS (SELECT 1 FROM public.vehicle_user_permissions p WHERE p.vehicle_id = v.id AND p.is_active)
+           OR (COALESCE(v.image_count, 0) >= 4
+               AND (EXISTS (SELECT 1 FROM public.vehicle_events e WHERE e.vehicle_id = v.id)
+                    OR EXISTS (SELECT 1 FROM public.vehicle_observations o WHERE o.vehicle_id = v.id))
+               AND v.year IS NOT NULL AND v.make IS NOT NULL AND v.model IS NOT NULL)
+        THEN 'a'
+      WHEN (COALESCE(v.sale_price, 0) > 0 OR COALESCE(v.sold_price, 0) > 0
+            OR COALESCE(v.bat_sold_price, 0) > 0 OR COALESCE(v.canonical_sold_price, 0) > 0)
+           AND v.year IS NOT NULL AND v.make IS NOT NULL
+        THEN 'b'
+      ELSE 'c'
+    END"
+
+if [ "${1:-}" = "--copy" ]; then
+  if [ "${NUKE_TIER_COPY_SANCTIONED:-0}" != "1" ]; then
+    echo "REFUSING --copy: phase B updates 910K vehicles rows and either fires the"
+    echo "churn-trigger pile (signal corruption + >110s/batch) or needs per-session"
+    echo "trigger suspension. Set NUKE_TIER_COPY_SANCTIONED=1 only with owner sanction,"
+    echo "or fix the trigger column-scoping first (see header)." >&2
+    exit 2
+  fi
+  echo "phase B: copying staging -> vehicles.existence_tier (1,000/batch, triggers suspended for session)..."
+  TOTAL=0
+  while :; do
+    N=$("${PSQL[@]}" -q -c "
+      -- ALLOW_RAW_TESTIMONY_WRITE: vehicles.existence_tier is an operational,
+      -- recomputable classification column — no testimony value is altered.
+      -- Sanctioned: source-data-reorg campaign step 4 (owner-sanctioned copy phase).
+      SET session_replication_role = replica;
+      WITH b AS (
+        SELECT s.vehicle_id, s.tier FROM public.existence_tier_staging s
+        JOIN public.vehicles v ON v.id = s.vehicle_id
+        WHERE v.existence_tier IS DISTINCT FROM s.tier
+        LIMIT 1000
+      ), u AS (
+        UPDATE public.vehicles v SET existence_tier = b.tier
+        FROM b WHERE v.id = b.vehicle_id RETURNING 1
+      ) SELECT count(*) FROM u;" | tail -1)
+    [ "${N:-0}" = "0" ] && break
+    TOTAL=$((TOTAL + N))
+    LOCKS=$("${PSQL[@]}" -q -c "SELECT count(*) FROM pg_stat_activity WHERE wait_event_type='Lock';")
+    if [ "${LOCKS:-0}" -gt 0 ]; then echo "lock cascade — stopping at $TOTAL rows" >&2; exit 1; fi
+    sleep 0.1
+  done
+  echo "phase B done: $TOTAL rows copied."
+  exit 0
+fi
+
+echo "phase A: computing tiers into public.existence_tier_staging (read-only on vehicles)"
+
+"${PSQL[@]}" -q -c "
+  CREATE TABLE IF NOT EXISTS public.existence_tier_staging (
+    vehicle_id uuid PRIMARY KEY,
+    tier text NOT NULL,
+    computed_at timestamptz NOT NULL DEFAULT now()
+  );"
+
+echo "phase A.1: generating fixed uuid-prefix ranges (uuids are uniform; no boundary precompute needed)..."
+# 256 ranges on the first id byte -> ~3.5K rows each on the 910K table.
+# (A row_number() boundary precompute over the full PK blows the 110s
+# statement_timeout on this table — measured 2026-06-10.)
+: > "$BOUNDS"
+for i in $(seq 0 255); do printf '%02x\n' "$i" >> "$BOUNDS"; done
+
+echo "phase A.2: generating batch SQL -> $BATCHSQL"
+{
+  echo "SET statement_timeout = '110s';"
+  echo "SET lock_timeout = '15s';"
+  awk -v tiercase="$(printf '%s' "$TIER_CASE" | tr '\n' ' ')" '
+    function emit(low, high,    cond) {
+      cond = "v.id >= '\''" low "000000-0000-0000-0000-000000000000'\''";
+      if (high != "") cond = cond " AND v.id < '\''" high "000000-0000-0000-0000-000000000000'\''";
+      print "WITH src AS (";
+      print "  SELECT v.id, " tiercase " AS tier";
+      print "  FROM public.vehicles v WHERE " cond;
+      print "), ins AS (";
+      print "  INSERT INTO public.existence_tier_staging (vehicle_id, tier)";
+      print "  SELECT id, tier FROM src";
+      print "  ON CONFLICT (vehicle_id) DO UPDATE SET tier = EXCLUDED.tier, computed_at = now()";
+      print "  RETURNING tier)";
+      print "SELECT '\''TIER|'\'' || tier || '\''|'\'' || count(*) FROM ins GROUP BY tier;";
+      print "SELECT pg_sleep(0.1);";
+      nb++;
+      if (nb % 20 == 0) {
+        # tripwire: abort only if someone is blocked BY THIS session
+        # (ambient lock waits from other writers are not ours to trip on)
+        print "SELECT CASE WHEN count(*) > 0 THEN 1/0 ELSE 0 END";
+        print "FROM pg_stat_activity";
+        print "WHERE wait_event_type = '\''Lock'\'' AND pg_blocking_pids(pid) @> ARRAY[pg_backend_pid()];";
+        print "SELECT '\''PROGRESS|'\'' || " nb " || '\''|'\'' || now()::time(0);";
+      }
+    }
+    NR > 1 { emit(prev, $0) } { prev = $0 }
+    END { emit(prev, "") }
+  ' "$BOUNDS"
+} > "$BATCHSQL"
+echo "  $(grep -c '^WITH src AS' "$BATCHSQL") range statements generated"
+
+echo "phase A.3: executing (single session, autocommit per statement)..."
+"${PSQL[@]}" -q -f "$BATCHSQL" > "$RUNLOG"
+
+echo "rows staged this run:"
+grep '^TIER|' "$RUNLOG" | awk -F'|' '{s[$2]+=$3; tot+=$3} END {for (k in s) printf "  %s: %d\n", k, s[k]; printf "  total: %d\n", tot}'
+
+echo "staging table tier counts (authoritative):"
+"${PSQL[@]}" -q -F' | ' -c "
+  SELECT tier, count(*) FROM public.existence_tier_staging GROUP BY tier ORDER BY tier;"
+
+echo "done. (artifacts in $WORKDIR — bounds.txt, batches.sql, run.log)"
+echo "next: phase B copy is gated — see header."

--- a/supabase/migrations/20260611040000_close_destructive_paths.sql
+++ b/supabase/migrations/20260611040000_close_destructive_paths.sql
@@ -1,0 +1,38 @@
+-- ============================================================================
+-- Source Data Reorg campaign, step 2: close the destructive paths.
+-- docs/plans/2026-06-11_source-data-reorg-campaign.md (step 2)
+--
+-- (a) Revoke DELETE on vehicle_images from client roles.
+--     vehicle_images is testimony — "testimony is never deleted"
+--     (.claude/rules/agent-trust-invariants.md). The inbox UI exposed a raw
+--     .delete() (personalPhotoLibraryService.deletePhotos), now replaced by
+--     organization_status='ignored'. This revoke closes the path at the DB
+--     layer for every current and future client. service_role retains DELETE
+--     for sanctioned admin/merge tooling.
+--
+-- (b) Drop the legacy 4-arg auto_match_image_to_vehicles overload.
+--     Prod had two overloads (pg_proc verified 2026-06-10):
+--       legacy : (p_image_id uuid, p_max_gps_distance_meters integer,
+--                 p_max_date_difference_days integer, p_min_confidence real)
+--                — GPS/date/FILENAME-LIKE scorer (year/make/model substring in
+--                filename = 20% weight), gated on organization_status =
+--                'unorganized'. Filename matching is inference, not evidence.
+--       current: (p_image_id uuid, p_latitude double precision, p_longitude
+--                 double precision, p_taken_at timestamptz, p_user_id uuid)
+--                — the ambiguity-guard version (20260610011000), KEPT.
+--     Caller grep before drop (2026-06-10): the only 4-arg caller was
+--     nuke_frontend/src/services/imageUploadService.ts:762, migrated to the
+--     5-arg overload in the same commit. photo-pipeline-orchestrator and all
+--     other callers already use the 5-arg version.
+-- ============================================================================
+
+-- (a) DELETE was granted to anon, authenticated, service_role, postgres
+--     (information_schema.role_table_grants, verified 2026-06-10).
+REVOKE DELETE ON public.vehicle_images FROM authenticated;
+REVOKE DELETE ON public.vehicle_images FROM anon;
+
+-- (b) Exact signature verified against pg_proc before drop (oid 16933).
+DROP FUNCTION IF EXISTS public.auto_match_image_to_vehicles(uuid, integer, integer, real);
+
+COMMENT ON FUNCTION public.auto_match_image_to_vehicles(uuid, double precision, double precision, timestamp with time zone, uuid) IS
+  'GPS-proximity vehicle matcher with shared-location ambiguity guard (caps confidence at 0.5 when 2+ vehicles score within 0.15 — see 20260610011000). Sole surviving overload: the legacy 4-arg filename-LIKE scorer was dropped by 20260611040000_close_destructive_paths (source-data-reorg step 2).';

--- a/supabase/migrations/20260611040100_v_vehicle_provenance.sql
+++ b/supabase/migrations/20260611040100_v_vehicle_provenance.sql
@@ -1,0 +1,63 @@
+-- ============================================================================
+-- Source Data Reorg campaign, step 3: canonical provenance view.
+-- docs/plans/2026-06-11_source-data-reorg-campaign.md (step 3)
+--
+-- The vehicles table carries 5 disagreeing source columns (population
+-- measured on prod 2026-06-10, 0.5% TABLESAMPLE n=4,822):
+--   source           99.9% set — CURRENT marketplace attribution; RELABELED
+--                    during dedup (e.g. conceptcarz-discovered rows relabeled
+--                    to mecum/barrett-jackson — the ~267K dead stratum)
+--   discovery_source 81.9% set — the extractor/site that FIRST discovered the
+--                    row (conceptcarz, bat_core, ecr_collection_text…)
+--   platform_source  86.6% set — normalized platform name (bringatrailer,
+--                    cars-and-bids…); usually mirrors discovery
+--   listing_source   40.9% set — the ingest MECHANISM (bat_simple_extract,
+--                    drain-no-ai, mecum-fast-discover) — HOW, not WHERE
+--   import_source     0.15% set — vestigial (7 of 4,822 sampled)
+--
+-- PRECEDENCE (canonical_source): discovery_source > platform_source > source
+--   > import_source.
+--   Rationale: provenance answers "where did this row originally come from",
+--   so the discovery-time signal outranks the dedup-relabeled `source`.
+--   platform_source is second because it is set on most rows where
+--   discovery_source is NULL (e.g. classic-driver) and is never relabeled.
+--   `source` is the fallback for rows with neither. import_source is last
+--   (vestigial). listing_source is deliberately EXCLUDED from precedence —
+--   it names the pipeline mechanism, not a source; exposed as
+--   ingest_mechanism instead.
+--
+-- `relabeled` flags rows whose current `source` disagrees with their
+-- discovery_source — the conceptcarz→mecum dead stratum is auditable as
+-- WHERE relabeled AND is_dead GROUP BY canonical_source.
+--
+-- Read-only analytics view; no row mutation. security_invoker so it
+-- inherits the caller's RLS on vehicles rather than the owner's.
+-- ============================================================================
+
+CREATE OR REPLACE VIEW public.v_vehicle_provenance
+WITH (security_invoker = true) AS
+SELECT
+  v.id AS vehicle_id,
+  COALESCE(v.discovery_source, v.platform_source, v.source, v.import_source::text)
+    AS canonical_source,
+  CASE
+    WHEN v.discovery_source IS NOT NULL THEN 'discovery_source'
+    WHEN v.platform_source  IS NOT NULL THEN 'platform_source'
+    WHEN v.source           IS NOT NULL THEN 'source'
+    WHEN v.import_source    IS NOT NULL THEN 'import_source'
+  END AS canonical_source_column,
+  v.source,
+  v.discovery_source,
+  v.platform_source,
+  v.import_source,
+  v.listing_source AS ingest_mechanism,
+  (v.discovery_source IS NOT NULL
+   AND v.source IS NOT NULL
+   AND v.source <> v.discovery_source) AS relabeled,
+  (v.deleted_at IS NOT NULL OR v.merged_into_vehicle_id IS NOT NULL) AS is_dead
+FROM public.vehicles v;
+
+COMMENT ON VIEW public.v_vehicle_provenance IS
+  'Canonical provenance per vehicle. Precedence: discovery_source > platform_source > source > import_source (discovery-time signal outranks dedup-relabeled source; listing_source excluded — it is the ingest mechanism, not a source). relabeled = source disagrees with discovery_source (the conceptcarz->mecum dead stratum). Source-data-reorg step 3 — analytics only, no mutation.';
+
+GRANT SELECT ON public.v_vehicle_provenance TO authenticated, service_role;

--- a/supabase/migrations/20260611040200_vehicles_existence_tier.sql
+++ b/supabase/migrations/20260611040200_vehicles_existence_tier.sql
@@ -1,0 +1,63 @@
+-- ============================================================================
+-- Source Data Reorg campaign, step 4: materialize vehicles.existence_tier.
+-- docs/plans/2026-06-11_source-data-reorg-campaign.md (step 4)
+--
+-- OPERATIONAL classification column (not testimony — recomputable at any
+-- time from on-row counters + EXISTS probes; a mistake is a re-run, not a
+-- loss). Encodes render-worthiness so RLS/search/profile surfaces can stop
+-- guessing (steps 5-7 wire the consumers; nothing reads it yet).
+--
+-- Tiers (measured predicates from the 3-agent substrate audit, predictions
+-- in parens against the 910,175-row table):
+--   'dead' (~316K) deleted_at IS NOT NULL OR merged_into_vehicle_id IS NOT NULL
+--   'a'    (~325K) human-linked (user_id/uploaded_by/owner_id set, or an
+--                  active vehicle_user_permissions row)
+--                  OR dense substrate: image_count>=4 AND (EXISTS
+--                  vehicle_events OR EXISTS vehicle_observations) AND
+--                  year+make+model all set
+--   'b'    (~166K) live, not 'a', any sale-price column > 0 (sale_price,
+--                  sold_price, bat_sold_price, canonical_sold_price) AND
+--                  year+make set — comp-stub stratum
+--   'c'    (~103K) remaining live rows — archive substrate, queryable forever
+--
+-- BACKFILL IS NOT IN THIS MIGRATION. An unbounded UPDATE over 910K rows
+-- violates .claude/rules/db-safety.md — and the vehicles table carries 26
+-- UPDATE triggers whose unscoped members (trigger_update_vehicle_status,
+-- update_vehicle_completion, vehicles_update_timestamp,
+-- vehicles_search_vector_trigger) make ANY mass UPDATE both >110s/batch
+-- (measured) and churn-corrupting: updated_at + last_activity_at bumped and
+-- a completion-recompute enqueued on every one of 910K rows. The backfill
+-- therefore runs in two phases via scripts/backfill-existence-tier.sh:
+--   A) tiers computed READ-ONLY into existence_tier_staging (no trigger
+--      fires anywhere) — executed 2026-06-10;
+--   B) gated copy staging -> vehicles.existence_tier, 1,000/batch — needs
+--      either the churn triggers scoped to their columns first, or
+--      owner-sanctioned per-session trigger suspension (the integrity
+--      triggers — VIN uniqueness, taxonomy, normalize — are column-scoped
+--      to vin/make/model/etc and never fire for an existence_tier-only
+--      update either way). See the script header.
+-- display_tier is untouched (FB importer's featured semantics).
+-- ============================================================================
+
+ALTER TABLE public.vehicles ADD COLUMN IF NOT EXISTS existence_tier text;
+
+-- Staging side of the two-phase backfill (phase A target, phase B source).
+-- Operational, recomputable, not testimony.
+CREATE TABLE IF NOT EXISTS public.existence_tier_staging (
+  vehicle_id uuid PRIMARY KEY,
+  tier text NOT NULL,
+  computed_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.existence_tier_staging IS
+  'Operational staging for the source-data-reorg step-4 existence_tier backfill: tiers computed read-only from vehicles (no trigger churn). Copy into vehicles.existence_tier is the gated final step. Recomputable; not testimony. See scripts/backfill-existence-tier.sh.';
+
+COMMENT ON COLUMN public.vehicles.existence_tier IS
+  'Operational render-worthiness tier (source-data-reorg step 4): dead=soft-deleted/merged; a=human-linked or dense (>=4 images + events/observations + full YMM); b=comp stub (sale price + year/make); c=archive residue. Recomputable — backfilled/maintained by scripts/backfill-existence-tier.sh; NOT testimony.';
+
+-- Partial index for the live-tier predicates the RLS/search consumers will
+-- use (steps 5-7). On prod this was created CONCURRENTLY (2026-06-10);
+-- IF NOT EXISTS makes this a no-op there and a plain create on fresh DBs.
+CREATE INDEX IF NOT EXISTS idx_vehicles_existence_tier
+  ON public.vehicles (existence_tier)
+  WHERE deleted_at IS NULL;


### PR DESCRIPTION
## What ships (Source Data Reorg campaign, steps 2-4)
- **Step 2** — close the destructive paths on `vehicle_images`: inbox hard-DELETE closed, legacy `auto_match` path dropped.
- **Step 3** — `v_vehicle_provenance`: canonical source view for where every vehicle row came from.
- **Step 4** — `vehicles.existence_tier` operational column (`dead`/`a`/`b`/`c` render-worthiness) + `existence_tier_staging` + partial index + gated two-phase backfill script (`scripts/backfill-existence-tier.sh`).

## Backfill status
- Phase A (read-only tier compute into staging) **executed 2026-06-10**: 910,175/910,175 rows staged — a=325,614 / b=163,240 / c=106,460 / dead=314,861.
- Phase B (copy staging → `vehicles.existence_tier`) is **gated**: vehicles carries 26 UPDATE triggers; an unsanctioned mass UPDATE churns `updated_at`/`last_activity_at` and enqueues 910K completion recomputes. Run requires `NUKE_TIER_COPY_SANCTIONED=1` (owner sanction) or scoping the churn triggers first.

## Pending human step
- Skylar: sanction phase B (`NUKE_TIER_COPY_SANCTIONED=1 dotenvx run ... backfill-existence-tier.sh --copy`) or approve trigger column-scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)