### PR TITLE
DB launch gates: iOS upload storage RLS, user_sites, org self-grant fix

### DIFF
--- a/nuke_frontend/src/components/organization/AddOrganizationData.tsx
+++ b/nuke_frontend/src/components/organization/AddOrganizationData.tsx
@@ -122,13 +122,17 @@ export default function AddOrganizationData({ organizationId, onClose, onSaved }
 
         if (error) throw error;
 
-        // Track contribution
+        // Track contribution. RLS only allows self-inserting low-privilege
+        // roles as status='pending' (an org owner activates them), and we
+        // must not downgrade an existing membership row — so insert-if-absent
+        // instead of overwriting (ignoreDuplicates -> ON CONFLICT DO NOTHING).
         await supabase.from('organization_contributors').upsert({
           organization_id: organizationId,
           user_id: user.id,
           role: 'contributor',
+          status: 'pending',
           contribution_count: 1
-        });
+        }, { onConflict: 'organization_id,user_id', ignoreDuplicates: true });
 
         onSaved();
         onClose();
@@ -287,13 +291,15 @@ export default function AddOrganizationData({ organizationId, onClose, onSaved }
         uploadedImages.push(publicUrl);
       }
 
-      // Track contribution
+      // Track contribution — same RLS rule as above: self-insert is
+      // pending-only, and never overwrite an existing membership row.
       await supabase.from('organization_contributors').upsert({
         organization_id: organizationId,
         user_id: user.id,
         role: 'photographer',
+        status: 'pending',
         contribution_count: uploadedImages.length
-      });
+      }, { onConflict: 'organization_id,user_id', ignoreDuplicates: true });
 
       // 4. Create timeline event with EXIF date
       const eventDate = earliestDate || new Date();

--- a/supabase/migrations/20260611050000_vehicle_photos_storage_policies.sql
+++ b/supabase/migrations/20260611050000_vehicle_photos_storage_policies.sql
@@ -1,0 +1,27 @@
+-- LAUNCH GATE: storage RLS for the iOS capture app's upload path.
+--
+-- WHY: storage.objects had 24 policies and ZERO covering bucket
+-- 'vehicle-photos' for user JWTs. The shipped iOS app (and the Mac relay)
+-- uploads to vehicle-photos at users/<auth.uid()>/capture-relay/<filename>
+-- (apps/nuke-capture-ios Config.swift), so every app upload died at the
+-- storage step with an RLS denial. The app has NEVER landed a photo in prod.
+--
+-- SHAPE: owner-scoped INSERT only, matching the path convention. The client
+-- uploads with upsert:false and tolerates "already exists" (SupabaseService
+-- .uploadPhoto), so no UPDATE policy is needed. The bucket is public-read
+-- (storage.buckets.public = true), so no SELECT policy is needed for
+-- retrieval — getPublicURL serves the bytes.
+--
+-- Naming/style mirrors the existing per-bucket policies
+-- ("ownership-documents: owner insert" etc.).
+
+DROP POLICY IF EXISTS "vehicle-photos: owner insert" ON storage.objects;
+CREATE POLICY "vehicle-photos: owner insert"
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'vehicle-photos'
+  AND (storage.foldername(name))[1] = 'users'
+  AND (storage.foldername(name))[2] = (SELECT auth.uid())::text
+);

--- a/supabase/migrations/20260611050100_user_sites.sql
+++ b/supabase/migrations/20260611050100_user_sites.sql
@@ -1,0 +1,30 @@
+-- iOS ignition site sync: server-side home for the capture app's confirmed
+-- sites. Today the app's GPS shop-gate sites are device-local only
+-- (Config.shopLocations is hardcoded; ignition-cluster confirmations live in
+-- UserDefaults) — they must sync to the server so the gate survives
+-- reinstalls and works across devices. Owner-scoped RLS: a user manages only
+-- their own sites.
+
+CREATE TABLE IF NOT EXISTS public.user_sites (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  name text,
+  lat double precision NOT NULL,
+  lon double precision NOT NULL,
+  radius_m integer NOT NULL DEFAULT 150,
+  source text NOT NULL DEFAULT 'ignition_cluster',
+  confirmed_at timestamptz DEFAULT now(),
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE public.user_sites ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS user_sites_owner_all ON public.user_sites;
+CREATE POLICY user_sites_owner_all
+ON public.user_sites
+FOR ALL
+TO authenticated
+USING (user_id = (SELECT auth.uid()))
+WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE INDEX IF NOT EXISTS idx_user_sites_user_id ON public.user_sites (user_id);

--- a/supabase/migrations/20260611050200_org_contributors_close_self_grant.sql
+++ b/supabase/migrations/20260611050200_org_contributors_close_self_grant.sql
@@ -1,0 +1,90 @@
+-- SECURITY: close the organization_contributors self-grant hole.
+--
+-- BEFORE: policy organization_contributors_insert allowed ANY authenticated
+-- user to INSERT any row — including role='owner', status='active' for any
+-- org. Owner role unlocks invite codes, deal jackets, org locations, org
+-- updates, organization_vehicles management and more (32 policies depend on
+-- this table). The UPDATE policy (organization_contributors_update_own) had
+-- no WITH CHECK, so the same escalation worked by inserting a low row and
+-- updating role → 'owner'.
+--
+-- AFTER:
+--   INSERT (self, user_id = auth.uid()) allowed only when one of:
+--     a) join request: role IN ('contributor','photographer') AND
+--        status = 'pending' — an org owner activates it later;
+--     b) creator owner-grant: role = 'owner' and the org row's
+--        discovered_by = auth.uid() — this is exactly the CreateOrganization
+--        / RestorationIntake flow (insert into businesses view with
+--        discovered_by = user.id, then self-insert the owner row);
+--     c) the inserter is already an active owner/co_founder of the org —
+--        they may add rows for other users (any role).
+--   UPDATE keeps USING (own rows) but gains a WITH CHECK that blocks
+--   escalating a row to owner/co_founder unless (b) or (c) holds.
+--
+-- The self-EXISTS subqueries are safe from RLS recursion because the table's
+-- SELECT policy is unconditional (organization_contributors_select: true).
+--
+-- NOTE for app code: AddOrganizationData.tsx upserts contributor/photographer
+-- rows without status (column default 'active') — those upserts must send
+-- status:'pending' to pass branch (a). Existing rows are untouched.
+
+DROP POLICY IF EXISTS organization_contributors_insert ON public.organization_contributors;
+CREATE POLICY organization_contributors_insert
+ON public.organization_contributors
+FOR INSERT
+WITH CHECK (
+  (SELECT auth.uid()) IS NOT NULL
+  AND (
+    -- (a) self join-request: low-privilege role, pending until approved
+    (
+      user_id = (SELECT auth.uid())
+      AND role IN ('contributor', 'photographer')
+      AND status = 'pending'
+    )
+    -- (b) org creator grants themself owner (CreateOrganization flow)
+    OR (
+      user_id = (SELECT auth.uid())
+      AND role = 'owner'
+      AND EXISTS (
+        SELECT 1 FROM public.organizations o
+        WHERE o.id = organization_id
+          AND o.discovered_by = (SELECT auth.uid())
+      )
+    )
+    -- (c) an active owner/co_founder of the org adds members
+    OR EXISTS (
+      SELECT 1 FROM public.organization_contributors oc
+      WHERE oc.organization_id = organization_contributors.organization_id
+        AND oc.user_id = (SELECT auth.uid())
+        AND oc.role IN ('owner', 'co_founder')
+        AND oc.status = 'active'
+    )
+  )
+);
+
+DROP POLICY IF EXISTS organization_contributors_update_own ON public.organization_contributors;
+CREATE POLICY organization_contributors_update_own
+ON public.organization_contributors
+FOR UPDATE
+USING (user_id = (SELECT auth.uid()))
+WITH CHECK (
+  user_id = (SELECT auth.uid())
+  AND (
+    -- cannot escalate own row to a controlling role…
+    role NOT IN ('owner', 'co_founder')
+    -- …unless they created the org
+    OR EXISTS (
+      SELECT 1 FROM public.organizations o
+      WHERE o.id = organization_id
+        AND o.discovered_by = (SELECT auth.uid())
+    )
+    -- …or are already an active owner/co_founder of it
+    OR EXISTS (
+      SELECT 1 FROM public.organization_contributors oc
+      WHERE oc.organization_id = organization_contributors.organization_id
+        AND oc.user_id = (SELECT auth.uid())
+        AND oc.role IN ('owner', 'co_founder')
+        AND oc.status = 'active'
+    )
+  )
+);

--- a/supabase/migrations/20260611050300_fix_create_initial_business_ownership.sql
+++ b/supabase/migrations/20260611050300_fix_create_initial_business_ownership.sql
@@ -1,0 +1,45 @@
+-- FIX: authenticated org creation has been broken platform-wide.
+--
+-- create_initial_business_ownership() (AFTER INSERT trigger on
+-- public.organizations) was hardened with SET search_path TO '' but left the
+-- INSERT target unqualified — with an empty search_path, `business_ownership`
+-- can never resolve, so EVERY insert into organizations by an authenticated
+-- user (CreateOrganization.tsx / RestorationIntake.tsx via the businesses
+-- view) failed with 42P01 'relation "business_ownership" does not exist'.
+-- Service-role inserts survived only because the function skips its body
+-- when auth.uid() IS NULL.
+--
+-- Discovered 2026-06-11 while witnessing the org-creation path for the
+-- contributor self-grant fix. Fix: schema-qualify the table.
+
+CREATE OR REPLACE FUNCTION public.create_initial_business_ownership()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+BEGIN
+    -- Only create ownership if there's an authenticated user (not service role)
+    -- Service role inserts (like from edge functions) won't have auth.uid()
+    IF auth.uid() IS NOT NULL THEN
+        INSERT INTO public.business_ownership (
+            business_id,
+            owner_id,
+            ownership_percentage,
+            ownership_type,
+            ownership_title,
+            acquisition_date
+        ) VALUES (
+            NEW.id,
+            auth.uid(),
+            100.00,
+            'founder',
+            'Founder/Owner',
+            CURRENT_DATE
+        )
+        ON CONFLICT (business_id, owner_id) DO NOTHING;
+    END IF;
+
+    RETURN NEW;
+END;
+$function$;


### PR DESCRIPTION
## Why

The shipped iOS capture app had **never landed a photo in prod**: `storage.objects` had 24 RLS policies and zero covering bucket `vehicle-photos` for user JWTs. Every upload died at the storage step. Tonight's launch gates make the write path real, witnessed end-to-end against prod.

All four migrations are **already applied to prod** (2026-06-11, via psql); this PR records them in `supabase/migrations/`.

## Changes

### 1. `vehicle-photos` storage RLS (the launch blocker)
`"vehicle-photos: owner insert"` — authenticated INSERT scoped to `users/<auth.uid()>/capture-relay/...` (the exact path in `apps/nuke-capture-ios` Config.swift). Bucket is public-read so no SELECT policy; client uploads with `upsert:false` and tolerates already-exists, so no UPDATE policy.

**Witness (user JWT, not service role) — first photo to ever travel the app path:**
- Storage `POST .../vehicle-photos/users/7baa60ae-4786-4218-8311-02235109b9a8/capture-relay/smoke-001.jpg` → **200**
- `vehicle_images` insert, app-exact shape, `source='capture_relay_ios'` → **201**, row `405f6249-54c6-46b0-8162-a5306bbd5063` (tagged in `exif_data.note` as launch-gate smoke test; left in place as evidence)
- Public GET of the object → **200**, byte-identical
- Negative: write to another user's folder → **403**; write outside `users/` → **403**

`vehicle_images` table RLS needed no change — existing policy "Logged in users can upload images" (`auth.uid() = user_id`) already passes the app's row shape (`vehicle_id` NULL).

### 2. `public.user_sites`
Server home for the iOS ignition-cluster site sync (today device-local only). Owner-ALL RLS. Smoke insert with user JWT → **201**.

### 3. Close the `organization_contributors` self-grant hole
**Before:** the INSERT policy was just `auth.uid() IS NOT NULL` — any signed-in user could insert `role='owner', status='active'` for **any** org (owner unlocks invite codes, deal jackets, org locations/updates/vehicles — 32 policies hang off this table). The UPDATE policy had no WITH CHECK, so the same escalation worked by updating one's own row.

**After:** self-insert is restricted to `role IN ('contributor','photographer') AND status='pending'`; org creators (`organizations.discovered_by = auth.uid()` — exactly the CreateOrganization/RestorationIntake flow) may self-grant owner; active owners/co_founders manage members. UPDATE gains a WITH CHECK blocking escalation to owner/co_founder.

**Prod verification with a non-member test user JWT:**
| Attempt | Result |
|---|---|
| self-insert `owner/active` on foreign org | **403** (42501) |
| self-insert `contributor/active` (skip approval) | **403** (42501) |
| self-insert `contributor/pending` (join request) | **201** |
| PATCH own pending row to `owner/active` | **403** (42501) |
| create org via `businesses` view, then self-insert `owner/active` | **201** (creator path intact) |

`AddOrganizationData.tsx` contributor/photographer upserts updated to match (`status:'pending'` + `ignoreDuplicates` so an existing membership row is never overwritten/downgraded).

### 4. Fix `create_initial_business_ownership()` (found during verification)
The trigger function had `SET search_path TO ''` with an **unqualified** `INSERT INTO business_ownership` — it could never resolve, so **every authenticated org creation failed platform-wide** with 42P01 (service-role inserts skip the branch, which masked it). Schema-qualified the target. Creator flow re-tested → works.

## Residual (founder eyes)
- A user can still flip their own row's `status` pending→active via UPDATE while keeping a low role (WITH CHECK can't see the OLD row; a trigger comparing OLD/NEW would close it). Low severity — low roles only.
- Throwaway test user `capture-smoke-20260611@nuke.ag` (7baa60ae-…) exists for future smoke tests; delete if unwanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)