### PR TITLE
perf(images): kill 7.4MB legacy select(*) + project jsonb sub-keys in profile widgets (−95%)

### DIFF
--- a/nuke_frontend/src/components/images/ImageGallery.tsx
+++ b/nuke_frontend/src/components/images/ImageGallery.tsx
@@ -467,38 +467,11 @@ const ImageGallery = ({
   }, [vehicleId]);
 
   // Vehicle meta (used to suppress "BaT homepage noise" images that were mistakenly attached to some vehicles)
+  // Loaded by the main fetchImages effect below. A legacy effect here used to fire
+  // an unpaginated select('*') of the entire vehicle_images set (7.4MB on a 3.6k-image
+  // vehicle) and race setAllImages against the real loader — it never actually loaded
+  // vehicle meta (its setVehicleMeta was a self-assignment) and was removed.
   const [vehicleMeta, setVehicleMeta] = useState<any | null>(null);
-  useEffect(() => {
-    const loadImages = async () => {
-      setLoading(true);
-      try {
-        // Load images from database
-        // Chained .or() with not.in.("a","b") syntax was producing PostgREST 500s.
-        // Fetch + filter client-side; result set is bounded by vehicle_id.
-        const { data: rawImages, error } = await supabase
-          .from('vehicle_images')
-          .select('*')
-          .eq('vehicle_id', vehicleId)
-          .order('position', { ascending: true })
-          .order('created_at', { ascending: true });
-
-        if (error) throw error;
-        const images = (rawImages || []).filter((r: any) => {
-          if (r?.is_duplicate === true) return false;
-          const mvms = r?.image_vehicle_match_status;
-          if (mvms === 'mismatch' || mvms === 'unrelated') return false;
-          const vgs = r?.vision_gate_status;
-          if (vgs != null && vgs !== 'approved') return false;
-          return true;
-        });
-        setAllImages(applyQuarantinePolicy(images));
-        setVehicleMeta(vehicleMeta || null);
-      } catch {
-        setVehicleMeta(null);
-      }
-    };
-    loadImages();
-  }, [vehicleId]);
 
   // Default BaT-only view for BaT-origin vehicles, with a user-toggle to show all sources
   const isBatVehicle = useMemo(() => {

--- a/nuke_frontend/src/pages/vehicle-profile/VehicleBasicInfo.tsx
+++ b/nuke_frontend/src/pages/vehicle-profile/VehicleBasicInfo.tsx
@@ -143,41 +143,23 @@ const VehicleBasicInfo: React.FC<VehicleBasicInfoProps> = ({
           }
         }
 
-        // 2. Check vehicle_images ai_scan_metadata
+        // 2. Check vehicle_images ai_scan_metadata — project just the three VIN
+        // paths instead of whole blobs (122KB -> 3KB for 50 rows, prod-measured).
         const { data: images, error: imagesError } = await supabase
           .from('vehicle_images')
-          .select('ai_scan_metadata')
+          .select(
+            'vin_tag_vin:ai_scan_metadata->vin_tag->>vin, spid_vin:ai_scan_metadata->spid_data->extracted_data->>vin, appraiser_vin:ai_scan_metadata->appraiser->extracted_data->>vin',
+          )
           .eq('vehicle_id', vehicle.id)
           .not('ai_scan_metadata', 'is', null)
           .limit(50);
 
         if (!imagesError && images) {
-          // Look through ai_scan_metadata for VIN
-          for (const img of images) {
-            const metadata = img.ai_scan_metadata;
-            if (!metadata) continue;
-
-            // Check vin_tag
-            if (metadata.vin_tag?.vin) {
-              const vin = String(metadata.vin_tag.vin).trim().toUpperCase();
-              if (isPlausibleVin(vin)) {
-                setVinFromImages(vin);
-                return;
-              }
-            }
-
-            // Check spid_data
-            if (metadata.spid_data?.extracted_data?.vin) {
-              const vin = String(metadata.spid_data.extracted_data.vin).trim().toUpperCase();
-              if (isPlausibleVin(vin)) {
-                setVinFromImages(vin);
-                return;
-              }
-            }
-
-            // Check appraiser analysis
-            if (metadata.appraiser?.extracted_data?.vin) {
-              const vin = String(metadata.appraiser.extracted_data.vin).trim().toUpperCase();
+          // Check vin_tag, then spid_data, then appraiser analysis
+          for (const img of images as Array<Record<string, unknown>>) {
+            for (const raw of [img.vin_tag_vin, img.spid_vin, img.appraiser_vin]) {
+              if (!raw) continue;
+              const vin = String(raw).trim().toUpperCase();
               if (isPlausibleVin(vin)) {
                 setVinFromImages(vin);
                 return;

--- a/nuke_frontend/src/pages/vehicle-profile/VehicleFindingsCard.tsx
+++ b/nuke_frontend/src/pages/vehicle-profile/VehicleFindingsCard.tsx
@@ -50,9 +50,14 @@ const VehicleFindingsCard: React.FC<Props> = ({ vehicleId }) => {
   useEffect(() => {
     let cancelled = false;
     (async () => {
+      // Project only the scalar keys this card reads — whole ai_scan_metadata
+      // rows carry multi-MB deep_analysis blobs (1.57MB -> 0.43MB for a
+      // 3.6k-image vehicle, measured on prod anon 2026-06-11).
       const { data, error } = await supabase
         .from('vehicle_images')
-        .select('ai_scan_metadata')
+        .select(
+          'classifier:ai_scan_metadata->classifier, error:ai_scan_metadata->error, vin:ai_scan_metadata->vin, license_plate:ai_scan_metadata->license_plate, engine:ai_scan_metadata->engine, engine_guess:ai_scan_metadata->engine_guess, engine_badge:ai_scan_metadata->engine_badge, transmission:ai_scan_metadata->transmission, color_visible:ai_scan_metadata->color_visible, interior_trim:ai_scan_metadata->interior_trim, odometer:ai_scan_metadata->odometer, mileage_at_listing:ai_scan_metadata->mileage_at_listing, source:ai_scan_metadata->source, part_number:ai_scan_metadata->part_number, critical:ai_scan_metadata->critical, privacy_concern:ai_scan_metadata->privacy_concern, attribution_concern:ai_scan_metadata->attribution_concern, phase:ai_scan_metadata->phase, scene_class:ai_scan_metadata->scene_class, make_guess:ai_scan_metadata->make_guess, model_guess:ai_scan_metadata->model_guess, year_guess:ai_scan_metadata->year_guess, confidence:ai_scan_metadata->confidence',
+        )
         .eq('vehicle_id', vehicleId)
         .limit(5000);
       if (error) return;
@@ -96,8 +101,8 @@ const VehicleFindingsCard: React.FC<Props> = ({ vehicleId }) => {
       const parts = new Set<string>();
 
       for (const r of rows) {
-        const m = (r as any).ai_scan_metadata as Record<string, any> | null;
-        if (!m) continue;
+        // Arrow projections land the keys flat on the row, same names as before.
+        const m = r as Record<string, any>;
         if (m.classifier === 'claude-opus-4-7-byok') out.classified++;
         if (m.error) out.errors++;
         if (m.vin) vins.add(String(m.vin));

--- a/nuke_frontend/src/pages/vehicle-profile/VehicleMediaKit.tsx
+++ b/nuke_frontend/src/pages/vehicle-profile/VehicleMediaKit.tsx
@@ -109,9 +109,13 @@ const VehicleMediaKit: React.FC<VehicleMediaKitProps> = ({ vehicleId, onImageCli
     (async () => {
       // Pull analyzed rows. We don't expect more than a few hundred per vehicle
       // with byok_deep_analysis present (vehicle 83f6f033 has 23/1366). Cap at 200.
+      // Only two byok_deep_analysis scalars are consumed; whole-blob select was
+      // 0.96MB vs 0.08MB projected (measured on prod anon 2026-06-11).
       const { data, error } = await supabase
         .from('vehicle_images')
-        .select('id, image_url, large_url, taken_at, created_at, ai_scan_metadata')
+        .select(
+          'id, image_url, large_url, taken_at, created_at, scene_type:ai_scan_metadata->byok_deep_analysis->>scene_type, build_phase_guess:ai_scan_metadata->byok_deep_analysis->>build_phase_guess',
+        )
         .eq('vehicle_id', vehicleId)
         .not('ai_scan_metadata->byok_deep_analysis', 'is', null)
         .order('taken_at', { ascending: false, nullsFirst: false })
@@ -124,18 +128,15 @@ const VehicleMediaKit: React.FC<VehicleMediaKitProps> = ({ vehicleId, onImageCli
         return;
       }
 
-      const rows: AnalyzedImage[] = data.map((r: any) => {
-        const ba = r.ai_scan_metadata?.byok_deep_analysis || {};
-        return {
-          id: r.id,
-          image_url: r.image_url,
-          large_url: r.large_url,
-          taken_at: r.taken_at,
-          created_at: r.created_at,
-          scene_type: ba.scene_type ?? null,
-          build_phase_guess: ba.build_phase_guess ?? null,
-        };
-      });
+      const rows: AnalyzedImage[] = data.map((r: any) => ({
+        id: r.id,
+        image_url: r.image_url,
+        large_url: r.large_url,
+        taken_at: r.taken_at,
+        created_at: r.created_at,
+        scene_type: r.scene_type ?? null,
+        build_phase_guess: r.build_phase_guess ?? null,
+      }));
       setAnalyzed(rows);
     })();
     return () => { cancelled = true; };


### PR DESCRIPTION
## Problem

Follow-up to [#280](https://github.com/sss97133/nuke/pull/280) (gallery fetch). Network capture on the signed-out vehicle profile showed three more heavy `vehicle_images` queries from profile widgets, all downloading multi-MB `ai_scan_metadata` jsonb they barely read.

## Measurements (prod anon, probe kit, 2026-06-11, vehicle e08bf694 / 3.6k images)

| Query | Before | After |
|---|---|---|
| ImageGallery legacy `select('*')` unpaginated | **7.36 MB / 7.0s** | deleted |
| VehicleFindingsCard `select('ai_scan_metadata')` limit 5000 | 1.57 MB / 1.0s | 0.43 MB / 0.30s |
| VehicleMediaKit byok whole-blob limit 200 | 0.96 MB / 1.8s | 0.08 MB / 0.38s |
| VehicleBasicInfo VIN scan limit 50 | 0.12 MB | 0.003 MB |
| **Total** | **10.01 MB** | **0.52 MB (−95%)** |

## Changes

- **ImageGallery.tsx** — deleted a vestigial `loadImages` effect that fetched the *entire* image set unpaginated with `select('*')` (this project's PostgREST has no max-rows cap, so it returns all 3.6k rows — 7.4 MB and growing with ingestion), raced `setAllImages` against the real loader, and whose `setVehicleMeta` was a self-assignment no-op. The main fetch effect is the real loader and is untouched.
- **VehicleFindingsCard.tsx** — projects the 23 scalar `ai_scan_metadata` keys the rollup actually reads (`vin:ai_scan_metadata->vin`, …) instead of whole blobs; `deep_analysis` was never rendered here. Aliases land flat under the same key names so the rollup loop logic is unchanged.
- **VehicleMediaKit.tsx** — only `byok_deep_analysis.scene_type` and `.build_phase_guess` are consumed; projects those two.
- **VehicleBasicInfo.tsx** — projects the three VIN paths (`vin_tag.vin`, `spid_data.extracted_data.vin`, `appraiser.extracted_data.vin`) instead of 50 whole blobs.

Arrow-projection technique validated against prod in #280. This PR is independent of #280 (different call sites); both can merge in either order.

## Verification

- tsc `--noEmit` clean, `vite build` clean.
- Ran the branch against prod (vite dev, signed-out, same vehicle): network capture shows **zero** `select=*` and **zero** whole-blob `ai_scan_metadata` requests; all three projected queries return 2xx; profile renders fully (hero, activity heatmap, day document, gallery).
- A `resolveVehicleImages` 500-burst seen during testing **reproduces on pristine origin/main** (verified via stash test) — pre-existing prod-side flakiness under the page's ~30-query burst (the same query curls 200 standalone), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)