### PR TITLE
CONNECT pillar: unified connections read model, claim table, cockpit wiring (T1 7-9)

### DIFF
--- a/nuke_frontend/src/components/layout/UserDropdown.tsx
+++ b/nuke_frontend/src/components/layout/UserDropdown.tsx
@@ -89,6 +89,7 @@ export const UserDropdown: React.FC<UserDropdownProps> = ({
           <div className="user-dropdown-section-label">SETTINGS</div>
           <button onClick={() => go('/capsule')}>Appearance</button>
           <button onClick={() => go('/capsule?tab=settings')}>Settings</button>
+          <button onClick={() => go('/settings')}>All Settings</button>
           {isAdmin && <button onClick={() => go('/admin')}>Admin</button>}
         </div>
 

--- a/nuke_frontend/src/pages/settings/SettingsHubPage.tsx
+++ b/nuke_frontend/src/pages/settings/SettingsHubPage.tsx
@@ -1,0 +1,116 @@
+/**
+ * Settings Hub — index of every settings surface.
+ *
+ * CONNECTION_COCKPIT T1-8: the cockpit surfaces (connected agents, API keys,
+ * webhooks, usage) existed with ZERO inbound links — reachable only by typed
+ * URL. This page is the single index; UserDropdown links here.
+ *
+ * Deliberately a plain list: navigation, not a dashboard.
+ *
+ * Route: /settings
+ */
+
+import { useNavigate } from 'react-router-dom';
+
+interface SettingsSurface {
+  path?: string;
+  label: string;
+  description: string;
+  /** dispatches the user-profile settings drawer instead of navigating */
+  drawer?: boolean;
+}
+
+const SURFACES: SettingsSurface[] = [
+  {
+    path: '/settings/connected-agents',
+    label: 'Connected Agents',
+    description: 'Issue, scope, and revoke per-vehicle API keys for external agents.',
+  },
+  {
+    path: '/settings/api-keys',
+    label: 'API Keys',
+    description: 'Developer keys for the public API.',
+  },
+  {
+    path: '/settings/webhooks',
+    label: 'Webhooks',
+    description: 'Outbound event delivery endpoints.',
+  },
+  {
+    path: '/settings/usage',
+    label: 'Usage',
+    description: 'API usage and rate-limit dashboard.',
+  },
+  {
+    path: '/business/settings',
+    label: 'Business Settings',
+    description: 'Organization profile and business configuration.',
+  },
+  {
+    path: '/claim-identity',
+    label: 'Claim External Identity',
+    description: 'Link your BaT or other platform handle and inherit its history.',
+  },
+  {
+    path: '/capsule?tab=settings',
+    label: 'Account & Appearance',
+    description: 'Profile capsule, appearance, and account preferences.',
+  },
+  {
+    label: 'Connections Drawer',
+    description: 'Connect auction platforms, social accounts, and data sources.',
+    drawer: true,
+  },
+];
+
+const SettingsHubPage = () => {
+  const navigate = useNavigate();
+
+  const open = (s: SettingsSurface) => {
+    if (s.drawer) {
+      window.dispatchEvent(new Event('up:open-settings'));
+      return;
+    }
+    if (s.path) navigate(s.path);
+  };
+
+  return (
+    <div style={{ maxWidth: 720, margin: '0 auto', padding: '24px 16px', fontFamily: 'Arial, sans-serif' }}>
+      <h1 style={{ fontSize: 18, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 4 }}>
+        Settings
+      </h1>
+      <p style={{ fontSize: 12, color: 'var(--up-pencil, #888)', marginBottom: 16 }}>
+        Every settings surface in one place.
+      </p>
+      <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+        {SURFACES.map((s) => (
+          <li key={s.label} style={{ borderTop: '2px solid var(--up-ink, #1a1a1a)' }}>
+            <button
+              type="button"
+              onClick={() => open(s)}
+              style={{
+                display: 'block',
+                width: '100%',
+                textAlign: 'left',
+                padding: '10px 4px',
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                fontFamily: 'Arial, sans-serif',
+              }}
+            >
+              <span style={{ display: 'block', fontSize: 12, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--up-ink, #1a1a1a)' }}>
+                {s.label}
+              </span>
+              <span style={{ display: 'block', fontSize: 11, color: 'var(--up-pencil, #888)', marginTop: 2 }}>
+                {s.description}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default SettingsHubPage;

--- a/nuke_frontend/src/pages/user-profile/UserConnectionStateStrip.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserConnectionStateStrip.tsx
@@ -1,37 +1,53 @@
 /**
  * UserConnectionStateStrip — first-screen data-source connection surface.
  *
- * Seed implementation per frontend-doctrine §2a + IA assessment Step B.
- * Renders a horizontal strip of connector pills on the user profile main surface,
- * exposing the connection IA primitive that currently lives only behind the
- * settings drawer (`ConnectedPlatforms`, `SocialConnections`).
+ * Per frontend-doctrine §2a + IA assessment Step B, now wired to the unified
+ * connections read model `v_user_connections` (CONNECTION_COCKPIT T1-7):
+ * api keys, agents, external accounts, organizations, vehicle grants, sites,
+ * platform logins — one row per grant edge, RLS-scoped to the signed-in user.
  *
- * For new users this is the single most important first-screen surface: without it
- * the platform looks dead because nothing has been ingested yet. Click → dispatches
- * the existing `up:open-settings` event so the drawer takes over for the actual
- * connect flow (no duplicated auth logic).
+ * Rows are grouped by kind into pills (count + status summary). Pills navigate
+ * to the /settings hub where every connection surface is indexed. When the
+ * user has no connections at all, the original connect-CTA pills render so a
+ * fresh profile still surfaces the IA primitive (click → settings drawer).
  *
- * This is a SEED. Real per-connector status queries land in a follow-up; for now
- * every pill shows NOT CONNECTED. Visual register matches user-profile.css tokens
- * (Arial, ALL CAPS labels, 2px borders, no shadows/radius/gradients).
+ * Visual register matches user-profile.css tokens (Arial, ALL CAPS labels,
+ * 2px borders, no shadows/radius/gradients).
  */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '../../lib/supabase';
 import { useUserProfile } from './UserProfileContext';
 
-interface Connector {
-  id: string;
-  label: string;
+interface ConnectionRow {
+  kind: string;
+  counterparty_name: string | null;
+  status: string | null;
+  health: string | null;
 }
 
-// Connector identities grounded in what actually exists per
-// docs/library/working/field-notes/2026-05-24_safety-audit-completion.md §4:
-// - 9 auction platforms (BaT, Cars & Bids, Mecum, etc.) — credential-based, real
-// - X/Twitter — Supabase linkIdentity('twitter'), real
-// - Manual upload — UniversalImageUpload, real
-// - Social (Instagram/Threads/LinkedIn/YouTube/Facebook/Dropbox) — stubbed/partial
-// iCloud Photos / Gmail / Bank (Plaid) / Snap-On do NOT exist as connectors.
-// Showing only real surfaces; future connectors land here as they ship.
-const CONNECTORS: Connector[] = [
+interface KindGroup {
+  kind: string;
+  label: string;
+  count: number;
+  /** rows whose health is not 'ok' (expired / stale / dead / unverified ...) */
+  attention: number;
+}
+
+const KIND_LABELS: Record<string, string> = {
+  api_key: 'API Keys',
+  agent: 'Agents',
+  external_account: 'External Accounts',
+  organization: 'Organizations',
+  vehicle: 'Vehicle Grants',
+  site: 'Sites',
+  platform_login: 'Platform Logins',
+};
+
+const KIND_ORDER = ['external_account', 'vehicle', 'organization', 'agent', 'api_key', 'site', 'platform_login'];
+
+// Connect-CTA fallback for users with zero connections (original seed pills).
+const EMPTY_CONNECTORS = [
   { id: 'auctions', label: 'Auction Platforms' },
   { id: 'social', label: 'X / Social' },
   { id: 'manual', label: 'Manual Upload' },
@@ -41,11 +57,82 @@ const openSettings = () => {
   window.dispatchEvent(new Event('up:open-settings'));
 };
 
+const pillStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 4,
+  padding: '4px 8px',
+  border: '2px solid var(--up-ink, #1a1a1a)',
+  background: 'var(--up-paper, #fff)',
+  color: 'var(--up-ink, #1a1a1a)',
+  fontFamily: 'Arial, sans-serif',
+  fontSize: 9,
+  fontWeight: 700,
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  borderRadius: 0,
+  cursor: 'pointer',
+  transition: 'background 180ms cubic-bezier(0.16, 1, 0.3, 1)',
+};
+
+const pillStatusStyle: React.CSSProperties = {
+  fontSize: 7,
+  fontWeight: 700,
+  color: 'var(--up-pencil, #888)',
+  letterSpacing: '0.1em',
+};
+
 const UserConnectionStateStrip: React.FC = () => {
   const { isOwnProfile, userId } = useUserProfile();
+  const navigate = useNavigate();
+  const [groups, setGroups] = useState<KindGroup[] | null>(null);
+
+  useEffect(() => {
+    if (!isOwnProfile || !userId) return;
+    let cancelled = false;
+    supabase
+      .from('v_user_connections')
+      .select('kind, counterparty_name, status, health')
+      .then(({ data, error }) => {
+        if (cancelled || error || !data) {
+          if (!cancelled) setGroups([]);
+          return;
+        }
+        const byKind = new Map<string, KindGroup>();
+        (data as ConnectionRow[]).forEach((row) => {
+          const g = byKind.get(row.kind) || {
+            kind: row.kind,
+            label: KIND_LABELS[row.kind] || row.kind.replace(/_/g, ' '),
+            count: 0,
+            attention: 0,
+          };
+          g.count += 1;
+          if (row.health && row.health !== 'ok') g.attention += 1;
+          byKind.set(row.kind, g);
+        });
+        setGroups(
+          Array.from(byKind.values()).sort(
+            (a, b) => KIND_ORDER.indexOf(a.kind) - KIND_ORDER.indexOf(b.kind),
+          ),
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOwnProfile, userId]);
 
   // Strip is owner-only; visitors don't need a CTA to connect another user's data.
   if (!isOwnProfile || !userId) return null;
+  if (groups === null) return null; // loading — render nothing rather than flash
+
+  const hover = {
+    onMouseEnter: (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.currentTarget.style.background = 'var(--up-ghost, #f0f0f0)';
+    },
+    onMouseLeave: (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.currentTarget.style.background = 'var(--up-paper, #fff)';
+    },
+  };
 
   return (
     <div
@@ -71,51 +158,38 @@ const UserConnectionStateStrip: React.FC = () => {
           marginRight: 6,
         }}
       >
-        Data Sources
+        Connections
       </div>
-      {CONNECTORS.map((c) => (
-        <button
-          key={c.id}
-          type="button"
-          onClick={openSettings}
-          title={`Connect ${c.label}`}
-          style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 4,
-            padding: '4px 8px',
-            border: '2px solid var(--up-ink, #1a1a1a)',
-            background: 'var(--up-paper, #fff)',
-            color: 'var(--up-ink, #1a1a1a)',
-            fontFamily: 'Arial, sans-serif',
-            fontSize: 9,
-            fontWeight: 700,
-            letterSpacing: '0.08em',
-            textTransform: 'uppercase',
-            borderRadius: 0,
-            cursor: 'pointer',
-            transition: 'background 180ms cubic-bezier(0.16, 1, 0.3, 1)',
-          }}
-          onMouseEnter={(e) => {
-            (e.currentTarget as HTMLButtonElement).style.background = 'var(--up-ghost, #f0f0f0)';
-          }}
-          onMouseLeave={(e) => {
-            (e.currentTarget as HTMLButtonElement).style.background = 'var(--up-paper, #fff)';
-          }}
-        >
-          <span>{c.label}</span>
-          <span
-            style={{
-              fontSize: 7,
-              fontWeight: 700,
-              color: 'var(--up-pencil, #888)',
-              letterSpacing: '0.1em',
-            }}
-          >
-            NOT CONNECTED
-          </span>
-        </button>
-      ))}
+      {groups.length === 0
+        ? EMPTY_CONNECTORS.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              onClick={openSettings}
+              title={`Connect ${c.label}`}
+              style={pillStyle}
+              {...hover}
+            >
+              <span>{c.label}</span>
+              <span style={pillStatusStyle}>NOT CONNECTED</span>
+            </button>
+          ))
+        : groups.map((g) => (
+            <button
+              key={g.kind}
+              type="button"
+              onClick={() => navigate('/settings')}
+              title={`${g.label}: ${g.count} connection${g.count === 1 ? '' : 's'}${g.attention ? `, ${g.attention} need attention` : ''}`}
+              style={pillStyle}
+              {...hover}
+            >
+              <span>{g.label}</span>
+              <span style={pillStatusStyle}>
+                {g.count}
+                {g.attention > 0 ? ` · ${g.attention}!` : ''}
+              </span>
+            </button>
+          ))}
     </div>
   );
 };

--- a/nuke_frontend/src/routes/DomainRoutes.tsx
+++ b/nuke_frontend/src/routes/DomainRoutes.tsx
@@ -90,6 +90,7 @@ const TeamInbox = React.lazy(() => import('../pages/TeamInbox'));
 // Photo / Unified Inbox
 const PersonalPhotoLibrary = React.lazy(() => import('../pages/PersonalPhotoLibrary').then(m => ({ default: m.PersonalPhotoLibrary })));
 
+const SettingsHubPage = React.lazy(() => import('../pages/settings/SettingsHubPage'));
 const ApiKeysPage = React.lazy(() => import('../pages/settings/ApiKeysPage'));
 const ConnectedAgentsPage = React.lazy(() => import('../pages/settings/ConnectedAgentsPage'));
 const WebhooksPage = React.lazy(() => import('../pages/settings/WebhooksPage'));
@@ -256,6 +257,7 @@ export const DomainRoutes = () => {
 
           {/* Settings (protected) */}
           <Route element={<ProtectedRoute />}>
+            <Route path="/settings" element={<SettingsHubPage />} />
             <Route path="/settings/api-keys" element={<ApiKeysPage />} />
             <Route path="/settings/connected-agents" element={<ConnectedAgentsPage />} />
             <Route path="/settings/webhooks" element={<WebhooksPage />} />

--- a/supabase/migrations/20260611210000_account_link_claims.sql
+++ b/supabase/migrations/20260611210000_account_link_claims.sql
@@ -1,0 +1,195 @@
+-- ============================================================
+-- account_link_claims — the canonical identity-claim table
+-- ============================================================
+-- CONNECTION_COCKPIT.md T1 item 9 ("the phonebook moment").
+--
+-- WHY (verified against prod 2026-06-11):
+--   * mcp-connector (DEPLOYED, unchangeable tonight) writes claims to
+--     `account_link_claims` in handleLinkAccount / handleVerifyAccountLink /
+--     handleListLinkedAccounts — the table does NOT exist in prod, so the
+--     entire MCP link_account flow 500s.
+--   * The web flow (`ClaimExternalIdentity.tsx` → RPC
+--     `request_external_identity_claim`, which EXISTS in prod) inserts into
+--     `external_identity_claims` — that table ALSO does not exist in prod.
+--   * 569,795 rows in external_identities (563,984 BaT handles) are one
+--     CREATE TABLE away from claimable. Only the tables are missing.
+--
+-- DESIGN: ONE canonical table (account_link_claims, the shape the deployed
+-- MCP connector expects) plus a compatibility VIEW named
+-- `external_identity_claims` with INSTEAD OF triggers, so the existing
+-- prod RPCs (request_external_identity_claim / approve_external_identity_claim)
+-- work UNMODIFIED and both paths land claims in the same canonical table.
+--
+-- STRICTLY ADDITIVE: creates 1 table, 1 view, 2 trigger functions, indexes,
+-- RLS policies on the NEW table only. No existing object is altered/dropped.
+
+-- ------------------------------------------------------------
+-- 1) Canonical table
+-- ------------------------------------------------------------
+-- Column superset:
+--   MCP path uses: id, user_id, platform, handle, external_identity_id,
+--                  status, verification_method, claim_confidence, proof_url,
+--                  created_at, updated_at
+--                  (upsert onConflict: user_id,platform,handle)
+--   Web RPC path uses (via compat view): external_identity_id,
+--                  requested_by_user_id, proof_type, proof_url, notes,
+--                  status, reviewed_by_user_id, reviewed_at
+CREATE TABLE IF NOT EXISTS public.account_link_claims (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  platform TEXT NOT NULL,
+  handle TEXT NOT NULL,
+  external_identity_id UUID REFERENCES public.external_identities(id) ON DELETE SET NULL,
+
+  -- union of both flows' vocabularies:
+  -- MCP: pending / pending_review / verified / rejected / expired
+  -- web RPC: pending / approved / rejected / expired
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN
+    ('pending','pending_review','verified','approved','rejected','expired')),
+
+  verification_method TEXT,            -- MCP: email_match | profile_url_proof | manual_review
+  claim_confidence INTEGER DEFAULT 0 CHECK (claim_confidence >= 0 AND claim_confidence <= 100),
+  proof_type TEXT,                     -- web RPC: profile_link | screenshot | oauth | other
+  proof_url TEXT,
+  notes TEXT,
+  reviewed_by_user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  reviewed_at TIMESTAMPTZ,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- required by mcp-connector's upsert({ onConflict: "user_id,platform,handle" })
+  CONSTRAINT account_link_claims_user_platform_handle_key UNIQUE (user_id, platform, handle)
+);
+
+CREATE INDEX IF NOT EXISTS idx_account_link_claims_user ON public.account_link_claims(user_id);
+CREATE INDEX IF NOT EXISTS idx_account_link_claims_identity ON public.account_link_claims(external_identity_id) WHERE external_identity_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_account_link_claims_open ON public.account_link_claims(status) WHERE status IN ('pending','pending_review');
+
+COMMENT ON TABLE public.account_link_claims IS
+  'Canonical identity-claim requests (MCP link_account + web claim flow via external_identity_claims compat view). CONNECTION_COCKPIT T1-9.';
+
+-- ------------------------------------------------------------
+-- 2) RLS: owner-read, owner-insert, service-role everything.
+--    (mcp-connector writes with the service key; the web RPC is
+--    SECURITY DEFINER and bypasses RLS as table owner.)
+--    NO owner-update policy on purpose: users must not be able to
+--    self-promote a claim to status='verified'.
+-- ------------------------------------------------------------
+ALTER TABLE public.account_link_claims ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='account_link_claims' AND policyname='alc_select_own') THEN
+    CREATE POLICY alc_select_own ON public.account_link_claims
+      FOR SELECT USING (user_id = (SELECT auth.uid()));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='account_link_claims' AND policyname='alc_insert_own') THEN
+    CREATE POLICY alc_insert_own ON public.account_link_claims
+      FOR INSERT WITH CHECK (user_id = (SELECT auth.uid()));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='account_link_claims' AND policyname='alc_service_role_all') THEN
+    CREATE POLICY alc_service_role_all ON public.account_link_claims
+      FOR ALL USING ((SELECT auth.jwt() ->> 'role') = 'service_role')
+      WITH CHECK ((SELECT auth.jwt() ->> 'role') = 'service_role');
+  END IF;
+END $$;
+
+GRANT SELECT, INSERT ON public.account_link_claims TO authenticated;
+GRANT ALL ON public.account_link_claims TO service_role;
+
+-- ------------------------------------------------------------
+-- 3) Compatibility surface for the EXISTING prod RPCs:
+--    a view named external_identity_claims with the column names the
+--    RPCs expect, writing through to account_link_claims.
+--    Created only if no relation of that name exists (in a fresh
+--    environment the 20251214 migration creates it as a real table;
+--    in prod it is absent — verified 2026-06-11).
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.external_identity_claims_compat_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+  v_platform TEXT;
+  v_handle TEXT;
+  v_id UUID;
+BEGIN
+  SELECT platform, handle INTO v_platform, v_handle
+  FROM external_identities WHERE id = NEW.external_identity_id;
+  IF v_platform IS NULL THEN
+    RAISE EXCEPTION 'external identity % not found', NEW.external_identity_id;
+  END IF;
+
+  INSERT INTO account_link_claims AS alc
+    (user_id, platform, handle, external_identity_id, status, proof_type, proof_url, notes)
+  VALUES
+    (NEW.requested_by_user_id, v_platform, v_handle, NEW.external_identity_id,
+     COALESCE(NEW.status, 'pending'), NEW.proof_type, NEW.proof_url, NEW.notes)
+  ON CONFLICT (user_id, platform, handle) DO UPDATE SET
+    external_identity_id = COALESCE(alc.external_identity_id, EXCLUDED.external_identity_id),
+    proof_type = COALESCE(EXCLUDED.proof_type, alc.proof_type),
+    proof_url  = COALESCE(EXCLUDED.proof_url,  alc.proof_url),
+    notes      = COALESCE(EXCLUDED.notes,      alc.notes),
+    -- a re-request never downgrades an already-decided claim
+    status     = CASE WHEN alc.status IN ('verified','approved') THEN alc.status
+                      ELSE COALESCE(EXCLUDED.status, 'pending') END,
+    updated_at = NOW()
+  RETURNING id INTO v_id;
+
+  NEW.id := v_id;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.external_identity_claims_compat_update()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE account_link_claims SET
+    status = NEW.status,
+    proof_type = NEW.proof_type,
+    proof_url = NEW.proof_url,
+    notes = NEW.notes,
+    reviewed_by_user_id = NEW.reviewed_by_user_id,
+    reviewed_at = NEW.reviewed_at,
+    updated_at = COALESCE(NEW.updated_at, NOW())
+  WHERE id = OLD.id;
+  RETURN NEW;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF to_regclass('public.external_identity_claims') IS NULL THEN
+    EXECUTE $v$
+      CREATE VIEW public.external_identity_claims
+      WITH (security_invoker = true) AS
+      SELECT id,
+             external_identity_id,
+             user_id AS requested_by_user_id,
+             proof_type,
+             proof_url,
+             notes,
+             status,
+             reviewed_by_user_id,
+             reviewed_at,
+             created_at,
+             updated_at
+      FROM public.account_link_claims
+    $v$;
+    EXECUTE 'CREATE TRIGGER external_identity_claims_compat_ins
+             INSTEAD OF INSERT ON public.external_identity_claims
+             FOR EACH ROW EXECUTE FUNCTION public.external_identity_claims_compat_insert()';
+    EXECUTE 'CREATE TRIGGER external_identity_claims_compat_upd
+             INSTEAD OF UPDATE ON public.external_identity_claims
+             FOR EACH ROW EXECUTE FUNCTION public.external_identity_claims_compat_update()';
+    EXECUTE 'GRANT SELECT ON public.external_identity_claims TO authenticated';
+    EXECUTE 'GRANT ALL ON public.external_identity_claims TO service_role';
+    EXECUTE $c$COMMENT ON VIEW public.external_identity_claims IS
+      'Compatibility view over account_link_claims for the pre-existing request/approve_external_identity_claim RPCs. Both claim flows land in one canonical table.'$c$;
+  END IF;
+END $$;

--- a/supabase/migrations/20260611211000_v_user_connections.sql
+++ b/supabase/migrations/20260611211000_v_user_connections.sql
@@ -1,0 +1,225 @@
+-- ============================================================
+-- v_user_connections — the unified connections read model
+-- ============================================================
+-- CONNECTION_COCKPIT.md T1 item 7: ONE read model unioning every
+-- identity/grant edge into (user_id, kind, counterparty_name,
+-- counterparty_id, scope, status, granted_at, expires_at, health).
+-- This is the literal cockpit screen; replaces the hardcoded
+-- NOT-CONNECTED strip on the user profile.
+--
+-- STRICTLY ADDITIVE: 1 view + 2 NEW owner-read policies (below).
+-- Nothing existing is altered or dropped.
+--
+-- SECURITY MODEL:
+--   * security_invoker = true (PG 17): every branch is evaluated with the
+--     caller's privileges, so each underlying table's RLS applies.
+--   * Additionally every branch filters user_id = auth.uid(), because two
+--     underlying tables (organization_contributors, vehicle_user_permissions)
+--     are public-read by existing policy — without the filter a caller
+--     would see other users' edges. The view is "MY connections" by
+--     construction; service-role consumers should query base tables.
+--
+-- Two underlying tables have RLS ENABLED with ZERO SELECT policies in prod
+-- (verified 2026-06-11): user_external_profiles and agent_registrations.
+-- Owners cannot read their OWN rows, which blanks two cockpit kinds (and
+-- already silently breaks the settings drawer's social connections read).
+-- We add narrow owner-read SELECT policies — NEW policies only, granting
+-- owners visibility of rows they already own. No existing policy is touched.
+--
+-- oauth_clients: NO user-linkage column exists (client_id/secret/name/uris
+-- only — verified against prod information_schema), so registered OAuth
+-- clients cannot be attributed to a user and are EXCLUDED from this view.
+-- When client ownership lands (e.g. an owner_user_id column added by a
+-- future migration), add an 'oauth_client' branch here.
+
+-- ------------------------------------------------------------
+-- 1) Owner-read policies for the two policy-less RLS tables
+-- ------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public'
+                 AND tablename='user_external_profiles' AND policyname='uep_select_own') THEN
+    CREATE POLICY uep_select_own ON public.user_external_profiles
+      FOR SELECT USING (user_id = (SELECT auth.uid()));
+  END IF;
+  -- agent_registrations has no user_id; ownership is via api_keys
+  -- (api_keys.agent_registration_id -> agent_registrations.id, api_keys.user_id).
+  -- user_external_profiles is also missing the table-level SELECT grant for
+  -- authenticated (every sibling table has it — verified in prod
+  -- information_schema.role_table_grants 2026-06-11). GRANT is additive;
+  -- rows stay protected by RLS (owner-read policy above).
+  GRANT SELECT ON public.user_external_profiles TO authenticated;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public'
+                 AND tablename='agent_registrations' AND policyname='agent_registrations_select_own_via_key') THEN
+    CREATE POLICY agent_registrations_select_own_via_key ON public.agent_registrations
+      FOR SELECT USING (EXISTS (
+        SELECT 1 FROM public.api_keys ak
+        WHERE ak.agent_registration_id = agent_registrations.id
+          AND ak.user_id = (SELECT auth.uid())
+      ));
+  END IF;
+END $$;
+
+-- ------------------------------------------------------------
+-- 2) The view
+-- ------------------------------------------------------------
+CREATE OR REPLACE VIEW public.v_user_connections
+WITH (security_invoker = true) AS
+
+-- api_key: personal API keys (non-agent)
+SELECT
+  ak.user_id,
+  'api_key'::text AS kind,
+  ak.name AS counterparty_name,
+  ak.id::text AS counterparty_id,
+  array_to_string(ak.scopes, ' ') AS scope,
+  CASE
+    WHEN NOT ak.is_active THEN 'revoked'
+    WHEN ak.expires_at IS NOT NULL AND ak.expires_at < NOW() THEN 'expired'
+    ELSE 'active'
+  END AS status,
+  ak.created_at AS granted_at,
+  ak.expires_at,
+  CASE
+    WHEN NOT ak.is_active THEN 'dead'
+    WHEN ak.expires_at IS NOT NULL AND ak.expires_at < NOW() THEN 'dead'
+    WHEN ak.expires_at IS NOT NULL AND ak.expires_at < NOW() + INTERVAL '7 days' THEN 'expiring'
+    WHEN ak.last_used_at IS NULL THEN 'never_used'
+    WHEN ak.last_used_at < NOW() - INTERVAL '30 days' THEN 'stale'
+    ELSE 'ok'
+  END AS health
+FROM public.api_keys ak
+WHERE ak.agent_registration_id IS NULL
+  AND ak.user_id = (SELECT auth.uid())
+
+UNION ALL
+
+-- agent: registered agents reachable through the caller's API keys
+SELECT
+  ak.user_id,
+  'agent'::text,
+  COALESCE(ar.name, ak.name),
+  COALESCE(ar.id, ak.agent_registration_id),
+  array_to_string(ak.scopes, ' '),
+  CASE
+    WHEN NOT ak.is_active THEN 'revoked'
+    WHEN ak.expires_at IS NOT NULL AND ak.expires_at < NOW() THEN 'expired'
+    ELSE COALESCE(ar.status, 'active')
+  END,
+  ak.created_at,
+  ak.expires_at,
+  CASE
+    WHEN NOT ak.is_active THEN 'dead'
+    WHEN ak.expires_at IS NOT NULL AND ak.expires_at < NOW() THEN 'dead'
+    WHEN ak.expires_at IS NOT NULL AND ak.expires_at < NOW() + INTERVAL '7 days' THEN 'expiring'
+    WHEN COALESCE(ar.last_seen_at, ak.last_used_at) IS NULL THEN 'never_used'
+    WHEN COALESCE(ar.last_seen_at, ak.last_used_at) < NOW() - INTERVAL '30 days' THEN 'stale'
+    ELSE 'ok'
+  END
+FROM public.api_keys ak
+LEFT JOIN public.agent_registrations ar ON ar.id = ak.agent_registration_id
+WHERE ak.agent_registration_id IS NOT NULL
+  AND ak.user_id = (SELECT auth.uid())
+
+UNION ALL
+
+-- external_account: linked platform identities (BaT, IG, ...)
+SELECT
+  uep.user_id,
+  'external_account'::text,
+  uep.platform || ':' || uep.username,
+  uep.platform || ':' || uep.username,
+  uep.platform,
+  CASE WHEN uep.verified THEN 'verified' ELSE 'unverified' END,
+  uep.created_at,
+  NULL::timestamptz,
+  CASE WHEN uep.verified THEN 'ok' ELSE 'unverified' END
+FROM public.user_external_profiles uep
+WHERE uep.user_id = (SELECT auth.uid())
+
+UNION ALL
+
+-- organization: org membership/contributor edges
+SELECT
+  oc.user_id,
+  'organization'::text,
+  COALESCE(o.business_name, o.name, 'organization ' || LEFT(oc.organization_id::text, 8)),
+  oc.organization_id::text,
+  oc.role,
+  COALESCE(oc.status, 'active'),
+  oc.created_at,
+  NULL::timestamptz,
+  CASE WHEN COALESCE(oc.status, 'active') = 'active' THEN 'ok' ELSE COALESCE(oc.status, 'ok') END
+FROM public.organization_contributors oc
+LEFT JOIN public.organizations o ON o.id = oc.organization_id
+WHERE oc.user_id = (SELECT auth.uid())
+
+UNION ALL
+
+-- vehicle: per-vehicle permission grants
+SELECT
+  vup.user_id,
+  'vehicle'::text,
+  NULLIF(TRIM(CONCAT_WS(' ', v.year::text, v.make, v.model)), ''),
+  vup.vehicle_id::text,
+  vup.role,
+  CASE
+    WHEN vup.revoked_at IS NOT NULL THEN 'revoked'
+    WHEN vup.expires_at IS NOT NULL AND vup.expires_at < NOW() THEN 'expired'
+    WHEN COALESCE(vup.is_active, true) THEN 'active'
+    ELSE 'inactive'
+  END,
+  COALESCE(vup.granted_at, vup.created_at),
+  vup.expires_at,
+  CASE
+    WHEN vup.revoked_at IS NOT NULL THEN 'dead'
+    WHEN vup.expires_at IS NOT NULL AND vup.expires_at < NOW() THEN 'dead'
+    WHEN vup.expires_at IS NOT NULL AND vup.expires_at < NOW() + INTERVAL '7 days' THEN 'expiring'
+    ELSE 'ok'
+  END
+FROM public.vehicle_user_permissions vup
+LEFT JOIN public.vehicles v ON v.id = vup.vehicle_id
+WHERE vup.user_id = (SELECT auth.uid())
+
+UNION ALL
+
+-- site: confirmed/suggested work sites (user_sites, T0 item 5)
+SELECT
+  us.user_id,
+  'site'::text,
+  us.name,
+  us.id::text,
+  ROUND(us.lat::numeric, 4) || ',' || ROUND(us.lon::numeric, 4) || ' r' || COALESCE(us.radius_m::text, '?') || 'm',
+  CASE WHEN us.confirmed_at IS NOT NULL THEN 'confirmed' ELSE 'suggested' END,
+  us.created_at,
+  NULL::timestamptz,
+  CASE WHEN us.confirmed_at IS NOT NULL THEN 'ok' ELSE 'pending_confirm' END
+FROM public.user_sites us
+WHERE us.user_id = (SELECT auth.uid())
+
+UNION ALL
+
+-- platform_login: stored platform credentials (BaT login etc.)
+SELECT
+  pc.user_id,
+  'platform_login'::text,
+  pc.platform,
+  pc.id::text,
+  NULL::text,
+  COALESCE(pc.status, 'unknown'),
+  pc.created_at,
+  pc.session_expires_at,
+  CASE
+    WHEN COALESCE(pc.status, '') NOT IN ('', 'active', 'valid') THEN COALESCE(pc.status, 'unknown')
+    WHEN pc.session_expires_at IS NOT NULL AND pc.session_expires_at < NOW() THEN 'session_expired'
+    WHEN pc.validation_error IS NOT NULL THEN 'error'
+    ELSE 'ok'
+  END
+FROM public.platform_credentials pc
+WHERE pc.user_id = (SELECT auth.uid());
+
+COMMENT ON VIEW public.v_user_connections IS
+  'Unified per-user connections read model (CONNECTION_COCKPIT T1-7): api keys, agents, external accounts, orgs, vehicle grants, sites, platform logins. security_invoker; each branch additionally scoped to auth.uid().';
+
+GRANT SELECT ON public.v_user_connections TO authenticated;
+GRANT SELECT ON public.v_user_connections TO service_role;


### PR DESCRIPTION
## What

CONNECTION_COCKPIT.md T1 items 7–9 (overnight mandate). Strictly additive prod DDL — already applied to prod and verified live.

### 1. `v_user_connections` — the unified read model (T1-7)
One view unioning every grant edge into `(user_id, kind, counterparty_name, counterparty_id, scope, status, granted_at, expires_at, health)`:

| kind | source |
|---|---|
| api_key | api_keys (non-agent) |
| agent | api_keys × agent_registrations |
| external_account | user_external_profiles |
| organization | organization_contributors × organizations |
| vehicle | vehicle_user_permissions × vehicles |
| site | user_sites |
| platform_login | platform_credentials |

`oauth_clients` is excluded: it has **no user-linkage column** in prod (client_id/secret/name/uris only) — documented in the migration; add a branch when ownership lands.

**Security:** `security_invoker = true` so every underlying table's RLS applies, PLUS each branch filters `user_id = auth.uid()` because organization_contributors and vehicle_user_permissions are public-read by existing policy. Two NEW owner-read policies added (`uep_select_own`, `agent_registrations_select_own_via_key`) because both tables had RLS enabled with **zero SELECT policies** — owners could not read their own rows (this was already silently breaking the settings drawer's social reads). One missing table-level `GRANT SELECT ... TO authenticated` on user_external_profiles (every sibling table has it). Nothing existing altered or dropped.

**RLS proof (prod, via PostgREST with throwaway user `connect-smoke-20260611@nuke.ag` / `81da4b69`):**
- View returned exactly the user's 3 seeded rows (api_key, external_account, site)
- `select=user_id` distinct → `["81da4b69-946c-4148-b0cf-c1c5c2277e64"]` only, while prod holds 11 org edges + 104 vehicle grants belonging to others

### 2. Cockpit wiring (T1-8)
- `UserConnectionStateStrip.tsx`: hardcoded NOT-CONNECTED pills replaced with real rows from `v_user_connections`, grouped by kind (count + needs-attention marker). Same visual grammar, zero new styling; connect-CTA pills remain as the empty-state fallback.
- New `/settings` hub page (plain list) indexing: connected-agents, api-keys, webhooks, usage, business settings, claim-identity, capsule, the connections drawer.
- `UserDropdown`: added one "All Settings" entry → `/settings` (existing capsule links kept).

### 3. `account_link_claims` — the phonebook moment (T1-9)
Both claim flows were broken on missing tables. ONE canonical table (`account_link_claims`, the shape the **deployed** mcp-connector writes: unique `(user_id, platform, handle)`, status/verification_method/claim_confidence/proof_url) + a compatibility **view** named `external_identity_claims` with INSTEAD OF triggers, so the pre-existing prod RPCs (`request_external_identity_claim` / `approve_external_identity_claim`) work **unmodified** and both paths land in the same table. RLS: owner-read + owner-insert + service-role; no owner-update (users cannot self-verify).

**Live proof (prod):**
- MCP `link_account` (deployed function, untouched) for the smoke user against unclaimed inert BaT handle `kdg13459` → `pending_verification`, claim row **`1f947dc0-5ad2-4838-84ef-3260b63f5163`**
- `list_linked_accounts` returns it (1 linked account, 1 pending claim)
- Compat-view INSERT path → canonical row `378dc261-8b3d-4669-a460-124ea338343d` with working `RETURNING id`

### Gap found (pre-existing, NOT fixed here — fix requires ALTER FUNCTION, forbidden tonight)
The prod `request_external_identity_claim` RPC was security-hardened with `search_path=""` while its body uses unqualified table names → it fails with `relation "external_identities" does not exist` **before reaching any table**. The web claim flow stays broken until an authorized change runs:
`ALTER FUNCTION request_external_identity_claim(text,text,text,text,text,text) SET search_path = public;` (same for `approve_external_identity_claim`). The compat view is ready and proven for the moment that lands.

## Verification
- Both migrations applied to prod via psql, idempotent (guarded DO blocks)
- `npm run build` in nuke_frontend: ✓ built in 11.32s
- Visual confirmation of the strip in prod needs the founder (SPA, auth-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)