### PR TITLE
fix(journal): restore /api/journal/:date in prod + per-day OG tags for shared links

### DIFF
--- a/nuke_frontend/api/journal/[date].ts
+++ b/nuke_frontend/api/journal/[date].ts
@@ -5,6 +5,13 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 // project_work_log tool in mcp-connector (which remains the writer of
 // audited projection_event rows). JournalPage.tsx consumes the
 // { date, audience, work_log } shape.
+//
+// DEPLOYED UNIVERSE: this file MUST live in nuke_frontend/api/. Both
+// deploy-vercel.yml and deploy-preview.yml run `vercel deploy` with
+// working-directory ./nuke_frontend, so only nuke_frontend/api/** becomes
+// functions and nuke_frontend/vercel.json is the live routing config.
+// Repo-root api/ is never uploaded (commit f07181e05 moved these handlers
+// there and prod /api/journal/* fell through to the mailbox 404).
 
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;

--- a/nuke_frontend/api/journal/index.ts
+++ b/nuke_frontend/api/journal/index.ts
@@ -6,6 +6,9 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 // before 2026-06-09: JournalIndex.tsx shipped fetching /api/journal while the
 // rewrite catchall sent it to the mailbox function (404). Same service-role
 // PostgREST pattern as api/v1/vehicle.
+//
+// DEPLOYED UNIVERSE: must live in nuke_frontend/api/ — deploys run
+// `vercel deploy` from ./nuke_frontend, so repo-root api/ never ships.
 
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;

--- a/nuke_frontend/api/og/journal/[date].ts
+++ b/nuke_frontend/api/og/journal/[date].ts
@@ -1,0 +1,138 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+// GET /api/og/journal/:date — crawler-only OG shim for the day-receipt page.
+// nuke_frontend/vercel.json rewrites /journal/:date here when the user-agent
+// is a link-preview bot (iMessage masquerades as facebookexternalhit/Facebot/
+// Twitterbot). Humans never hit this route: they fall through to the SPA
+// catchall and get index.html, so client navigation is untouched.
+//
+// v1 is text-only: og:title "SAT AUG 24 2024 — 60 photos — 1977 Chevrolet
+// Blazer", og:description first/last/span, og:url. No og:image yet.
+//
+// DEPLOYED UNIVERSE: must live in nuke_frontend/api/ — deploys run
+// `vercel deploy` from ./nuke_frontend, so repo-root api/ never ships.
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const TZ = 'America/Los_Angeles'; // shop timezone for human-readable times
+
+async function rest(path: string): Promise<any[]> {
+  const r = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    headers: {
+      apikey: SUPABASE_SERVICE_ROLE_KEY!,
+      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      Accept: 'application/json',
+    },
+  });
+  if (!r.ok) throw new Error(`${path.split('?')[0]}: ${r.status}`);
+  return r.json();
+}
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// "2024-08-24" -> "SAT AUG 24 2024"
+function dayLabel(date: string): string {
+  const d = new Date(`${date}T12:00:00Z`);
+  const wk = d.toLocaleDateString('en-US', { weekday: 'short', timeZone: 'UTC' });
+  const mo = d.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' });
+  return `${wk} ${mo} ${d.getUTCDate()} ${d.getUTCFullYear()}`.toUpperCase();
+}
+
+function clock(iso: string): string {
+  return new Date(iso).toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: TZ,
+  });
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
+
+  const raw = req.query.date;
+  const date = Array.isArray(raw) ? raw[0] : raw;
+  if (!date || !DATE_RE.test(date)) {
+    return res.status(400).json({ error: 'date must be YYYY-MM-DD' });
+  }
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    return res.status(500).json({ error: 'Server misconfigured' });
+  }
+
+  let title = `${dayLabel(date)} — Nuke journal`;
+  let description = 'Shop day receipt on nuke.ag.';
+
+  try {
+    const photos = await rest(
+      `vehicle_images?select=vehicle_id,taken_at` +
+        `&taken_at=gte.${date}T00:00:00Z&taken_at=lte.${date}T23:59:59Z` +
+        `&order=taken_at.asc&limit=200`,
+    );
+
+    if (photos.length > 0) {
+      const count = photos.length === 200 ? '200+' : String(photos.length);
+      const noun = photos.length === 1 ? 'photo' : 'photos';
+
+      // most-photographed vehicle that day
+      const tally = new Map<string, number>();
+      for (const p of photos) {
+        if (p.vehicle_id) tally.set(p.vehicle_id, (tally.get(p.vehicle_id) || 0) + 1);
+      }
+      let vehicleLabel = '';
+      const topId = [...tally.entries()].sort((a, b) => b[1] - a[1])[0]?.[0];
+      if (topId) {
+        const [v] = await rest(`vehicles?id=eq.${topId}&select=year,make,model&limit=1`);
+        if (v) vehicleLabel = [v.year, v.make, v.model].filter(Boolean).join(' ');
+      }
+
+      title = `${dayLabel(date)} — ${count} ${noun}${vehicleLabel ? ` — ${vehicleLabel}` : ''}`;
+
+      const first = photos[0].taken_at;
+      const last = photos[photos.length - 1].taken_at;
+      if (first && last) {
+        const spanMin = Math.round((new Date(last).getTime() - new Date(first).getTime()) / 60000);
+        const span =
+          spanMin >= 60 ? `${Math.floor(spanMin / 60)}h ${spanMin % 60}m` : `${spanMin}m`;
+        description = `First photo ${clock(first)} · last ${clock(last)} · ${span} span.`;
+      }
+    } else {
+      description = `No shop activity recorded for ${dayLabel(date)}.`;
+    }
+  } catch {
+    // serve generic tags rather than a 5xx — a degraded preview beats none
+  }
+
+  const url = `https://nuke.ag/journal/${date}`;
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${esc(title)}</title>
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Nuke">
+<meta property="og:title" content="${esc(title)}">
+<meta property="og:description" content="${esc(description)}">
+<meta property="og:url" content="${esc(url)}">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="${esc(title)}">
+<meta name="twitter:description" content="${esc(description)}">
+<link rel="canonical" href="${esc(url)}">
+</head>
+<body>
+<p>${esc(title)}</p>
+<p>${esc(description)}</p>
+<p><a href="${esc(url)}">${esc(url)}</a></p>
+</body>
+</html>`;
+
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  res.setHeader('Cache-Control', 's-maxage=3600, stale-while-revalidate=86400');
+  return res.status(200).send(html);
+}

--- a/nuke_frontend/vercel.json
+++ b/nuke_frontend/vercel.json
@@ -53,8 +53,23 @@
       "destination": "/api/journal/:date"
     },
     {
+      "source": "/api/og/journal/:date",
+      "destination": "/api/og/journal/:date"
+    },
+    {
       "source": "/api/:path+",
       "destination": "https://qkgaybvrernstplzjaam.functions.supabase.co/mailbox/:path+"
+    },
+    {
+      "source": "/journal/:date(\\d{4}-\\d{2}-\\d{2})",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": ".*(facebookexternalhit|Facebot|Twitterbot|twitterbot|Slackbot|Slack-ImgProxy|WhatsApp|Discordbot|TelegramBot|LinkedInBot|Applebot|iMessageBot|SkypeUriPreview|Pinterestbot|redditbot|Googlebot|bingbot).*"
+        }
+      ],
+      "destination": "/api/og/journal/:date"
     },
     {
       "source": "/:path*",


### PR DESCRIPTION
## Root cause of the prod 404 (proven, not guessed)

`vercel deploy` runs from `working-directory: ./nuke_frontend` in **both** `deploy-vercel.yml` and `deploy-preview.yml`. That makes `nuke_frontend/` the upload root: only `nuke_frontend/api/**` becomes serverless functions, and `nuke_frontend/vercel.json` is the live routing config. Repo-root `api/` is never uploaded.

Commit f07181e05 moved `journal/[date].ts` + `journal/index.ts` from `nuke_frontend/api/` to repo-root `api/` — the wrong direction. In prod, `/api/journal/*` matched no function, fell through the live config's `/api/:path+` catchall to the Supabase mailbox function, and returned `{"code":"NOT_FOUND","message":"Requested function was not found"}`.

Prod evidence (nuke.ag at current main, deploy run 04:05Z on 0c16ca2aa):
- `/api/v1/vehicle` → **200** from a Vercel function — it exists in `nuke_frontend/api/v1/` (this is the "sibling that serves fine": it works because a duplicate copy lives in the deployed universe, not because root `api/` ships)
- `/api/journal`, `/api/journal/2024-08-24`, `/api/docs` → **404** with `x-served-by: supabase-edge-runtime` (root-api-only files)
- homepage has **no CSP header** (root `vercel.json` sets one on `/(.*)`; `nuke_frontend/vercel.json` doesn't) and `/api/landing` → 200 SPA shell (rewrite that exists only in `nuke_frontend/vercel.json`)

f07181e05's commit message said `.claude/rules/production-engineering.md` case law was wrong — it was right (line ~65: "the DEPLOYED vercel.json … existed only in the root config Vercel ignores").

## Changes

- **Move back**: `api/journal/{[date],index}.ts` → `nuke_frontend/api/journal/` (header comments now encode the deployed-universe rule so this stops flip-flopping)
- **Per-day OG tags (v1, text-only)**: new `nuke_frontend/api/og/journal/[date].ts` + a user-agent-conditioned rewrite in `nuke_frontend/vercel.json`. Link-preview bots (facebookexternalhit / Facebot / Twitterbot — iMessage masquerades as these — plus Slack/WhatsApp/Discord/Telegram/LinkedIn/Apple/Google/Bing) requesting `/journal/:date` get a tiny HTML page with `og:title` / `og:description` / `og:url`; humans never match the rewrite and get the SPA shell exactly as before. No SPA navigation change.
- Self-rewrite for `/api/og/journal/:date` ahead of the mailbox catchall (same pattern as the existing `/api/journal` entries).

## Verification

Ran both handlers directly with tsx against prod Supabase (service-role REST, read-only):

```
GET /api/journal/2024-08-24 → 200
  summary: { photo_count: 56, receipt_count: 6, receipt_total: 236.99, ... }

OG /journal/2024-08-24 → 200 text/html
  og:title       "SAT AUG 24 2024 — 56 photos — 1977 Chevrolet Blazer"
  og:description "First photo 10:17 AM · last 4:52 PM · 6h 35m span."
  og:url         https://nuke.ag/journal/2024-08-24

OG not-a-date → 400 {"error":"date must be YYYY-MM-DD"}
```

`JournalPage.tsx:118` fetches `` /api/journal/${date} `` — exactly the route `nuke_frontend/api/journal/[date].ts` serves (same file-routing + self-rewrite pattern as the already-working `/api/v1/vehicle`). Env vars (`SUPABASE_SERVICE_ROLE_KEY` etc.) confirmed present in the prod project via the working v1 function. `api/` is outside the frontend tsconfig `include`, so no build impact; `@vercel/node` already a dependency.

After merge, smoke check:
```
curl -s https://nuke.ag/api/journal/2024-08-24 | jq .work_log.summary
curl -s -A facebookexternalhit https://nuke.ag/journal/2024-08-24 | grep og:title
```

## Known follow-ups (not in this PR)

- `/api/docs` is also 404 in prod (`api/docs/index.ts` exists only at repo root). Same class of fix.
- Repo-root `api/v1/vehicle/*` duplicates the deployed `nuke_frontend/api/v1/vehicle/*` (currently byte-identical — drift risk). Root `api/` + root `vercel.json` deserve a cleanup/tombstone.
- On UTC-midnight-crossing days the OG description can read "First photo 4:00 PM · last 10:02 AM" (LA times inside a UTC-bucketed day) — cosmetic, mirrors the page's bucketing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)