### PR TITLE
perf(images): vehicle_images full-set fetch — 10.9MB serial → 3MB parallel (-72%)

### DIFF
--- a/nuke_frontend/src/components/images/ImageGallery.tsx
+++ b/nuke_frontend/src/components/images/ImageGallery.tsx
@@ -64,8 +64,67 @@ const TAG_TYPES = [
   { value: 'tool', label: 'Tool' }
 ];
 
+// exif_data and ai_scan_metadata are NOT selected whole: together they were
+// ~80% of the list payload (ai_scan_metadata alone 62% — multi-MB deep_analysis
+// blobs the gallery never renders). Only the sub-keys the gallery actually
+// reads come down, as PostgREST arrow projections; rehydrateGalleryRows folds
+// them back into the nested shapes consumers expect.
 const GALLERY_IMAGE_SELECT =
-  'id, image_url, thumbnail_url, medium_url, large_url, variants, is_primary, position, caption, created_at, taken_at, exif_data, source, source_url, user_id, is_sensitive, sensitive_type, is_document, document_category, ai_scan_metadata, ai_last_scanned, angle, category, storage_path, file_hash, vehicle_zone, photo_quality_score, condition_score, damage_flags, image_medium';
+  'id, image_url, thumbnail_url, medium_url, large_url, variants, is_primary, position, caption, created_at, taken_at, source, source_url, user_id, is_sensitive, sensitive_type, is_document, document_category, ai_last_scanned, angle, category, storage_path, file_hash, vehicle_zone, photo_quality_score, condition_score, damage_flags, image_medium, ' +
+  'ai_tier1:ai_scan_metadata->tier_1_analysis, ai_classification:ai_scan_metadata->classification, ai_deep_condition_score:ai_scan_metadata->deep_analysis->condition_detail->overall_score, ai_fabrication_stage:ai_scan_metadata->deep_analysis->>fabrication_stage, ' +
+  'exif_source_url:exif_data->>source_url, exif_discovery_url:exif_data->>discovery_url, exif_original_url:exif_data->>original_url, exif_listing_urls:exif_data->listing_urls, exif_listing_positions:exif_data->listing_positions, exif_auction_start_date:exif_data->>auction_start_date, exif_listed_date:exif_data->>listed_date, exif_start_date:exif_data->>start_date, exif_auction_end_date:exif_data->>auction_end_date, exif_end_date:exif_data->>end_date, exif_camera:exif_data->camera, exif_location:exif_data->location';
+
+const compactObject = (obj: Record<string, any>): Record<string, any> | null => {
+  const out: Record<string, any> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== null && v !== undefined) out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : null;
+};
+
+// Fold the flat arrow-projection aliases back into the nested exif_data /
+// ai_scan_metadata objects that this component and ImageZoneSection read.
+const rehydrateGalleryRows = (rows: any[]): any[] =>
+  (rows || []).map((r: any) => {
+    if (!r || typeof r !== 'object') return r;
+    const {
+      ai_tier1, ai_classification, ai_deep_condition_score, ai_fabrication_stage,
+      exif_source_url, exif_discovery_url, exif_original_url, exif_listing_urls,
+      exif_listing_positions, exif_auction_start_date, exif_listed_date,
+      exif_start_date, exif_auction_end_date, exif_end_date, exif_camera, exif_location,
+      ...rest
+    } = r;
+    return {
+      ...rest,
+      ai_scan_metadata: compactObject({
+        tier_1_analysis: ai_tier1,
+        classification: ai_classification,
+        deep_analysis: compactObject({
+          condition_detail: ai_deep_condition_score != null ? { overall_score: ai_deep_condition_score } : null,
+          fabrication_stage: ai_fabrication_stage,
+        }),
+      }),
+      exif_data: compactObject({
+        source_url: exif_source_url,
+        discovery_url: exif_discovery_url,
+        original_url: exif_original_url,
+        listing_urls: exif_listing_urls,
+        listing_positions: exif_listing_positions,
+        auction_start_date: exif_auction_start_date,
+        listed_date: exif_listed_date,
+        start_date: exif_start_date,
+        auction_end_date: exif_auction_end_date,
+        end_date: exif_end_date,
+        camera: exif_camera,
+        location: exif_location,
+      }),
+    };
+  });
+
+const fetchGalleryImages = async (vehicleId: string): Promise<any[]> =>
+  rehydrateGalleryRows(
+    await fetchVehicleImages<any>(vehicleId, GALLERY_IMAGE_SELECT, { includeMismatchFilter: true }),
+  );
 const UNKNOWN_DEVICE_FINGERPRINT = 'Unknown-Unknown-Unknown-Unknown';
 
 // Convert a Supabase storage URL to an on-the-fly transform URL.
@@ -1149,7 +1208,7 @@ const ImageGallery = ({
       }
 
       // Refresh DB-backed gallery view immediately
-      const refreshed = await fetchVehicleImages<any>(vehicleId, GALLERY_IMAGE_SELECT, { includeMismatchFilter: true });
+      const refreshed = await fetchGalleryImages(vehicleId);
 
       const images = filterBatNoiseRows(dedupeFetchedImages(refreshed || []));
       setUsingFallback(false);
@@ -1783,7 +1842,7 @@ const ImageGallery = ({
 
         // Fetch images and duplicate count in parallel
         const [rawImages, dupCountResult] = await Promise.all([
-          fetchVehicleImages<any>(vehicleId, GALLERY_IMAGE_SELECT, { includeMismatchFilter: true }),
+          fetchGalleryImages(vehicleId),
           // Count duplicates filtered out (for "dupes removed" display)
           supabase
             .from('vehicle_images')
@@ -1866,7 +1925,7 @@ const ImageGallery = ({
         setTimeout(async () => {
           try {
             console.log(`Refresh attempt ${index + 1}/${refreshAttempts.length} after ${delay}ms...`);
-            const refreshedImages = await fetchVehicleImages<any>(vehicleId, GALLERY_IMAGE_SELECT, { includeMismatchFilter: true });
+            const refreshedImages = await fetchGalleryImages(vehicleId);
 
             if (refreshedImages) {
               const refreshedDeduped = dedupeFetchedImages(refreshedImages || []);
@@ -2075,18 +2134,10 @@ const ImageGallery = ({
       const sortAfterUpload: 'quality' | 'date_desc' | 'date_asc' = 'date_desc';
       setSortBy(sortAfterUpload);
 
-      // Refresh images and notify parent
-      const { data: refreshedImages } = await supabase
-        .from('vehicle_images')
-        .select('id, image_url, thumbnail_url, medium_url, large_url, variants, is_primary, position, caption, created_at, taken_at, exif_data, source, source_url, user_id, is_sensitive, sensitive_type, is_document, document_category, ai_scan_metadata, ai_last_scanned, angle, category, storage_path, file_hash, vehicle_zone, photo_quality_score, condition_score, damage_flags, image_medium')
-        .eq('vehicle_id', vehicleId)
-        // Filter out documents (treat NULL as false)
-        .not('is_document', 'is', true)
-        .not('is_duplicate', 'is', true)
-        .or('image_vehicle_match_status.is.null,image_vehicle_match_status.not.in.("mismatch","unrelated")')
-        .order('is_primary', { ascending: false })
-        .order('position', { ascending: true, nullsFirst: false })
-        .order('created_at', { ascending: true });
+      // Refresh images and notify parent. Same fetch path as initial load —
+      // the old inline query here was unpaginated (capped at the REST row
+      // limit) and skipped the vision-gate filter the other refresh paths use.
+      const refreshedImages = await fetchGalleryImages(vehicleId);
 
       const refreshedDeduped = dedupeFetchedImages(refreshedImages || []);
       const refreshedCleaned = applyQuarantinePolicy(refreshedDeduped);

--- a/nuke_frontend/src/lib/fetchVehicleImages.ts
+++ b/nuke_frontend/src/lib/fetchVehicleImages.ts
@@ -1,6 +1,8 @@
 import { supabase } from './supabase';
 
 const PAGE_SIZE = 500;
+// Cap the fan-out so a 50k-image vehicle doesn't fire 100 concurrent requests.
+const MAX_PARALLEL_PAGES = 6;
 
 interface FetchVehicleImagesOptions {
   includeMismatchFilter?: boolean;
@@ -15,6 +17,10 @@ const inflightFetches = new Map<string, Promise<any[]>>();
 /**
  * Fetch all matching vehicle images even when a vehicle exceeds the REST row cap.
  * Identical concurrent calls (same vehicle + select + options) share one request.
+ *
+ * Page 0 carries an exact count, then the remaining pages fan out in parallel
+ * (measured 2026-06-11 on a 2,686-row vehicle: 6 serial round-trips -> 1 + one
+ * parallel wave).
  */
 export async function fetchVehicleImages<T = any>(
   vehicleId: string,
@@ -38,43 +44,51 @@ async function fetchVehicleImagesUncached<T = any>(
   selectClause: string,
   options: FetchVehicleImagesOptions = {},
 ): Promise<T[]> {
-  const rows: T[] = [];
-  let from = 0;
+  // Gate + mismatch filters run server-side as ONE or=(and(or(),or())) group.
+  // Two chained .or() calls emit duplicate or= params (PostgREST 500s on those);
+  // a single combined group is accepted (probed against prod 2026-06-11).
+  // Server-side filtering also stops rejected rows from being downloaded just
+  // to be discarded (20% of rows for heavy vehicles), and applies the vision
+  // gate even when the caller's select omits vision_gate_status — the old
+  // client-side filter silently no-opped in that case.
+  const gateFilter = options.includeMismatchFilter
+    ? 'and(or(vision_gate_status.is.null,vision_gate_status.eq.approved),or(image_vehicle_match_status.is.null,image_vehicle_match_status.not.in.("mismatch","unrelated")))'
+    : 'vision_gate_status.is.null,vision_gate_status.eq.approved';
 
-  while (true) {
-    // Chained .or() with not.in.("a","b") was producing PostgREST 500s.
-    // Server-side filters that work cleanly stay; the OR-chain filters move client-side.
-    const query = supabase
+  const fetchPage = (from: number, withCount: boolean) =>
+    supabase
       .from('vehicle_images')
-      .select(selectClause)
+      .select(selectClause, withCount ? { count: 'exact' } : undefined)
       .eq('vehicle_id', vehicleId)
       .not('is_document', 'is', true)
       .not('is_duplicate', 'is', true)
       .not('image_url', 'is', null)
+      .or(gateFilter)
       .order('is_primary', { ascending: false })
       .order('position', { ascending: true, nullsFirst: false })
       .order('created_at', { ascending: true })
       .range(from, from + PAGE_SIZE - 1);
 
-    const { data, error } = await query;
-    if (error) throw error;
+  const { data, error, count } = await fetchPage(0, true);
+  if (error) throw error;
 
-    const rawBatch = (data || []) as any[];
-    const filtered = rawBatch.filter((r: any) => {
-      if (options.includeMismatchFilter) {
-        const mvms = r?.image_vehicle_match_status;
-        if (mvms === 'mismatch' || mvms === 'unrelated') return false;
-      }
-      const vgs = r?.vision_gate_status;
-      if (vgs != null && vgs !== 'approved') return false;
-      return true;
-    }) as T[];
-    rows.push(...filtered);
+  const rows = [...((data || []) as T[])];
+  const total = typeof count === 'number' ? count : rows.length;
+  if (rows.length < PAGE_SIZE || total <= rows.length) return rows;
 
-    // Pagination break MUST use raw page size — filtering can drop rows but the
-    // next page may still have unfiltered ones.
-    if (rawBatch.length < PAGE_SIZE) break;
-    from += PAGE_SIZE;
+  const offsets: number[] = [];
+  for (let from = PAGE_SIZE; from < total; from += PAGE_SIZE) offsets.push(from);
+
+  for (let i = 0; i < offsets.length; i += MAX_PARALLEL_PAGES) {
+    const wave = offsets.slice(i, i + MAX_PARALLEL_PAGES);
+    const pages = await Promise.all(
+      wave.map(async (from) => {
+        const { data: page, error: pageError } = await fetchPage(from, false);
+        if (pageError) throw pageError;
+        return (page || []) as T[];
+      }),
+    );
+    for (const page of pages) rows.push(...page);
   }
 
   return rows;


### PR DESCRIPTION
## Problem

The signed-out vehicle profile (`/vehicle/e08bf694-…`) fires a full-set `vehicle_images` fetch via `fetchVehicleImages.ts`: 6 **serial** 500-row REST pages with a ~30-column select including whole `ai_scan_metadata` and `exif_data` jsonb. After #279 fixed first paint, this was the slowest remaining tail — it delays gallery completeness and burns bandwidth (7-12s/request observed on residential pipes; transfer-bound).

## Measurements (prod anon, probe kit, 2026-06-11)

| | Before | After |
|---|---|---|
| Payload, full set | **10.94 MB** (1.27–3.28 MB/page) | **3.04 MB** (−72%) |
| Round-trips | 6 serial | 1 + parallel wave (max 6 concurrent) |
| Rows downloaded | 2,686 (551 discarded client-side after download) | 2,135 (gate filter server-side) |
| Wall (fast pipe) | 2.8s | 2.5s (1.6s page0+count + 0.86s tail) |
| Wall (transfer-bound) | bytes-dominated | ~3.6× from byte cut alone |

Payload anatomy that drove the fix: `ai_scan_metadata` = **62%** of bytes (multi-MB `deep_analysis`/`byok_deep_analysis` blobs the gallery never renders), `exif_data` = 17%, and 20% of rows were vision-gate rejects downloaded just to be discarded.

## Changes

**`fetchVehicleImages.ts`**
- Page 0 carries `count: 'exact'`; remaining ranges fan out in parallel (capped at 6 concurrent so a 50k-image vehicle doesn't fire 100 requests).
- Vision-gate + mismatch filters moved server-side as a single `or=(and(or(),or()))` group — probed against prod, no PostgREST 500 (the historical 500 came from *duplicate* `or=` params via chained `.or()`).
- Side-effect fix: the old client-side gate filter silently no-opped when the caller's select omitted `vision_gate_status` — which the gallery's select did. Gate now enforced for all callers (consistent with fcba1642 / 575d3241 extending the gate to display surfaces). Display count for this vehicle: 2,686 → 2,135.

**`ImageGallery.tsx`**
- `GALLERY_IMAGE_SELECT` no longer pulls whole `ai_scan_metadata`/`exif_data`; only the sub-keys the gallery actually reads come down as PostgREST arrow projections (`ai_tier1:ai_scan_metadata->tier_1_analysis`, `exif_camera:exif_data->camera`, …) and `rehydrateGalleryRows` folds them back into the nested shapes consumers (incl. `ImageZoneSection` zone scores/fabrication stage) expect — no consumer changes.
- The post-upload refresh now uses the same shared fetch path; its old inline query was unpaginated (capped at the REST row limit) and skipped the vision gate.

## Verification

- tsc `--noEmit` clean, `vite build` clean.
- Ran the branch against prod (vite dev, signed-out): gallery fetched the complete set in 1+5 pages; in-app row count matched the server-side gated count **exactly** (2,974 — the set grew during the session; ingestion is actively adding images to this vehicle). Profile renders, hero + grid populated, zero console errors.
- Out of scope but observed while probing: other components on this page still issue `select=*` unpaginated and `select=ai_scan_metadata&limit=5000` queries — candidates for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)