### PR TITLE
Repair the real user profile (mobile-first)

### DIFF
--- a/nuke_frontend/src/components/profile/UserDiscoveries.tsx
+++ b/nuke_frontend/src/components/profile/UserDiscoveries.tsx
@@ -228,19 +228,31 @@ const UserDiscoveries: React.FC<UserDiscoveriesProps> = ({ userId, isOwnProfile 
     }
   };
 
-  if (loading && discoveries.length === 0) {
-    return (
-      <div style={{ padding: 'var(--space-6)', textAlign: 'center', color: 'var(--text-muted)', fontSize: '11px' }}>
-        Loading discoveries...
-      </div>
-    );
-  }
+  // No Empty Shells: nothing while loading. For a visitor with no discoveries
+  // at all, render nothing rather than an empty card. The discovery tracker is
+  // an owner workspace tool, so the owner still sees it (to paste/ingest URLs)
+  // even at zero.
+  if (loading && discoveries.length === 0) return null;
+  if (!isOwnProfile && discoveries.length === 0) return null;
+
+  // Only show stat cells that carry a non-zero count — a wall of zeros is an
+  // empty shell. "Found" always shows when there's any discovery activity.
+  const statCells = stats
+    ? ([
+        { label: 'Found', value: stats.total_discoveries },
+        { label: 'Saved', value: stats.saved },
+        { label: 'Watching', value: stats.watching },
+        { label: 'Contacted', value: stats.contacted },
+        { label: 'Purchased', value: stats.purchased },
+        { label: 'Sources', value: stats.sources_used },
+      ].filter(c => c.value > 0))
+    : [];
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
 
-      {/* Stats bar */}
-      {stats && (
+      {/* Stats bar — only non-zero counts */}
+      {statCells.length > 0 && (
         <div style={{
           display: 'flex',
           gap: 'var(--space-4)',
@@ -250,12 +262,9 @@ const UserDiscoveries: React.FC<UserDiscoveriesProps> = ({ userId, isOwnProfile 
           background: 'var(--surface)',
           fontFamily: '"Courier New", Courier, monospace',
         }}>
-          <StatCell label="Found" value={stats.total_discoveries} />
-          <StatCell label="Saved" value={stats.saved} />
-          <StatCell label="Watching" value={stats.watching} />
-          <StatCell label="Contacted" value={stats.contacted} />
-          <StatCell label="Purchased" value={stats.purchased} />
-          <StatCell label="Sources" value={stats.sources_used} />
+          {statCells.map(c => (
+            <StatCell key={c.label} label={c.label} value={c.value} />
+          ))}
         </div>
       )}
 

--- a/nuke_frontend/src/components/profile/VehicleCollection.tsx
+++ b/nuke_frontend/src/components/profile/VehicleCollection.tsx
@@ -18,15 +18,53 @@ const VehicleCollection: React.FC<VehicleCollectionProps> = ({ userId, isOwnProf
   const loadVehicles = async () => {
     try {
       setLoading(true);
-      
-      // Check both user_id and uploaded_by for vehicle ownership
+
+      // OWNED / BUILT only — the C0-correct ownership signal (founder teardown
+      // PROFILE_BUILD_ORDER 2026-06-13, item 8 "the ONE thing I wanna see").
+      //
+      // The old query (user_id ∪ uploaded_by ∪ owner_id) returned ~330 rows —
+      // mostly scraped Craigslist listings and a truck he SOLD (the 1983 K2500
+      // sits here as a `contributor` row). Showing those as "his" is the cardinal
+      // sin he named ("I'm not the verified owner of the K2500 … I sold that
+      // fucking truck"). owner_id is set by ingestion, not ownership.
+      //
+      // Truth comes from two gated rungs:
+      //   1. active owner/co_owner permissions  (vehicle_user_permissions)
+      //   2. approved title verifications        (ownership_verifications)
+      // The `contributor` role is deliberately EXCLUDED — it's the scraped/touched
+      // noise bucket (it even contains the sold K2500), so it fails the
+      // built/owned confidence test.
+      const [permRes, titleRes] = await Promise.all([
+        supabase
+          .from('vehicle_user_permissions')
+          .select('vehicle_id')
+          .eq('user_id', userId)
+          .is('revoked_at', null)
+          .in('role', ['owner', 'co_owner']),
+        supabase
+          .from('ownership_verifications')
+          .select('vehicle_id')
+          .eq('user_id', userId)
+          .eq('status', 'approved'),
+      ]);
+
+      const ownedIds = Array.from(new Set([
+        ...((permRes.data || []).map((r: any) => r.vehicle_id)),
+        ...((titleRes.data || []).map((r: any) => r.vehicle_id)),
+      ].filter(Boolean)));
+
+      if (ownedIds.length === 0) {
+        setVehicles([]);
+        return;
+      }
+
       let query = supabase
         .from('vehicles')
         .select(`
           *,
           vehicle_images(image_url, is_primary)
         `)
-        .or(`user_id.eq.${userId},uploaded_by.eq.${userId},owner_id.eq.${userId}`);
+        .in('id', ownedIds);
 
       // For public profiles, only show public vehicles
       if (!isOwnProfile) {
@@ -34,7 +72,7 @@ const VehicleCollection: React.FC<VehicleCollectionProps> = ({ userId, isOwnProf
       }
 
       const { data, error } = await query
-        .order('created_at', { ascending: false })
+        .order('year', { ascending: false })
         .limit(50);
 
       if (error) throw error;

--- a/nuke_frontend/src/pages/user-profile/UserBriefing.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserBriefing.tsx
@@ -2,32 +2,21 @@
  * UserBriefing — Intelligence headline + stat pills.
  * Mirrors VehicleBriefing pattern.
  *
- * Priority order for headline:
- * 1. Onboarding prompt (own profile, missing data)
- * 2. Active auctions count
- * 3. Collection summary
- * 4. Recent activity summary
- * 5. null (don't render)
+ * Priority order for headline (each fact appears exactly ONCE — tenet 2):
+ * 1. Onboarding prompt (own profile, missing data) — unique to briefing
+ * 2. Active auctions count — unique to briefing
+ * 3. null (don't render)
+ *
+ * Collection summary ("N worked on, N listed") and "member since" headlines
+ * were REMOVED: the header already carries WORKED ON / LISTINGS pills and a
+ * "SINCE {year}" meta line. Restating them here was the redundancy Skylar
+ * flagged (PROFILE_BUILD_ORDER #9). The briefing now adds only what the header
+ * lacks.
  *
  * Self-guarding: returns null if no headline AND no stats.
  */
 import React, { useMemo } from 'react';
 import { useUserProfile } from './UserProfileContext';
-
-// ---------------------------------------------------------------------------
-// Date formatting
-// ---------------------------------------------------------------------------
-
-function formatMemberSince(dateStr: string | null | undefined): string | null {
-  if (!dateStr) return null;
-  try {
-    const d = new Date(dateStr);
-    const months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
-    return `${months[d.getMonth()]} ${d.getFullYear()}`;
-  } catch {
-    return null;
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -45,7 +34,7 @@ const UserBriefing: React.FC = () => {
     // NOT total_vehicles (record-authorship, ~half scraped — number doctrine).
     const vehicles = stats?.vehicles_count ?? 0;
 
-    // 1. Onboarding prompt
+    // 1. Onboarding prompt — unique to the briefing (header has no such call).
     if (isOwnProfile) {
       const missingAvatar = !profile.avatar_url;
       const missingBio = !profile.bio;
@@ -59,7 +48,7 @@ const UserBriefing: React.FC = () => {
       }
     }
 
-    // 2. Active auctions
+    // 2. Active auctions — unique, time-sensitive (header shows totals, not live).
     const activeListings = comprehensiveData?.listings?.filter(
       (l: any) => l.status === 'active' || l.auction_status === 'live'
     ) || [];
@@ -67,18 +56,8 @@ const UserBriefing: React.FC = () => {
       return `${activeListings.length} active auction${activeListings.length > 1 ? 's' : ''} right now`;
     }
 
-    // 3. Collection summary
-    const listed = stats?.total_listings || 0;
-    if (vehicles > 0) {
-      return `${vehicles} vehicle${vehicles > 1 ? 's' : ''} worked on${listed > 0 ? `, ${listed} listed` : ''}`;
-    }
-
-    // 4. Recent activity
-    const since = formatMemberSince(profile.member_since || profile.created_at);
-    if (since) {
-      return `Active member since ${since}`;
-    }
-
+    // Collection-summary and member-since headlines removed: pure restatement of
+    // header WORKED ON / LISTINGS pills and the "SINCE {year}" meta (tenet 2).
     return null;
   }, [profile, isOwnProfile, stats, comprehensiveData]);
 
@@ -89,24 +68,13 @@ const UserBriefing: React.FC = () => {
 
     const items: { label: string; value: string | number }[] = [];
 
-    // Worked-on count, labeled honestly (total_vehicles is record-authorship,
-    // ~half scraped — never a headline; number doctrine).
-    if (stats?.vehicles_count != null && stats.vehicles_count > 0) {
-      items.push({ label: 'WORKED ON', value: stats.vehicles_count });
-    }
-
+    // CONTRIBUTIONS is the ONLY stat the header doesn't already carry, so it's
+    // the only pill the briefing keeps. WORKED ON, MEMBER SINCE (header meta
+    // "SINCE {year}"), and AUCTIONS (header "AUCTIONS WON") were removed —
+    // each was a verbatim restatement of a header fact (tenet 2: every fact
+    // appears exactly once). PROFILE_BUILD_ORDER #9.
     if (stats?.total_contributions != null && stats.total_contributions > 0) {
       items.push({ label: 'CONTRIBUTIONS', value: stats.total_contributions });
-    }
-
-    const memberSince = formatMemberSince(profile.member_since || profile.created_at);
-    if (memberSince) {
-      items.push({ label: 'MEMBER SINCE', value: memberSince });
-    }
-
-    const auctions = stats?.total_auction_wins || 0;
-    if (auctions > 0) {
-      items.push({ label: 'AUCTIONS', value: auctions });
     }
 
     return items;

--- a/nuke_frontend/src/pages/user-profile/UserBriefing.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserBriefing.tsx
@@ -41,9 +41,9 @@ const UserBriefing: React.FC = () => {
   const headline = useMemo(() => {
     if (!profile) return null;
 
-    // Garage-wide vehicle count comes from profile_stats (via stats), NOT the
-    // nonexistent profiles.total_vehicles column (always undefined at runtime).
-    const vehicles = stats?.total_vehicles ?? 0;
+    // Worked-on count (vehicles_count = distinct vehicles with real activity),
+    // NOT total_vehicles (record-authorship, ~half scraped — number doctrine).
+    const vehicles = stats?.vehicles_count ?? 0;
 
     // 1. Onboarding prompt
     if (isOwnProfile) {
@@ -70,7 +70,7 @@ const UserBriefing: React.FC = () => {
     // 3. Collection summary
     const listed = stats?.total_listings || 0;
     if (vehicles > 0) {
-      return `${vehicles} vehicle${vehicles > 1 ? 's' : ''} in collection${listed > 0 ? `, ${listed} listed` : ''}`;
+      return `${vehicles} vehicle${vehicles > 1 ? 's' : ''} worked on${listed > 0 ? `, ${listed} listed` : ''}`;
     }
 
     // 4. Recent activity
@@ -89,10 +89,10 @@ const UserBriefing: React.FC = () => {
 
     const items: { label: string; value: string | number }[] = [];
 
-    // profile_stats-backed counts (profiles.total_vehicles / contribution_count /
-    // reputation_score are not real columns — never read them).
-    if (stats?.total_vehicles != null && stats.total_vehicles > 0) {
-      items.push({ label: 'VEHICLES', value: stats.total_vehicles });
+    // Worked-on count, labeled honestly (total_vehicles is record-authorship,
+    // ~half scraped — never a headline; number doctrine).
+    if (stats?.vehicles_count != null && stats.vehicles_count > 0) {
+      items.push({ label: 'WORKED ON', value: stats.vehicles_count });
     }
 
     if (stats?.total_contributions != null && stats.total_contributions > 0) {

--- a/nuke_frontend/src/pages/user-profile/UserDossierPanel.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserDossierPanel.tsx
@@ -105,17 +105,6 @@ function formatLinkDisplay(url: string): string {
   }
 }
 
-function formatDate(dateStr: string | null | undefined): string | null {
-  if (!dateStr) return null;
-  try {
-    const d = new Date(dateStr);
-    const months = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
-    return `${months[d.getMonth()]} ${d.getFullYear()}`;
-  } catch {
-    return dateStr;
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -131,20 +120,14 @@ const UserDossierPanel: React.FC = () => {
 
   // ── Field groups ──
 
-  // Structured city/state is the trustworthy location; the legacy free-text
-  // `location` field holds stale junk (a bare ZIP fragment of the github
-  // handle) so it's only the last-resort fallback — never shown over city/state.
-  const locationDisplay =
-    [profile.city, profile.state].filter(Boolean).join(', ') ||
-    profile.location ||
-    null;
-
+  // IDENTITY group trimmed to NON-REDUNDANT fields only (founder teardown,
+  // PROFILE_BUILD_ORDER 2026-06-13): the header already carries NAME, USERNAME,
+  // LOCATION and MEMBER SINCE — repeating them here is pure redundancy ("my name
+  // AGAIN, username AGAIN, location AGAIN, member since AGAIN"). EMAIL is the one
+  // identity field NOT in the header, and it's owner-only, so it stays. Everything
+  // else identity-wise is said once, in the header.
   const identityFields: FieldDef[] = [
-    { key: 'full_name', label: 'NAME', value: profile.full_name, editable: true },
     { key: 'email', label: 'EMAIL', value: profile.email, ownerOnly: true },
-    { key: 'username', label: 'USERNAME', value: profile.username, editable: true },
-    { key: 'location', label: 'LOCATION', value: locationDisplay, editable: true },
-    { key: 'member_since', label: 'MEMBER SINCE', value: formatDate(profile.member_since || profile.created_at) },
   ];
 
   const socialFields: FieldDef[] = [

--- a/nuke_frontend/src/pages/user-profile/UserDossierPanel.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserDossierPanel.tsx
@@ -131,11 +131,19 @@ const UserDossierPanel: React.FC = () => {
 
   // ── Field groups ──
 
+  // Structured city/state is the trustworthy location; the legacy free-text
+  // `location` field holds stale junk (a bare ZIP fragment of the github
+  // handle) so it's only the last-resort fallback — never shown over city/state.
+  const locationDisplay =
+    [profile.city, profile.state].filter(Boolean).join(', ') ||
+    profile.location ||
+    null;
+
   const identityFields: FieldDef[] = [
     { key: 'full_name', label: 'NAME', value: profile.full_name, editable: true },
     { key: 'email', label: 'EMAIL', value: profile.email, ownerOnly: true },
     { key: 'username', label: 'USERNAME', value: profile.username, editable: true },
-    { key: 'location', label: 'LOCATION', value: profile.location, editable: true },
+    { key: 'location', label: 'LOCATION', value: locationDisplay, editable: true },
     { key: 'member_since', label: 'MEMBER SINCE', value: formatDate(profile.member_since || profile.created_at) },
   ];
 
@@ -145,11 +153,12 @@ const UserDossierPanel: React.FC = () => {
     { key: 'linkedin_url', label: 'LINKEDIN', value: profile.linkedin_url, isLink: true, editable: true },
   ];
 
-  const accountFields: FieldDef[] = [
-    { key: 'user_type', label: 'TYPE', value: profile.user_type?.toUpperCase() || 'USER' },
-    { key: 'verification_status', label: 'VERIFICATION', value: profile.verification_status?.toUpperCase() || null },
-    { key: 'is_public', label: 'VISIBILITY', value: profile.is_public ? 'PUBLIC' : 'PRIVATE', ownerOnly: true },
-  ];
+  // ACCOUNT group removed from the public record (audit P3/P5):
+  //  - TYPE (USER/ADMIN) is moderation metadata, not part of the record;
+  //    role is conveyed by the sub-header type badge.
+  //  - VERIFICATION read `verification_status`, a column that doesn't exist on
+  //    profiles (always null) — the VERIFIED badge already attests this.
+  //  - VISIBILITY is a settings toggle, not a dossier datum.
 
   // Filter: hide ownerOnly fields for non-owners
   const filterFields = (fields: FieldDef[]) =>
@@ -176,15 +185,13 @@ const UserDossierPanel: React.FC = () => {
 
   const identityGroup = renderGroup('IDENTITY', identityFields);
   const socialGroup = renderGroup('SOCIAL', socialFields);
-  const accountGroup = renderGroup('ACCOUNT', accountFields);
 
-  if (!identityGroup && !socialGroup && !accountGroup) return null;
+  if (!identityGroup && !socialGroup) return null;
 
   return (
     <CollapsibleWidget variant="profile" title="Dossier">
       {identityGroup}
       {socialGroup}
-      {accountGroup}
     </CollapsibleWidget>
   );
 };

--- a/nuke_frontend/src/pages/user-profile/UserHeader.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserHeader.tsx
@@ -22,11 +22,16 @@ const UserHeader: React.FC = () => {
     profile,
     stats,
     isOwnProfile,
-    isAdmin,
-    isExternalIdentity,
+    comprehensiveData,
   } = useUserProfile();
 
-  const [adminMenuOpen, setAdminMenuOpen] = useState(false);
+  // EXPAND-DON'T-NAVIGATE (founder law: "everything is a button, everything
+  // expands"). The header stats are doors: clicking WORKED ON / LISTINGS /
+  // COMMENTS reveals its detail inline, right under the header, and clicking
+  // again (or the ✕) closes it — reversible depth (C10), no page jump.
+  const [openDoor, setOpenDoor] = useState<null | 'worked' | 'listings' | 'comments'>(null);
+  const toggleDoor = (door: 'worked' | 'listings' | 'comments') =>
+    setOpenDoor((cur) => (cur === door ? null : door));
 
   if (!profile) return null;
 
@@ -102,26 +107,43 @@ const UserHeader: React.FC = () => {
         </div>
       </div>
 
-      {/* Center: Stat pills — only show a count when it's real and non-zero
-          (No Empty Shells). Each pill is a labeled, honest figure. */}
+      {/* Center: Stat DOORS — each is a button that expands its detail inline
+          (founder law). Only render a count when it's real and non-zero
+          (No Empty Shells). The count and its drilled list always come from the
+          same source, so they can't disagree (C0). */}
       <div className="up-header__center">
         {workedOnVehicles != null && workedOnVehicles > 0 && (
-          <span className="up-stat-pill">
+          <button
+            type="button"
+            className={`up-stat-pill up-stat-pill--door${openDoor === 'worked' ? ' up-stat-pill--open' : ''}`}
+            aria-expanded={openDoor === 'worked'}
+            onClick={() => toggleDoor('worked')}
+          >
             <span className="up-stat-pill__label">WORKED ON</span>
             {workedOnVehicles}
-          </span>
+          </button>
         )}
         {totalListings > 0 && (
-          <span className="up-stat-pill">
+          <button
+            type="button"
+            className={`up-stat-pill up-stat-pill--door${openDoor === 'listings' ? ' up-stat-pill--open' : ''}`}
+            aria-expanded={openDoor === 'listings'}
+            onClick={() => toggleDoor('listings')}
+          >
             <span className="up-stat-pill__label">LISTINGS</span>
             {totalListings}
-          </span>
+          </button>
         )}
         {totalComments > 0 && (
-          <span className="up-stat-pill">
+          <button
+            type="button"
+            className={`up-stat-pill up-stat-pill--door${openDoor === 'comments' ? ' up-stat-pill--open' : ''}`}
+            aria-expanded={openDoor === 'comments'}
+            onClick={() => toggleDoor('comments')}
+          >
             <span className="up-stat-pill__label">COMMENTS</span>
             {totalComments}
-          </span>
+          </button>
         )}
         {auctionsWon > 0 && (
           <span className="up-stat-pill">
@@ -138,58 +160,118 @@ const UserHeader: React.FC = () => {
             EDIT PROFILE
           </button>
         )}
-        {isExternalIdentity && !isOwnProfile && (
-          <button className="up-btn" onClick={() => console.log('claim')}>
-            CLAIM
-          </button>
-        )}
-        {isAdmin && (
-          <div style={{ position: 'relative' }}>
-            <button
-              className="up-btn"
-              onClick={() => setAdminMenuOpen((v) => !v)}
-            >
-              ADMIN
-            </button>
-            {adminMenuOpen && (
-              <div
-                style={{
-                  position: 'absolute',
-                  top: '100%',
-                  right: 0,
-                  background: '#fff',
-                  border: '1px solid #1a1a1a',
-                  zIndex: 1010,
-                  minWidth: 120,
-                  fontFamily: 'Arial, sans-serif',
-                  fontSize: '8px',
-                }}
-              >
-                <button
-                  className="up-btn"
-                  style={{ width: '100%', border: 'none', borderBottom: '1px solid #ddd' }}
-                  onClick={() => {
-                    console.log('admin:inspect');
-                    setAdminMenuOpen(false);
-                  }}
-                >
-                  INSPECT
-                </button>
-                <button
-                  className="up-btn"
-                  style={{ width: '100%', border: 'none' }}
-                  onClick={() => {
-                    console.log('admin:flag');
-                    setAdminMenuOpen(false);
-                  }}
-                >
-                  FLAG USER
-                </button>
-              </div>
-            )}
-          </div>
-        )}
+        {/* REMOVED (founder teardown PROFILE_BUILD_ORDER 2026-06-13 + audit P5):
+            - CLAIM button: onClick was console.log('claim') — a dead control.
+            - ADMIN menu (INSPECT / FLAG USER): both console.log only (dead), and
+              moderation tooling does not belong on the public record ("some
+              random stupid shit admin"). */}
       </div>
+
+      {/* Inline DOOR detail — expands under the bar for the open stat (C10
+          reversible: ✕ or re-click the pill to close). */}
+      {openDoor && (
+        <StatDoorPanel
+          door={openDoor}
+          workedOn={workedOnVehicles}
+          listings={comprehensiveData?.listings || []}
+          comments={comprehensiveData?.comments || []}
+          onClose={() => setOpenDoor(null)}
+        />
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Stat door detail panel — renders the real list behind a header stat.
+// Count and list share a source so they can't disagree (C0). No fabrication:
+// WORKED ON has no client-loaded list, so it links to the owned/built garage
+// below rather than inventing 88 rows.
+// ---------------------------------------------------------------------------
+
+const vehLabel = (v: any): string =>
+  v ? [v.year, v.make, v.model].filter(Boolean).join(' ') || 'Vehicle' : 'Vehicle';
+
+const StatDoorPanel: React.FC<{
+  door: 'worked' | 'listings' | 'comments';
+  workedOn: number | null;
+  listings: any[];
+  comments: any[];
+  onClose: () => void;
+}> = ({ door, workedOn, listings, comments, onClose }) => {
+  const title =
+    door === 'worked' ? `WORKED ON · ${workedOn ?? 0}`
+      : door === 'listings' ? `LISTINGS · ${listings.length}`
+        : `COMMENTS · ${comments.length}`;
+
+  return (
+    <div className="up-stat-door" role="region" aria-label={title}>
+      <div className="up-stat-door__bar">
+        <span className="up-stat-door__title">{title}</span>
+        <button type="button" className="up-btn up-stat-door__close" onClick={onClose}>
+          ✕ CLOSE
+        </button>
+      </div>
+
+      {door === 'worked' && (
+        <div className="up-stat-door__body">
+          {/* The 88 worked-on list is not loaded client-side; per C0 we don't
+              fabricate it. The door points at the built/owned garage rendered
+              below (the vehicles he actually owns), the trustworthy subset. */}
+          <a href="#vehicle-collection" className="up-stat-door__cta" onClick={onClose}>
+            View the {workedOn ?? 0} vehicles worked on →
+          </a>
+        </div>
+      )}
+
+      {door === 'listings' && (
+        <div className="up-stat-door__body">
+          {listings.length === 0 ? (
+            <div className="up-stat-door__empty">No listings.</div>
+          ) : (
+            listings.slice(0, 50).map((l: any, i: number) => (
+              <a
+                key={l.id || i}
+                href={l.vehicle?.id ? `/vehicle/${l.vehicle.id}` : (l.source_url || '#')}
+                className="up-stat-door__row"
+              >
+                <span className="up-stat-door__row-main">{vehLabel(l.vehicle)}</span>
+                <span className="up-stat-door__row-meta">
+                  {l.event_status ? String(l.event_status).toUpperCase() : 'LISTED'}
+                  {l.sale_price ? ` · $${Number(l.sale_price).toLocaleString()}` : ''}
+                </span>
+              </a>
+            ))
+          )}
+        </div>
+      )}
+
+      {door === 'comments' && (
+        <div className="up-stat-door__body">
+          {comments.length === 0 ? (
+            <div className="up-stat-door__empty">No comments.</div>
+          ) : (
+            comments.slice(0, 50).map((c: any, i: number) => {
+              const veh = c.auction?.vehicle;
+              const when = c.posted_at ? new Date(c.posted_at).toLocaleDateString() : '';
+              return (
+                <a
+                  key={c.id || i}
+                  href={veh?.id ? `/vehicle/${veh.id}` : '#'}
+                  className="up-stat-door__row"
+                >
+                  <span className="up-stat-door__row-main">
+                    {c.comment_text || '(comment)'}
+                  </span>
+                  <span className="up-stat-door__row-meta">
+                    {[vehLabel(veh), when].filter(Boolean).join(' · ')}
+                  </span>
+                </a>
+              );
+            })
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/nuke_frontend/src/pages/user-profile/UserHeader.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserHeader.tsx
@@ -40,15 +40,20 @@ const UserHeader: React.FC = () => {
   const memberSince = profile.member_since || profile.created_at;
   const memberYear = memberSince ? new Date(memberSince).getFullYear() : null;
 
-  // Stats — profile_stats (refreshed by recompute_profile_stats) is the source
-  // of truth for garage-wide counts; listings/comments/bids are computed live
-  // by profileStatsService. No fallback to BaT seller events or the dead
-  // profiles.total_* columns (all 0 in prod).
-  const totalVehicles = stats?.total_vehicles ?? 0;
+  // Stats — every headline carries an honest denominator (number doctrine).
+  // VEHICLES uses vehicles_count = "worked on" (distinct vehicles with timeline
+  // activity), NOT total_vehicles (record-authorship over a 4-col union, ~half
+  // scraped Craigslist listings — never a public headline). Labeled WORKED ON.
+  const workedOnVehicles = stats?.vehicles_count ?? null;
   const totalListings = stats?.total_listings ?? 0;
   const totalComments = stats?.total_comments ?? 0;
-  const totalBids = stats?.total_bids ?? 0;
-  const totalImages = stats?.total_images ?? 0;
+  // BIDS is structurally blind (the bids table doesn't exist; only completed
+  // purchases materialize) — a "0" asserts an inactivity the data can't
+  // support, so it's suppressed. AUCTIONS WON is the real, observable figure.
+  const auctionsWon = stats?.total_auction_wins ?? 0;
+  // IMAGES is intentionally NOT shown here: profile_stats.total_images is a
+  // stale cron snapshot (23,376 vs 22,728 live) and RECENT PHOTOS already shows
+  // the live count — two image totals on one page is a contradiction.
 
   const handleEditProfile = () => {
     window.dispatchEvent(new CustomEvent('up:open-settings'));
@@ -97,28 +102,31 @@ const UserHeader: React.FC = () => {
         </div>
       </div>
 
-      {/* Center: Stat pills */}
+      {/* Center: Stat pills — only show a count when it's real and non-zero
+          (No Empty Shells). Each pill is a labeled, honest figure. */}
       <div className="up-header__center">
-        <span className="up-stat-pill">
-          <span className="up-stat-pill__label">VEHICLES</span>
-          {totalVehicles}
-        </span>
-        <span className="up-stat-pill">
-          <span className="up-stat-pill__label">LISTINGS</span>
-          {totalListings}
-        </span>
-        <span className="up-stat-pill">
-          <span className="up-stat-pill__label">COMMENTS</span>
-          {totalComments}
-        </span>
-        <span className="up-stat-pill">
-          <span className="up-stat-pill__label">BIDS</span>
-          {totalBids}
-        </span>
-        {totalImages > 0 && (
+        {workedOnVehicles != null && workedOnVehicles > 0 && (
           <span className="up-stat-pill">
-            <span className="up-stat-pill__label">IMAGES</span>
-            {totalImages}
+            <span className="up-stat-pill__label">WORKED ON</span>
+            {workedOnVehicles}
+          </span>
+        )}
+        {totalListings > 0 && (
+          <span className="up-stat-pill">
+            <span className="up-stat-pill__label">LISTINGS</span>
+            {totalListings}
+          </span>
+        )}
+        {totalComments > 0 && (
+          <span className="up-stat-pill">
+            <span className="up-stat-pill__label">COMMENTS</span>
+            {totalComments}
+          </span>
+        )}
+        {auctionsWon > 0 && (
+          <span className="up-stat-pill">
+            <span className="up-stat-pill__label">AUCTIONS WON</span>
+            {auctionsWon}
           </span>
         )}
       </div>

--- a/nuke_frontend/src/pages/user-profile/UserRecentPhotos.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserRecentPhotos.tsx
@@ -4,17 +4,31 @@
  * Replaces PublicImageGallery on the profile (that component is shared with
  * Profile.tsx / Profile.legacy.tsx, so it is left untouched for other consumers).
  *
- * Data: vehicle_images by user_id, newest-first.
- *  - Owner path includes NULL-vehicle (inbox) images.
+ * Data: vehicle_images by user_id, ordered by REAL recency — taken_at DESC.
+ *  - Owner path includes NULL-vehicle (inbox) images; left-joins the vehicle
+ *    so the lightbox rail can name it (NULL → UNFILED, never fabricated).
  *  - Visitor path only vehicle-attached images on public vehicles (RLS-aligned).
+ *
+ * Why taken_at, not created_at (audit P2, USER_PROFILE_AUDIT.md:30-31): the
+ * grid keyed on created_at surfaced an 8-year-old bulk import (capture_relay_ios
+ * Aug-2018 photos imported 2026-06-14) at the top as "recent". taken_at is the
+ * truth of when the WORK happened — same bug class as the TODAY card.
  *
  * Header shows EXACT totals via count/head queries (no top-K pretence):
  *   "20,978 IMAGES · 154 THIS WEEK"
  *
+ * Every thumb is a button (tenet 1): click opens the in-place evidence
+ * lightbox (?photo=<id>, ESC / click-out closes, ←/→ navigate) — the same
+ * evidence-rail mechanics as the vehicle profile's VehiclePhotoLightbox, but
+ * indexed over THESE grid rows (that component is hard-bound to a single
+ * vehicle's VehicleProfileContext, so it can't be reused across his 131
+ * vehicles). No parallel data system: the lightbox reads the rows the grid
+ * already loaded.
+ *
  * Self-guarding: returns null while loading and at 0 images (No Empty Shells).
  */
-import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import { supabase } from '../../lib/supabase';
 import { optimizeImageUrl } from '../../lib/imageOptimizer';
 import { CollapsibleWidget } from '../../components/ui/CollapsibleWidget';
@@ -22,6 +36,13 @@ import { CollapsibleWidget } from '../../components/ui/CollapsibleWidget';
 interface UserRecentPhotosProps {
   userId: string;
   isOwnProfile: boolean;
+}
+
+interface VehicleRef {
+  id: string;
+  year: number | null;
+  make: string | null;
+  model: string | null;
 }
 
 interface PhotoRow {
@@ -33,6 +54,7 @@ interface PhotoRow {
   source_url: string | null;
   taken_at: string | null;
   created_at: string | null;
+  vehicle?: VehicleRef | VehicleRef[] | null;
 }
 
 const GRID_LIMIT = 60;
@@ -84,6 +106,259 @@ const journalDay = (img: PhotoRow): string | null => {
 };
 
 const GRID_COLUMNS = `id, image_url, thumbnail_url, storage_path, source, source_url, taken_at, created_at`;
+const VEHICLE_FIELDS = `id, year, make, model`;
+
+/** First vehicle row from a PostgREST embed (object or array shape). */
+const vehicleOf = (img: PhotoRow): VehicleRef | null => {
+  const v = img.vehicle;
+  if (!v) return null;
+  return (Array.isArray(v) ? v[0] : v) || null;
+};
+
+const vehicleLabel = (img: PhotoRow): string => {
+  const v = vehicleOf(img);
+  if (!v) return 'UNFILED';
+  const parts = [v.year, v.make, v.model].filter(Boolean).join(' ').trim();
+  return parts ? parts.toUpperCase() : 'UNFILED';
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  user_upload: 'OWNER UPLOAD',
+  owner_upload: 'OWNER UPLOAD',
+  capture_relay_ios: 'OWNER CAPTURE (iOS)',
+  photo_auto_sync: 'OWNER SYNC',
+  iphoto: 'OWNER ARCHIVE',
+  ssd_blast: 'OWNER ARCHIVE',
+  hd_archive: 'OWNER ARCHIVE',
+  'drop-folder': 'OWNER ARCHIVE',
+  image_intake: 'OWNER ARCHIVE',
+  dropbox_import: 'OWNER ARCHIVE',
+  daily_receipt: 'DAILY RECEIPT',
+};
+
+const sourceLabelOf = (src: string | null): string | null =>
+  src ? (SOURCE_LABELS[src] || src.toUpperCase().replace(/_/g, ' ')) : null;
+
+/** Render-endpoint URL at a target width (transcodes HEIC; never a raw multi-MB original). */
+const stageUrl = (url: string, width: number): string =>
+  optimizeImageUrl(url, width >= 1000 ? 'large' : 'medium') || url;
+
+// ── Analysis record, loaded on demand for the open frame ──
+interface ImageAnalysis {
+  status: string | null;          // ai_processing_status
+  componentCount: number | null;  // ai_component_count
+  model: string | null;           // vision_model_version
+  scannedAt: string | null;       // vision_analyzed_at | ai_last_scanned
+  imageType: string | null;       // classification.image_type
+  classConfidence: number | null; // classification.confidence
+  description: string | null;     // classification.description
+  caption: string | null;
+  medium: string | null;
+  atoms: Array<[string, string]>; // byok_deep_analysis surfaced keys
+}
+
+const analysisCache = new Map<string, ImageAnalysis>();
+
+const railLabel: React.CSSProperties = {
+  fontFamily: 'Arial, sans-serif', fontSize: 8, fontWeight: 700,
+  letterSpacing: '0.12em', color: '#888',
+};
+const railValue: React.CSSProperties = {
+  fontFamily: "'Courier New', Courier, monospace", fontSize: 10, color: '#eee', lineHeight: 1.5,
+};
+const railLink: React.CSSProperties = {
+  ...railValue, textDecoration: 'none', border: '1px solid #444',
+  padding: '3px 6px', display: 'inline-block', cursor: 'pointer',
+};
+
+/**
+ * RecentPhotoLightbox — in-place evidence viewer for the user-profile photo
+ * grid. Same evidence-rail mechanics as the vehicle profile's
+ * VehiclePhotoLightbox (taken · source · vehicle · analysis · original), but
+ * indexed over THESE grid rows so it works across his 131 vehicles + unfiled
+ * inbox (the vehicle lightbox is hard-bound to one VehicleProfileContext).
+ *
+ * Two paths per image (founder requirement):
+ *   → VEHICLE:  /vehicle/:id when attributed.
+ *   → ANALYSIS: attributed → /vehicle/:id?photo=<id> (full analysis lightbox);
+ *               unfiled (owner) → /photo-library (review/assign). Real
+ *               classification/atoms shown inline; honest "NOT ANALYZED YET"
+ *               when the record carries none (C0 — never fabricated).
+ */
+const RecentPhotoLightbox: React.FC<{
+  rows: PhotoRow[];
+  index: number;
+  isOwnProfile: boolean;
+  onClose: () => void;
+  onStep: (dir: -1 | 1) => void;
+}> = ({ rows, index, isOwnProfile, onClose, onStep }) => {
+  const img = rows[index];
+  const [analysis, setAnalysis] = useState<ImageAnalysis | null>(null);
+
+  // Per-frame analysis (one cheap single-row query, cached).
+  useEffect(() => {
+    if (!img) return;
+    const cached = analysisCache.get(img.id);
+    if (cached) { setAnalysis(cached); return; }
+    let cancelled = false;
+    setAnalysis(null);
+    supabase
+      .from('vehicle_images')
+      .select('ai_processing_status, ai_component_count, vision_model_version, vision_analyzed_at, ai_last_scanned, ai_scan_metadata, caption, image_medium')
+      .eq('id', img.id)
+      .maybeSingle()
+      .then(({ data }: { data: any | null }) => {
+        if (cancelled || !data) return;
+        const meta = data.ai_scan_metadata || {};
+        const cls = meta.classification || {};
+        const byok = meta.byok_deep_analysis || {};
+        const atoms: Array<[string, string]> = [];
+        for (const k of ['scene_type', 'build_phase_guess', 'work_activity', 'subject', 'notable_details']) {
+          const val = byok[k];
+          if (typeof val === 'string' && val.trim()) atoms.push([k.replace(/_/g, ' ').toUpperCase(), val.trim()]);
+        }
+        const rec: ImageAnalysis = {
+          status: data.ai_processing_status || null,
+          componentCount: typeof data.ai_component_count === 'number' ? data.ai_component_count : null,
+          model: data.vision_model_version || null,
+          scannedAt: data.vision_analyzed_at || data.ai_last_scanned || null,
+          imageType: typeof cls.image_type === 'string' ? cls.image_type : null,
+          classConfidence: typeof cls.confidence === 'number' ? cls.confidence : null,
+          description: typeof cls.description === 'string' ? cls.description : null,
+          caption: data.caption || null,
+          medium: data.image_medium || null,
+          atoms,
+        };
+        analysisCache.set(img.id, rec);
+        setAnalysis(rec);
+      });
+    return () => { cancelled = true; };
+  }, [img?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!img) return null;
+  const url = img.image_url || img.thumbnail_url;
+  if (!url) return null;
+
+  const vehicle = vehicleOf(img);
+  const takenLabel = img.taken_at
+    ? new Date(img.taken_at).toLocaleString([], { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+    : null;
+  const srcLabel = sourceLabelOf(img.source);
+
+  // ── The two paths ──
+  const vehiclePath = vehicle ? `/vehicle/${vehicle.id}` : null;
+  const analysisPath = vehicle
+    ? `/vehicle/${vehicle.id}?photo=${img.id}`   // full analysis lightbox on the vehicle
+    : (isOwnProfile ? '/photo-library' : null);  // owner reviews/assigns the unfiled image
+
+  // Has the image genuinely been analyzed? completed+0 atoms+rate-limited
+  // classification = not really. Be honest (C0).
+  const hasRealAtoms = !!(analysis && analysis.atoms.length > 0);
+  const hasUsefulClass = !!(
+    analysis && analysis.imageType && analysis.imageType !== 'other'
+    && (analysis.classConfidence ?? 0) >= 0.4
+  );
+  const analyzed = hasRealAtoms || hasUsefulClass;
+
+  return createPortal(
+    <div
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      role="dialog" aria-modal="true" aria-label="Photo viewer"
+      style={{ position: 'fixed', inset: 0, zIndex: 10050, background: 'rgba(0,0,0,0.92)', display: 'flex', flexDirection: 'row' }}
+    >
+      {/* Stage */}
+      <div style={{ position: 'relative', flex: 1, minWidth: 0 }} onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+        <img
+          key={img.id}
+          src={stageUrl(url, 1260)}
+          alt=""
+          style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'contain', pointerEvents: 'none' }}
+        />
+        {index > 0 && (
+          <button onClick={() => onStep(-1)} aria-label="Previous photo"
+            style={{ position: 'absolute', left: 10, top: '50%', transform: 'translateY(-50%)', width: 36, height: 36, background: 'rgba(0,0,0,0.55)', color: '#fff', border: '2px solid rgba(255,255,255,0.2)', fontSize: 14, fontWeight: 700, cursor: 'pointer' }}>{'<'}</button>
+        )}
+        {index < rows.length - 1 && (
+          <button onClick={() => onStep(1)} aria-label="Next photo"
+            style={{ position: 'absolute', right: 10, top: '50%', transform: 'translateY(-50%)', width: 36, height: 36, background: 'rgba(0,0,0,0.55)', color: '#fff', border: '2px solid rgba(255,255,255,0.2)', fontSize: 14, fontWeight: 700, cursor: 'pointer' }}>{'>'}</button>
+        )}
+        <div style={{ fontFamily: "'Courier New', Courier, monospace", position: 'absolute', top: 10, left: 10, fontSize: 9, color: '#bbb', background: 'rgba(0,0,0,0.55)', padding: '2px 6px' }}>
+          {index + 1} / {rows.length}
+        </div>
+        <button onClick={onClose} aria-label="Close photo viewer"
+          style={{ position: 'absolute', top: 10, right: 10, width: 30, height: 30, background: 'rgba(0,0,0,0.55)', color: '#fff', border: '2px solid rgba(255,255,255,0.2)', fontSize: 13, fontWeight: 700, cursor: 'pointer' }}>✕</button>
+      </div>
+
+      {/* Evidence rail */}
+      <div style={{ width: 240, flexShrink: 0, borderLeft: '2px solid #333', background: '#111', padding: '14px 12px', overflowY: 'auto', display: window.innerWidth < 700 ? 'none' : 'block' }}>
+        {takenLabel && (
+          <div style={{ marginBottom: 10 }}>
+            <div style={railLabel}>TAKEN</div>
+            <div style={railValue}>{takenLabel}</div>
+          </div>
+        )}
+        {srcLabel && (
+          <div style={{ marginBottom: 10 }}>
+            <div style={railLabel}>SOURCE</div>
+            <div style={railValue}>{srcLabel}</div>
+          </div>
+        )}
+        {/* PATH 1 → the vehicle / asset */}
+        <div style={{ marginBottom: 10 }}>
+          <div style={railLabel}>VEHICLE</div>
+          {vehiclePath ? (
+            <a href={vehiclePath} style={{ ...railValue, color: '#9cf', borderBottom: '1px solid #456', textDecoration: 'none' }}>
+              {vehicleLabel(img)} →
+            </a>
+          ) : (
+            <div style={railValue}>UNFILED — not yet on a vehicle</div>
+          )}
+        </div>
+        {/* PATH 2 → the analysis of this image */}
+        <div style={{ marginBottom: 10 }}>
+          <div style={railLabel}>ANALYSIS</div>
+          {analysis === null ? (
+            <div style={{ ...railValue, color: '#777' }}>loading…</div>
+          ) : analyzed ? (
+            <>
+              {analysis.imageType && analysis.imageType !== 'other' && (
+                <div style={railValue}>
+                  {analysis.imageType.toUpperCase().replace(/_/g, ' ')}
+                  {analysis.classConfidence != null ? ` · ${Math.round(analysis.classConfidence * 100)}%` : ''}
+                </div>
+              )}
+              {analysis.atoms.map(([k, val]) => (
+                <div key={k} style={{ marginTop: 4 }}>
+                  <div style={{ ...railLabel, fontSize: 7, color: '#666' }}>{k}</div>
+                  <div style={{ ...railValue, fontSize: 9 }}>{val}</div>
+                </div>
+              ))}
+              {analysis.componentCount ? (
+                <div style={{ ...railValue, fontSize: 9, color: '#aaa', marginTop: 4 }}>{analysis.componentCount} COMPONENTS</div>
+              ) : null}
+            </>
+          ) : (
+            <div style={{ ...railValue, color: '#c96' }}>NOT ANALYZED YET</div>
+          )}
+          {analysisPath && (
+            <div style={{ marginTop: 6 }}>
+              <a href={analysisPath} style={railLink}>
+                {analyzed ? 'OPEN ANALYSIS ↗' : (vehicle ? 'OPEN ANALYSIS ↗' : 'REVIEW / ASSIGN ↗')}
+              </a>
+            </div>
+          )}
+        </div>
+        {/* PATH 3 → the original storage object */}
+        <div style={{ marginTop: 14 }}>
+          <a href={url} target="_blank" rel="noopener noreferrer" style={{ ...railLabel, color: '#bbb', textDecoration: 'none', border: '1px solid #444', padding: '3px 6px', display: 'inline-block' }}>
+            ORIGINAL ↗
+          </a>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+};
 
 const UserRecentPhotos: React.FC<UserRecentPhotosProps> = ({ userId, isOwnProfile }) => {
   const [images, setImages] = useState<PhotoRow[]>([]);
@@ -96,74 +371,195 @@ const UserRecentPhotos: React.FC<UserRecentPhotosProps> = ({ userId, isOwnProfil
     if (!userId) return;
     let cancelled = false;
 
-    const load = async () => {
-      try {
-        const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+    // One round-trip. Returns the rows + counts, or throws the PostgREST error.
+    const fetchOnce = async () => {
+      const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
 
-        // Visitor path inner-joins vehicles and keeps only public ones;
-        // owner path has no vehicle filter so NULL-vehicle inbox images count.
+      // Visitor path inner-joins vehicles and keeps only public ones; owner
+      // path LEFT-joins so NULL-vehicle inbox images still count and the
+      // lightbox rail can name the vehicle (or UNFILED) without re-querying.
+      const countSelect = isOwnProfile
+        ? 'id'
+        : 'id, vehicle:vehicles!vehicle_images_vehicle_id_fkey!inner(id)';
+      const gridSelect = isOwnProfile
+        ? `${GRID_COLUMNS}, vehicle:vehicles!vehicle_images_vehicle_id_fkey(${VEHICLE_FIELDS})`
+        : `${GRID_COLUMNS}, vehicle:vehicles!vehicle_images_vehicle_id_fkey!inner(${VEHICLE_FIELDS})`;
+
+      const withVisibility = <T,>(query: T): T => {
+        if (isOwnProfile) return query;
+        return (query as any).eq('vehicle.is_public', true);
+      };
+
+      // Load-bearing pair: the grid (the actual photos, taken_at DESC) and the
+      // exact total for the badge. These two must succeed for the section to
+      // render. The "THIS WEEK" count is intentionally NOT here — it is an
+      // expensive taken_at-range count on a 1M-row table that can exceed the
+      // 15s anon statement timeout (→ 500); it is fetched best-effort below so
+      // its failure degrades the badge, never the whole section.
+      const [totalRes, gridRes] = await Promise.all([
+        withVisibility(
+          supabase
+            .from('vehicle_images')
+            .select(countSelect, { count: 'exact', head: true })
+            .eq('user_id', userId)
+            .not('is_duplicate', 'is', true)
+        ),
+        withVisibility(
+          supabase
+            .from('vehicle_images')
+            .select(gridSelect)
+            .eq('user_id', userId)
+            .not('is_duplicate', 'is', true)
+            .order('taken_at', { ascending: false, nullsFirst: false })
+            .limit(GRID_LIMIT)
+        ),
+      ]);
+
+      if (totalRes.error) throw totalRes.error;
+      if (gridRes.error) throw gridRes.error;
+
+      return {
+        rows: ((gridRes.data || []) as unknown as PhotoRow[]).filter(passesSourceGuards),
+        total: totalRes.count || 0,
+        weekAgo,
+      };
+    };
+
+    // Best-effort "THIS WEEK" — real work shot this week (taken_at, not import
+    // time). Never throws into the main path; on timeout/error the badge just
+    // omits it (weekCount stays 0 → hidden).
+    const fetchWeek = async (weekAgo: string): Promise<number> => {
+      try {
         const countSelect = isOwnProfile
           ? 'id'
           : 'id, vehicle:vehicles!vehicle_images_vehicle_id_fkey!inner(id)';
-        const gridSelect = isOwnProfile
-          ? GRID_COLUMNS
-          : `${GRID_COLUMNS}, vehicle:vehicles!vehicle_images_vehicle_id_fkey!inner(id)`;
+        let q = supabase
+          .from('vehicle_images')
+          .select(countSelect, { count: 'exact', head: true })
+          .eq('user_id', userId)
+          .not('is_duplicate', 'is', true)
+          .gte('taken_at', weekAgo);
+        if (!isOwnProfile) q = (q as any).eq('vehicle.is_public', true);
+        const { count, error } = await q;
+        if (error) return 0;
+        return count || 0;
+      } catch {
+        return 0;
+      }
+    };
 
-        const withVisibility = <T,>(query: T): T => {
-          if (isOwnProfile) return query;
-          return (query as any).eq('vehicle.is_public', true);
-        };
+    // A real PostgREST error carries a message/code. On a fresh page load the
+    // GoTrue session is still resolving, and the auth event that lands
+    // mid-flight tears down the in-flight request — it rejects with an EMPTY
+    // error (no message, no code). That is a transient abort, not a failure.
+    const isTransientAbort = (e: unknown): boolean => {
+      const err = e as { message?: string; code?: string } | null;
+      return !err?.message && !err?.code;
+    };
 
-        const [totalRes, weekRes, gridRes] = await Promise.all([
-          withVisibility(
-            supabase
-              .from('vehicle_images')
-              .select(countSelect, { count: 'exact', head: true })
-              .eq('user_id', userId)
-          ),
-          withVisibility(
-            supabase
-              .from('vehicle_images')
-              .select(countSelect, { count: 'exact', head: true })
-              .eq('user_id', userId)
-              .gte('created_at', weekAgo)
-          ),
-          withVisibility(
-            supabase
-              .from('vehicle_images')
-              .select(gridSelect)
-              .eq('user_id', userId)
-              .order('created_at', { ascending: false })
-              .limit(GRID_LIMIT)
-          ),
-        ]);
-
+    const load = async () => {
+      try {
+        // Gate on the auth bootstrap: await the session so no auth event fires
+        // mid-query and aborts it. Without this the three parallel queries are
+        // torn down on first load and the section renders falsely empty.
+        await supabase.auth.getSession();
         if (cancelled) return;
 
-        if (totalRes.error) throw totalRes.error;
-        if (weekRes.error) throw weekRes.error;
-        if (gridRes.error) throw gridRes.error;
-
-        const rows = ((gridRes.data || []) as unknown as PhotoRow[]).filter(passesSourceGuards);
-
-        setTotalCount(totalRes.count || 0);
-        setWeekCount(weekRes.count || 0);
-        setImages(rows);
-      } catch (error) {
-        console.error('[UserRecentPhotos] load failed:', error);
-        if (!cancelled) {
-          setImages([]);
-          setTotalCount(0);
-          setWeekCount(0);
+        // Retry through the settle window on a transient abort; surface a real
+        // PostgREST error immediately (cleared honestly below — C0, no shell).
+        const delays = [0, 150, 400];
+        let result: Awaited<ReturnType<typeof fetchOnce>> | null = null;
+        let lastErr: unknown = null;
+        for (const d of delays) {
+          if (cancelled) return;
+          if (d) await new Promise(r => setTimeout(r, d));
+          if (cancelled) return;
+          try {
+            result = await fetchOnce();
+            break;
+          } catch (error) {
+            lastErr = error;
+            if (!isTransientAbort(error)) throw error;
+          }
         }
-      } finally {
-        if (!cancelled) setLoading(false);
+        if (cancelled) return;
+        if (!result) throw lastErr;
+
+        setTotalCount(result.total);
+        setImages(result.rows);
+        setLoading(false);
+
+        // Badge enrichment — best-effort, never blocks or clears the section.
+        const week = await fetchWeek(result.weekAgo);
+        if (!cancelled && week > 0) setWeekCount(week);
+      } catch (error) {
+        if (cancelled) return;
+        console.error('[UserRecentPhotos] load failed:', error);
+        setImages([]);
+        setTotalCount(0);
+        setWeekCount(0);
+        setLoading(false);
       }
     };
 
     load();
     return () => { cancelled = true; };
   }, [userId, isOwnProfile]);
+
+  // ── In-place evidence lightbox (tenet 1: every thumb is a button) ──
+  // Renderable rows only — a thumb that failed to render or has no URL is not
+  // a valid lightbox target, so prev/next never lands on a dead frame.
+  const viewable = useMemo(
+    () => images.filter(img => (img.thumbnail_url || img.image_url) && !failedIds.has(img.id)),
+    [images, failedIds],
+  );
+
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  const setPhotoParam = useCallback((id: string | null) => {
+    const url = new URL(window.location.href);
+    if (id) url.searchParams.set('photo', id);
+    else url.searchParams.delete('photo');
+    window.history.replaceState(window.history.state, '', url.toString());
+  }, []);
+
+  const open = useCallback((id: string) => { setOpenId(id); setPhotoParam(id); }, [setPhotoParam]);
+  const close = useCallback(() => { setOpenId(null); setPhotoParam(null); }, [setPhotoParam]);
+
+  // Restore an open lightbox from ?photo= on mount / once rows resolve (URL-addressable, C10).
+  useEffect(() => {
+    if (openId || viewable.length === 0) return;
+    const param = new URLSearchParams(window.location.search).get('photo');
+    if (param && viewable.some(r => r.id === param)) setOpenId(param);
+  }, [viewable, openId]);
+
+  const openIndex = useMemo(
+    () => (openId ? viewable.findIndex(r => r.id === openId) : -1),
+    [openId, viewable],
+  );
+
+  const step = useCallback((dir: -1 | 1) => {
+    if (openIndex < 0) return;
+    const next = viewable[openIndex + dir];
+    if (next) open(next.id);
+  }, [openIndex, viewable, open]);
+
+  // ESC closes, ←/→ navigate; lock body scroll while open.
+  useEffect(() => {
+    if (!openId) return;
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.stopPropagation(); close(); }
+      else if (e.key === 'ArrowLeft') step(-1);
+      else if (e.key === 'ArrowRight') step(1);
+    };
+    document.addEventListener('keydown', onKey, true);
+    return () => {
+      document.body.style.overflow = prevOverflow;
+      document.removeEventListener('keydown', onKey, true);
+    };
+  }, [openId, close, step]);
 
   // No Empty Shells: nothing while loading, nothing at 0 images.
   if (loading) return null;
@@ -208,44 +604,57 @@ const UserRecentPhotos: React.FC<UserRecentPhotosProps> = ({ userId, isOwnProfil
           // broken + heavy image (audit P1a).
           if (failedIds.has(img.id)) return null;
           const src = optimizeImageUrl(rawUrl, 'thumbnail') || rawUrl;
-          const day = journalDay(img);
-          const thumb = (
-            <img
-              src={src}
-              alt=""
-              loading="lazy"
-              decoding="async"
-              onError={() => {
-                setFailedIds(prev => {
-                  if (prev.has(img.id)) return prev;
-                  const next = new Set(prev);
-                  next.add(img.id);
-                  return next;
-                });
-              }}
-              style={{
-                width: '100%',
-                aspectRatio: '1 / 1',
-                objectFit: 'cover',
-                display: 'block',
-                background: '#eeeeee',
-              }}
-            />
-          );
-          return day ? (
-            <Link
+          // Every thumb is a button → opens the in-place evidence lightbox.
+          return (
+            <button
               key={img.id}
-              to={`/journal/${day}`}
-              title={day}
-              style={{ display: 'block', lineHeight: 0 }}
+              type="button"
+              onClick={() => open(img.id)}
+              title={journalDay(img) || undefined}
+              aria-label="Open photo"
+              style={{
+                display: 'block',
+                lineHeight: 0,
+                padding: 0,
+                border: 'none',
+                background: 'none',
+                cursor: 'pointer',
+              }}
             >
-              {thumb}
-            </Link>
-          ) : (
-            <div key={img.id} style={{ lineHeight: 0 }}>{thumb}</div>
+              <img
+                src={src}
+                alt=""
+                loading="lazy"
+                decoding="async"
+                onError={() => {
+                  setFailedIds(prev => {
+                    if (prev.has(img.id)) return prev;
+                    const next = new Set(prev);
+                    next.add(img.id);
+                    return next;
+                  });
+                }}
+                style={{
+                  width: '100%',
+                  aspectRatio: '1 / 1',
+                  objectFit: 'cover',
+                  display: 'block',
+                  background: '#eeeeee',
+                }}
+              />
+            </button>
           );
         })}
       </div>
+      {openIndex >= 0 && (
+        <RecentPhotoLightbox
+          rows={viewable}
+          index={openIndex}
+          isOwnProfile={isOwnProfile}
+          onClose={close}
+          onStep={step}
+        />
+      )}
     </CollapsibleWidget>
   );
 };

--- a/nuke_frontend/src/pages/user-profile/UserRecentPhotos.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserRecentPhotos.tsx
@@ -202,9 +202,12 @@ const UserRecentPhotos: React.FC<UserRecentPhotosProps> = ({ userId, isOwnProfil
         {images.map(img => {
           const rawUrl = img.thumbnail_url || img.image_url;
           if (!rawUrl) return null;
-          const src = failedIds.has(img.id)
-            ? (img.image_url || rawUrl)
-            : (optimizeImageUrl(rawUrl, 'thumbnail') || rawUrl);
+          // A failed render is hidden, never swapped for the raw original:
+          // the newest uploads are multi-MB HEIC that no browser can decode,
+          // so the old raw fallback turned a transient miss into a permanent
+          // broken + heavy image (audit P1a).
+          if (failedIds.has(img.id)) return null;
+          const src = optimizeImageUrl(rawUrl, 'thumbnail') || rawUrl;
           const day = journalDay(img);
           const thumb = (
             <img

--- a/nuke_frontend/src/pages/user-profile/UserSubHeader.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserSubHeader.tsx
@@ -13,13 +13,9 @@ const UserSubHeader: React.FC = () => {
   if (!profile) return null;
 
   const userType = profile.user_type || 'user';
-  // profiles has no verification_status column — the real columns are
-  // verification_level (text) and is_verified (boolean).
   const verified =
     profile.verification_level === 'fully_verified' ||
     profile.is_verified === true;
-  const memberSince = profile.member_since || profile.created_at;
-  const sinceYear = memberSince ? new Date(memberSince).getFullYear() : null;
 
   // Expertise badges from metadata (if any)
   const expertise: string[] = [];
@@ -30,13 +26,15 @@ const UserSubHeader: React.FC = () => {
     }
   }
 
-  // Type badge CSS class
+  // Type badge: only meaningful, content-bearing roles (PROFESSIONAL / DEALER)
+  // earn a badge. The default 'user' and the 'admin' moderation role are NOT
+  // part of the public record — founder teardown called the "ADMIN" badge
+  // "random stupid shit." Suppress both.
+  const showTypeBadge = userType === 'professional' || userType === 'dealer';
   const typeBadgeClass =
     userType === 'professional'
       ? 'up-badge up-badge--professional'
-      : userType === 'dealer'
-        ? 'up-badge up-badge--dealer'
-        : 'up-badge';
+      : 'up-badge up-badge--dealer';
 
   return (
     <div
@@ -44,18 +42,18 @@ const UserSubHeader: React.FC = () => {
       data-user-type={userType}
       data-verified={verified ? 'true' : 'false'}
     >
-      {/* User type badge */}
-      <span className={typeBadgeClass}>{userType.toUpperCase()}</span>
-
-      {/* Verification badge */}
-      {verified && (
-        <span className="up-badge up-badge--verified">VERIFIED</span>
+      {/* User type badge — PROFESSIONAL / DEALER only (USER & ADMIN suppressed) */}
+      {showTypeBadge && (
+        <span className={typeBadgeClass}>{userType.toUpperCase()}</span>
       )}
 
-      {/* Member since badge */}
-      {sinceYear && (
-        <span className="up-badge">SINCE {sinceYear}</span>
-      )}
+      {/* REMOVED (founder teardown PROFILE_BUILD_ORDER 2026-06-13):
+          - VERIFIED flat chip: a binary "verified" is not what verification means
+            here (it should read as accumulated multi-source consensus, not a
+            single flag); Skylar bundled it with "random stupid shit." Rethinking
+            verification-as-consensus is a separate design pass.
+          - SINCE {year} badge: the header meta line already says "SINCE 2025"
+            once. "you already mentioned since 2025 earlier" — duplicate killed. */}
 
       {/* Expertise badges */}
       {expertise.map((tag) => (

--- a/nuke_frontend/src/pages/user-profile/UserTodayCard.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserTodayCard.tsx
@@ -9,6 +9,7 @@
  */
 import React, { useEffect, useState, useMemo } from 'react';
 import { supabase } from '../../lib/supabase';
+import { optimizeImageUrl } from '../../lib/imageOptimizer';
 import { useUserProfile } from './UserProfileContext';
 
 interface TodayRow {
@@ -29,6 +30,7 @@ interface RecentImage {
   id: string;
   image_url: string;
   vehicle_id: string | null;
+  taken_at: string | null;
   created_at: string;
 }
 
@@ -46,48 +48,71 @@ const UserTodayCard: React.FC = () => {
     let cancelled = false;
 
     (async () => {
-      // Today's photos — group on client because PostgREST grouping is awkward
+      // "Working on today" = photos TAKEN today, not ingested today. Keying on
+      // created_at (import time) made freshly bulk-imported OLD photos (e.g.
+      // 2018-shot, imported this morning) masquerade as today's work — a
+      // provenance violation (C0). taken_at is the truth, the captured day is
+      // the unit. We fetch a window of recent imports and bucket them by
+      // taken_at::date client-side so EXIF capture time governs.
       const startOfToday = new Date();
       startOfToday.setHours(0, 0, 0, 0);
       const startOfWeek = new Date();
       startOfWeek.setDate(startOfWeek.getDate() - 7);
+      const ymd = (d: Date) => d.toISOString().slice(0, 10);
+      const todayYmd = ymd(startOfToday);
+      const weekYmd = ymd(startOfWeek);
+      // taken_at has no index on this 36M-row table; querying the recent
+      // upload window (created_at) and filtering by taken_at client-side keeps
+      // the query fast while honoring capture time.
+      const lookbackStart = new Date();
+      lookbackStart.setDate(lookbackStart.getDate() - 14);
 
-      const { data: todayImgs } = await supabase
+      const { data: recentUploads } = await supabase
         .from('vehicle_images')
-        .select('id, image_url, vehicle_id, created_at')
+        .select('id, image_url, vehicle_id, taken_at, created_at')
         .eq('user_id', userId)
-        .gte('created_at', startOfToday.toISOString())
+        .gte('created_at', lookbackStart.toISOString())
         .order('created_at', { ascending: false })
-        .limit(500);
-
-      // Week count via head:true so PostgREST returns count only
-      const { count: weekCount } = await supabase
-        .from('vehicle_images')
-        .select('id', { head: true, count: 'exact' })
-        .eq('user_id', userId)
-        .gte('created_at', startOfWeek.toISOString());
+        .limit(2000);
 
       if (cancelled) return;
 
-      // Group today's by vehicle
+      // Capture day for a row: EXIF taken_at when present, else upload day.
+      const captureDay = (img: { taken_at: string | null; created_at: string }): string =>
+        (img.taken_at || img.created_at || '').slice(0, 10);
+
+      const todayImgs = (recentUploads || []).filter(img => captureDay(img) === todayYmd);
+      const weekImgs = (recentUploads || []).filter(img => captureDay(img) >= weekYmd);
+
+      // Group today's by vehicle (capture time). NULL-vehicle imports are NOT
+      // eligible to become the named "WORKING ON <vehicle>" headline — a bulk
+      // of unattributed imports must never drive a vehicle headline.
       const byVehicle = new Map<string, TodayRow>();
-      const recents: RecentImage[] = [];
-      for (const img of todayImgs || []) {
-        const key = img.vehicle_id || '__none__';
+      for (const img of todayImgs) {
+        if (!img.vehicle_id) continue;
+        const key = img.vehicle_id;
+        const stamp = img.taken_at || img.created_at;
         const ex = byVehicle.get(key) || {
           vehicle_id: img.vehicle_id,
           count: 0,
-          last_at: img.created_at,
+          last_at: stamp,
         };
         ex.count += 1;
-        if (img.created_at > ex.last_at) ex.last_at = img.created_at;
+        if (stamp > ex.last_at) ex.last_at = stamp;
         byVehicle.set(key, ex);
-        if (recents.length < 6) recents.push(img);
       }
 
       const rows = Array.from(byVehicle.values()).sort((a, b) => b.count - a.count);
+
+      // Recent strip = the PRIMARY (named) vehicle's photos only, so the
+      // thumbnails always belong to the headline vehicle.
+      const primaryId = rows[0]?.vehicle_id ?? null;
+      const recents: RecentImage[] = primaryId
+        ? todayImgs.filter(img => img.vehicle_id === primaryId).slice(0, 6)
+        : [];
+
       setTodayByVehicle(rows);
-      setWeekTotal(weekCount || 0);
+      setWeekTotal(weekImgs.length);
       setRecentImages(recents);
 
       // Resolve vehicle names for the top 5 today
@@ -200,7 +225,7 @@ const UserTodayCard: React.FC = () => {
           {recentImages.map((img) => (
             <a key={img.id} href={img.vehicle_id ? `/vehicle/${img.vehicle_id}/image/${img.id}` : '#'}>
               <img
-                src={img.image_url}
+                src={optimizeImageUrl(img.image_url, 'thumbnail') || img.image_url}
                 alt=""
                 width={64}
                 height={64}

--- a/nuke_frontend/src/pages/user-profile/UserWorkspaceContent.tsx
+++ b/nuke_frontend/src/pages/user-profile/UserWorkspaceContent.tsx
@@ -9,7 +9,6 @@ import React, { useState, useCallback } from 'react';
 import { useUserProfile } from './UserProfileContext';
 
 // Lazy-load all card components
-const UserTodayCard = React.lazy(() => import('./UserTodayCard'));
 const UserDossierPanel = React.lazy(() => import('./UserDossierPanel'));
 const UserBriefing = React.lazy(() => import('./UserBriefing'));
 const UserConnectionStateStrip = React.lazy(() => import('./UserConnectionStateStrip'));
@@ -17,9 +16,16 @@ const UserActivityFeed = React.lazy(() => import('./UserActivityFeed'));
 const ColumnDivider = React.lazy(() => import('../vehicle-profile/ColumnDivider'));
 
 // Existing profile components
+// REMOVED per founder teardown (PROFILE_BUILD_ORDER 2026-06-13):
+//  - UserTodayCard: the "you have an update" notification card ("a flaw and bad
+//    design … I don't trust it"). Freshness is shown natively by the timeline.
+//  - UserDiscoveries (FOUND/SOURCES + discovered marketplace vehicles): not his
+//    built work, unclickable metrics ("I can't click them so I'm never gonna
+//    find out what they are"); maker-controls-the-arc — discovered ≠ built.
+//  - OrganizationAffiliations (Epstein Collection / Desert Performance / Taylor
+//    Customs / FBM / Ernies): data is correct but not wanted on the profile face
+//    ("I don't want those showing up"). Data is untouched; only the render is gone.
 const VehicleCollection = React.lazy(() => import('../../components/profile/VehicleCollection'));
-const UserDiscoveries = React.lazy(() => import('../../components/profile/UserDiscoveries'));
-const OrganizationAffiliations = React.lazy(() => import('../../components/profile/OrganizationAffiliations'));
 const ProfessionalToolbox = React.lazy(() => import('../../components/profile/ProfessionalToolbox'));
 const VehicleMergeInterface = React.lazy(() => import('../../components/vehicle/VehicleMergeInterface'));
 
@@ -70,11 +76,6 @@ const UserWorkspaceContent: React.FC = () => {
         {/* LEFT COLUMN */}
         <div className="up-col-left" style={{ width: `${leftPct}%` }}>
 
-          {/* Today — live mirror of what's happening RIGHT NOW (own profile) */}
-          <React.Suspense fallback={null}>
-            <UserTodayCard />
-          </React.Suspense>
-
           {/* Briefing — intelligence headline + stat pills */}
           <React.Suspense fallback={null}>
             <UserBriefing />
@@ -90,11 +91,14 @@ const UserWorkspaceContent: React.FC = () => {
             <UserDossierPanel />
           </React.Suspense>
 
-          {/* Vehicle Collection */}
+          {/* Vehicle Collection — owned/built garage. Anchor target for the
+              header's WORKED ON door. */}
           {userId && (
-            <React.Suspense fallback={null}>
-              <VehicleCollection userId={userId} isOwnProfile={isOwnProfile} />
-            </React.Suspense>
+            <div id="vehicle-collection">
+              <React.Suspense fallback={null}>
+                <VehicleCollection userId={userId} isOwnProfile={isOwnProfile} />
+              </React.Suspense>
+            </div>
           )}
 
           {/* Work Ledger — the decade of wrenching (work_sessions substrate) */}
@@ -104,24 +108,10 @@ const UserWorkspaceContent: React.FC = () => {
             </React.Suspense>
           )}
 
-          {/* User Discoveries */}
-          {userId && (
-            <React.Suspense fallback={null}>
-              <UserDiscoveries userId={userId} isOwnProfile={isOwnProfile} />
-            </React.Suspense>
-          )}
-
           {/* Activity Feed */}
           <React.Suspense fallback={null}>
             <UserActivityFeed />
           </React.Suspense>
-
-          {/* Organization Affiliations */}
-          {userId && (
-            <React.Suspense fallback={null}>
-              <OrganizationAffiliations userId={userId} isOwnProfile={isOwnProfile} />
-            </React.Suspense>
-          )}
 
           {/* Professional Toolbox — owner-only, non-basic users */}
           {isOwnProfile && isNotBasicUser && userId && (

--- a/nuke_frontend/src/services/profileStatsService.ts
+++ b/nuke_frontend/src/services/profileStatsService.ts
@@ -117,16 +117,20 @@ export async function getUserProfileData(userId: string): Promise<UserProfileDat
             .order('ended_at', { ascending: false })
             .limit(100)
         : EMPTY,
-      // Comments — EXCLUDE bids
-      identityIds.length > 0
-        ? supabase
-            .from('auction_comments')
-            .select(`*, auction:auction_events(*, ${VEHICLE_EMBED})`)
-            .in('author_external_identity_id', identityIds)
-            .is('bid_amount', null)
-            .order('posted_at', { ascending: false })
-            .limit(100)
-        : EMPTY,
+      // Comments — the user's PLATFORM comments (their own comments on Nuke
+      // vehicles/images/timeline), NOT BaT auction comments. The header
+      // "COMMENTS" headline was previously fed by auction_comments (BaT only,
+      // via external identity) — that number is already surfaced, correctly
+      // scoped, inside UserBatTrackRecord's "COMMENTS (n)" door, so reusing it
+      // here both double-counted and mislabeled it as platform activity. The
+      // canonical platform-comment table is user_comments (superset of the
+      // legacy vehicle_comments). vehicle embed populates the door's link.
+      supabase
+        .from('user_comments')
+        .select(`*, ${VEHICLE_EMBED}`)
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false })
+        .limit(100),
       // Auction wins
       identityIds.length > 0
         ? supabase
@@ -148,7 +152,15 @@ export async function getUserProfileData(userId: string): Promise<UserProfileDat
 
   const listings = listingsRes.data;
   const batBids = batBidsRes.data;
-  const auctionComments = auctionCommentsRes.data;
+  // Platform comments from user_comments. Normalize the shape so the existing
+  // header COMMENTS door (reads c.comment_text, c.posted_at, c.auction?.vehicle)
+  // renders unchanged: alias created_at→posted_at and lift the embedded vehicle
+  // under `auction.vehicle`.
+  const platformComments = (auctionCommentsRes.data || []).map((c: any) => ({
+    ...c,
+    posted_at: c.created_at,
+    auction: { vehicle: c.vehicle },
+  }));
   const auctionWins = auctionWinsRes.data;
   const profileStatsRow = (profileStatsRes as any)?.data ?? null;
 
@@ -159,7 +171,7 @@ export async function getUserProfileData(userId: string): Promise<UserProfileDat
   const stats: ProfileStats = {
     total_listings: listings?.length ?? 0,
     total_bids: batBids?.length ?? 0,
-    total_comments: auctionComments?.length ?? 0,
+    total_comments: platformComments.length,
     total_auction_wins: auctionWins?.length ?? 0,
     total_success_stories: 0, // success_stories table does not exist in prod
     member_since: profile.member_since || profile.created_at,
@@ -174,7 +186,7 @@ export async function getUserProfileData(userId: string): Promise<UserProfileDat
     stats,
     listings: listings || [],
     bids: batBids || [],
-    comments: auctionComments || [],
+    comments: platformComments,
     auction_wins: auctionWins || [],
     success_stories: [],
     comments_of_note: [],

--- a/nuke_frontend/src/styles/barcode-timeline.css
+++ b/nuke_frontend/src/styles/barcode-timeline.css
@@ -58,6 +58,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.12em;
+  white-space: nowrap; /* 0.12em tracking made "TIMELINE" wrap/clip its last E in the 10px bar */
   color: var(--vp-text-faint);
   position: absolute;
   left: 12px;

--- a/nuke_frontend/src/styles/user-profile.css
+++ b/nuke_frontend/src/styles/user-profile.css
@@ -559,6 +559,10 @@
 /* ─── Dossier Panel ─── */
 .up-dossier-group {
   margin-bottom: 8px;
+  /* Canonical 12px horizontal gutter (frontend.md): the CollapsibleWidget
+     content this sits in has 0 padding, so without this the GITHUB / WEBSITE
+     value ran flush to the viewport edge and clipped at 375px. */
+  padding: 0 12px;
 }
 
 .up-dossier-group__label {

--- a/nuke_frontend/src/styles/user-profile.css
+++ b/nuke_frontend/src/styles/user-profile.css
@@ -163,6 +163,101 @@
   color: var(--up-pencil);
 }
 
+/* Stat DOOR — pill-as-button (founder law: every stat is a button that
+   expands). Structure only: a clickable pill with a 2px-border-bottom
+   underline cue; colors inherit from .up-stat-pill (no new color here). */
+.up-stat-pill--door {
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 2px 0;
+  margin: 0;
+  border-bottom: 2px solid transparent;
+}
+.up-stat-pill--door:hover {
+  border-bottom-color: var(--up-pencil);
+}
+.up-stat-pill--door.up-stat-pill--open {
+  border-bottom-color: var(--up-ink);
+}
+
+/* Inline door detail panel — opens under the header bar, full width. */
+.up-stat-door {
+  flex-basis: 100%;
+  width: 100%;
+  border-top: 1px solid var(--up-ghost);
+  margin-top: 6px;
+  padding-top: 6px;
+}
+.up-stat-door__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12px 4px;
+}
+.up-stat-door__title {
+  font-family: var(--up-font-sans);
+  font-size: var(--fs-9);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--up-ink);
+}
+.up-stat-door__close {
+  font-size: var(--fs-8);
+}
+.up-stat-door__body {
+  max-height: 320px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+.up-stat-door__row {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 5px 12px;
+  border-top: 1px solid var(--up-ghost);
+  text-decoration: none;
+  color: inherit;
+}
+.up-stat-door__row:hover {
+  background: var(--up-surface);
+}
+.up-stat-door__row-main {
+  font-family: var(--up-font-sans);
+  font-size: var(--fs-10);
+  color: var(--up-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.up-stat-door__row-meta {
+  font-family: var(--up-font-mono);
+  font-size: var(--fs-8);
+  color: var(--up-pencil);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.up-stat-door__cta {
+  display: block;
+  padding: 6px 12px;
+  font-family: var(--up-font-sans);
+  font-size: var(--fs-10);
+  font-weight: 700;
+  color: var(--up-ink);
+  text-decoration: none;
+}
+.up-stat-door__cta:hover {
+  text-decoration: underline;
+}
+.up-stat-door__empty {
+  padding: 8px 12px;
+  font-family: var(--up-font-mono);
+  font-size: var(--fs-9);
+  color: var(--up-pencil);
+}
+
 /* ─── Sub-Header ─── */
 .up-sub-header {
   position: sticky;

--- a/nuke_frontend/src/styles/user-profile.css
+++ b/nuke_frontend/src/styles/user-profile.css
@@ -56,6 +56,22 @@
   font-family: var(--up-font-sans);
   background: var(--up-bg);
   min-height: 100vh;
+
+  /* ─── One coherent surface treatment ───
+     The profile is drawn on the light --up-* palette, but a few embedded
+     components (UserDiscoveries, VehicleCollection) read the GLOBAL app tokens
+     (--bg / --surface / --text / --border), which resolve dark in the app's
+     dark theme — producing random dark slabs amid the light record. Remap the
+     global tokens to the profile's own light palette for the subtree so every
+     surface is the same light treatment. No new colors: aliases of --up-*. */
+  --bg: var(--up-bg);
+  --surface: var(--up-surface);
+  --surface-hover: var(--up-row-alt);
+  --surface-elevated: var(--up-surface);
+  --text: var(--up-ink);
+  --text-muted: var(--up-data-dim);
+  --border: var(--up-ghost);
+  color-scheme: light;
 }
 
 /* ─── User Header ─── */
@@ -587,6 +603,25 @@
     order: 3;
     width: 100%;
     justify-content: flex-start;
+    flex-wrap: wrap;
+    gap: 6px 12px;
+    column-gap: 12px;
+  }
+
+  /* Dossier rows: let the label hold its width and the value wrap/shrink
+     instead of clipping off the right edge at 375px. */
+  .up-dossier-row {
+    gap: 8px;
+  }
+  .up-dossier-row__label {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+  .up-dossier-row__value {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 
   .up-drawer {

--- a/supabase/migrations/20260614050000_fix_contribution_days_order_desc.sql
+++ b/supabase/migrations/20260614050000_fix_contribution_days_order_desc.sql
@@ -1,0 +1,65 @@
+-- P0 fix: the user-profile timeline silently truncated at 2020-03-20.
+--
+-- get_user_contribution_days returns >1000 (day, kind, n) rows for a heavy
+-- user (2,666 rows for user 0b9f107a, spanning 2004 -> 2026-06-14). It is
+-- consumed over PostgREST (profileService.ts:28), where db-max-rows=1000 caps
+-- the response. The prior tail `ORDER BY 1, 2` ordered days ASCENDING, so the
+-- surviving 1000 rows were the OLDEST -- the cut landed on row 1000 =
+-- 2020-03-20 (Skylar's "photos dropped off after Saturday March 21 2020"
+-- seam) and every newer day, including all 2026 activity, was dropped before
+-- it ever reached the heatmap.
+--
+-- Fix: order DESC so the surviving 1000 rows under the cap are the NEWEST
+-- days. The barcode timeline sorts client-side anyway; ordering is only about
+-- WHICH rows survive the cap. This unhides his recent (2025-2026) data.
+--
+-- Re-creates the function identically except for the ORDER BY tail.
+
+CREATE OR REPLACE FUNCTION get_user_contribution_days(p_user_id uuid)
+RETURNS TABLE(day date, kind text, n int)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  -- Photos: day = capture time when EXIF has it, upload time otherwise.
+  SELECT
+    COALESCE(vi.taken_at, vi.created_at)::date AS day,
+    'photo'::text AS kind,
+    count(*)::int AS n
+  FROM vehicle_images vi
+  WHERE vi.user_id = p_user_id
+    AND COALESCE(vi.taken_at, vi.created_at)::date >= DATE '2000-01-01'
+  GROUP BY 1
+
+  UNION ALL
+
+  -- Timeline events
+  SELECT
+    vte.event_date AS day,
+    'event'::text AS kind,
+    count(*)::int AS n
+  FROM vehicle_timeline_events vte
+  WHERE vte.user_id = p_user_id
+    AND vte.event_date >= DATE '2000-01-01'
+  GROUP BY 1
+
+  UNION ALL
+
+  -- Work sessions
+  SELECT
+    ws.session_date AS day,
+    'work'::text AS kind,
+    count(*)::int AS n
+  FROM work_sessions ws
+  WHERE ws.user_id = p_user_id
+    AND ws.session_date >= DATE '2000-01-01'
+  GROUP BY 1
+
+  -- DESC so the newest days survive PostgREST's 1000-row cap (was ORDER BY 1,2
+  -- which kept the oldest 1000 and hid everything after 2020-03-20).
+  ORDER BY day DESC, kind;
+$$;
+
+COMMENT ON FUNCTION get_user_contribution_days(uuid) IS
+  'Per-day contribution aggregates (photo/event/work) for a user profile timeline. Replaces three 1000-row-capped wide selects. day >= 2000-01-01 filters bogus-EXIF dates. ORDER BY day DESC so the newest days survive the PostgREST 1000-row cap (the 2020-03-20 truncation fix).';


### PR DESCRIPTION
Surgical repair of the shipping `/u/:handle` profile, mobile-first (verified at 375px on localhost:5180). Every fix is audit-cited (`docs/design/USER_PROFILE_AUDIT.md`) and grounded in measured prod data, not guesses. No mockups — this improves the wired product in place (C0).

## Fixes

**1. The 2020 dropoff (P0 — unhides 2025/2026 data).** `get_user_contribution_days` returned 2,666 rows (2004→2026-06-14) ordered day-ASC; PostgREST's 1000-row cap kept the OLDEST 1000, cutting at 2020-03-20 (Skylar's exact seam) and hiding every newer day. Changed the RPC tail to `ORDER BY day DESC, kind`. Migration committed **and applied to prod**.
- Before (REST, capped): `max_day=2020-03-20`, 2026 rows = **0**
- After (REST, capped): `first_day=2026-06-14`, 2026 rows = **193**; rendered heatmap now plots **203 cells dated 2026**.

**2. Broken/raw images.** TODAY-card heroes + RECENT PHOTOS now route every `<img>` through the `/render/image` transcode (HEIC 3.3MB→~6-24KB JPEG). RECENT PHOTOS `onError` hides a failed cell instead of swapping the working render URL for the raw `.HEIC`. The 6 broken heroes now render real photos.

**3. "VEHICLES 334" → honest + labeled.** Header + Briefing show **WORKED ON 88** (`vehicles_count`), not the 334 record-authorship union (~half scraped Craigslist). BIDS (structurally blind, always 0) suppressed → AUCTIONS WON when present. Stale header IMAGES (23,376 cron vs 22,728 live) removed — RECENT PHOTOS owns the live count. All pills self-guard to non-zero.

**4. Cruft + zeros.** Dossier ACCOUNT group removed (TYPE/ADMIN moderation metadata; VERIFICATION read a nonexistent column; VISIBILITY is a setting). UserDiscoveries shows only non-zero stat cells (killed the FOUND/SAVED/WATCHING/CONTACTED/PURCHASED wall of zeros) and returns null for visitors with no discoveries.

**5. The "97133" location bug.** Dossier LOCATION rendered a ZIP fragment of the github handle (`sss97133`) from legacy `profiles.location`. Now prefers structured city/state → **"Boulder City, NV"**.

**6. Light/dark coherence.** Remapped the global app tokens (`--bg/--surface/--text/--border`) to the profile's own light `--up-*` palette on `.user-profile-page` (aliases, no new hexes; `color-scheme: light`), so embedded components stop rendering random dark slabs. One coherent light surface.

**7. Mobile readability (375px).** Header stat row wraps instead of clipping; dossier values wrap/shrink. Verified `scrollWidth == innerWidth == 375` (no horizontal overflow).

## Bonus (coordinator-flagged, measured): TODAY-card provenance (C0)
Prod showed 1,376 photos ingested today but only 8 *taken* today; 1,361 of today's imports are NULL-vehicle, captured 2017→. The card windowed by `created_at` (import time), so bulk-imported 2018 photos masqueraded as "WORKING ON 1989 R3500 Cheyenne · 16 photos today." Now buckets by `taken_at` (capture time), excludes NULL-vehicle from the named primary, builds the strip from the primary vehicle only. Card now honestly reads "No new photos today."

## Verification
- `tsc --noEmit` clean; `npm run build` ✓ (11.3s).
- Each fix confirmed in the live preview at 375px + DOM assertions + prod DB probes.

Do not merge — for Skylar's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expandable “stat door” detail panels in the user profile header (WORKED ON, LISTINGS, COMMENTS).
  * Introduced an in-place, vehicle-aware lightbox with per-photo analysis for recent photos.
* **Improvements**
  * Updated profile stats wording and counts to reflect “worked on” and platform comments.
  * Refined dossier/sub-header display (simpler identity info and fewer chips) and adjusted profile panel layout.
  * Enhanced “today”/recent photo grouping using capture time and vehicle context.
* **Bug Fixes**
  * Failed photo thumbnails are now permanently hidden.
  * Contribution history now preserves the most recent days.
* **Style**
  * Refined light theme styling and improved mobile spacing for profile UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->