### PR TITLE
Evidence-anchored agent write pipeline + finite-asset consensus

### DIFF
--- a/supabase/functions/_shared/cockpit/attribute-registry.evidence.test.ts
+++ b/supabase/functions/_shared/cockpit/attribute-registry.evidence.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Phase 1 — evidence-class binding tests (the anti-laundering rule).
+ *
+ * Pure unit tests over the registry; no DB. The headline guarantee the prompt asks
+ * for: a photo-cited horsepower claim is rejected, a VIN-decode-cited one is accepted.
+ *
+ * Run: deno test supabase/functions/_shared/cockpit/attribute-registry.evidence.test.ts
+ */
+
+import {
+  validateEvidenceClass,
+  admissibleEvidence,
+  getAttribute,
+  listAttributes,
+  EVIDENCE_CLASSES,
+} from "./attribute-registry.ts";
+
+function assert(cond: unknown, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+Deno.test("HEADLINE: a photo cannot cite horsepower (rejected)", () => {
+  const err = validateEvidenceClass("vehicle.horsepower", "image");
+  assert(err !== null, "image-cited horsepower MUST be rejected");
+  assert(/not admissible/.test(err!), `expected an admissibility error, got: ${err}`);
+});
+
+Deno.test("HEADLINE: a VIN decode CAN cite horsepower (accepted)", () => {
+  assert(validateEvidenceClass("vehicle.horsepower", "vin_decode") === null, "vin_decode-cited horsepower must be accepted");
+});
+
+Deno.test("spec facts (torque/displacement) reject image, accept vin_decode/document/owner_claim", () => {
+  for (const attr of ["vehicle.torque", "vehicle.displacement"]) {
+    assert(validateEvidenceClass(attr, "image") !== null, `${attr}: image must be rejected`);
+    assert(validateEvidenceClass(attr, "vin_decode") === null, `${attr}: vin_decode must be accepted`);
+    assert(validateEvidenceClass(attr, "document") === null, `${attr}: document must be accepted`);
+    assert(validateEvidenceClass(attr, "owner_claim") === null, `${attr}: owner_claim must be accepted`);
+  }
+});
+
+Deno.test("current color is image-class, NOT vin_decode (a decode can't show refinished paint)", () => {
+  assert(validateEvidenceClass("vehicle.exterior_color", "image") === null, "image must cite current color");
+  assert(validateEvidenceClass("vehicle.exterior_color", "vin_decode") !== null, "vin_decode must NOT cite current color");
+});
+
+Deno.test("seat_count accepts both image and vin_decode", () => {
+  assert(validateEvidenceClass("vehicle.seat_count", "image") === null, "image counts seats");
+  assert(validateEvidenceClass("vehicle.seat_count", "vin_decode") === null, "vin_decode derives seats from body style");
+});
+
+Deno.test("owner_claim is the universal low-tier fallback where bound", () => {
+  // It is admissible for owner-assertable attributes...
+  assert(validateEvidenceClass("vehicle.modifications", "owner_claim") === null, "owner may claim mods");
+  // ...but NOT silently admissible for pure-vision detection tasks.
+  assert(validateEvidenceClass("image.has_vehicle", "owner_claim") !== null, "owner_claim should not cite a vision detection task");
+});
+
+Deno.test("unknown evidence class is rejected", () => {
+  assert(validateEvidenceClass("vehicle.horsepower", "vibes") !== null, "unknown class must be rejected");
+  assert(validateEvidenceClass("vehicle.horsepower", 42) !== null, "non-string class must be rejected");
+});
+
+Deno.test("unknown attribute is rejected", () => {
+  assert(validateEvidenceClass("vehicle.nonexistent", "owner_claim") !== null, "unknown attribute must be rejected");
+});
+
+Deno.test("the 4 spec attributes exist in the registry", () => {
+  for (const a of ["vehicle.horsepower", "vehicle.torque", "vehicle.displacement", "vehicle.seat_count"]) {
+    assert(getAttribute(a) !== null, `${a} must be registered`);
+  }
+});
+
+Deno.test("every registered attribute resolves a non-empty, valid admissible set", () => {
+  for (const attr of listAttributes()) {
+    const adm = admissibleEvidence(attr);
+    assert(adm.length > 0, `${attr} has no admissible evidence — would be unsubmittable`);
+    for (const c of adm) {
+      assert(EVIDENCE_CLASSES.includes(c), `${attr} lists invalid evidence class '${c}'`);
+    }
+  }
+});
+
+Deno.test("INVARIANT: no factory-spec attribute admits image evidence", () => {
+  // The whole point — spec facts must never be citable by a photograph.
+  for (const attr of ["vehicle.horsepower", "vehicle.torque", "vehicle.displacement"]) {
+    assert(!admissibleEvidence(attr).includes("image"), `${attr} must NOT admit image evidence`);
+  }
+});

--- a/supabase/functions/_shared/cockpit/attribute-registry.ts
+++ b/supabase/functions/_shared/cockpit/attribute-registry.ts
@@ -27,7 +27,35 @@
 
 import type { ResultKind } from "./types.ts";
 
-export type SubjectKind = "vehicle" | "image" | "person" | "cluster";
+export type SubjectKind = "vehicle" | "image" | "person" | "cluster" | "user";
+
+// ── Evidence-class binding (the anti-laundering rule) ────────────────────────
+// Every attribute declares which classes of evidence may legitimately CITE it.
+// A photo cannot show horsepower; a VIN decode cannot show the current paint.
+// submit_attribute_value rejects any claim whose citation class is not admissible
+// for the attribute — so a high-tier fact can't be laundered in behind a low-tier
+// (or simply wrong-modality) citation.
+//
+//   image         — visible in a photograph of THIS asset (current color, seat count,
+//                   body style, visible mods, condition, plate/VIN read).
+//   vin_decode    — derived from the VIN per a factory decode rule (hp, torque,
+//                   displacement, engine/trans codes, factory equipment).
+//   document      — a record: build sheet / Marti report / title / service history
+//                   (original color, mileage, ownership chain).
+//   owner_claim   — the owner asserts it. Universally admissible but LOWEST tier and
+//                   upgradable — a confirming image/document/decode supersedes it.
+//   context_atoms — derived from Nuke's own graph (user/cluster substrate joins);
+//                   the "evidence" is existing attributed atoms, not an external source.
+export type EvidenceClass =
+  | "image"
+  | "vin_decode"
+  | "document"
+  | "owner_claim"
+  | "context_atoms";
+
+export const EVIDENCE_CLASSES: readonly EvidenceClass[] = [
+  "image", "vin_decode", "document", "owner_claim", "context_atoms",
+];
 
 export type ExpectedShape =
   | "string"
@@ -84,6 +112,11 @@ export interface AttributeDefinition {
 
   // Versioning so prompt drift is observable. Bump when the prompt changes.
   prompt_version: string;
+
+  // Admissible evidence classes for this attribute. Optional on the definition;
+  // the authoritative binding is ADMISSIBLE_EVIDENCE below (one auditable block).
+  // admissibleEvidence(attribute) resolves the effective set.
+  admissible_evidence?: EvidenceClass[];
 }
 
 // ============================================================================
@@ -290,6 +323,83 @@ const L2: AttributeDefinition[] = [
 // ============================================================================
 
 const L3: AttributeDefinition[] = [
+  // ── Factory-spec facts (VIN-decode tier) ───────────────────────────────────
+  // A photograph cannot show these; admissible evidence is the VIN decode (factory
+  // rule), a document (build sheet / window sticker), or a low-tier owner_claim.
+  {
+    attribute: "vehicle.horsepower",
+    subject_kind: "vehicle",
+    result_kind: "substrate",
+    layer: 3,
+    modalities: ["context_atoms"],
+    admissible_evidence: ["vin_decode", "document", "owner_claim"],
+    prompt:
+      "Report the factory-rated gross horsepower for this VIN's engine code. " +
+      "Cite the decode rule (e.g. 1966 Ford 289 2V C-code = 200 hp gross). Do NOT " +
+      "infer from a photo — a photo cannot show horsepower. Return an integer.",
+    expected_shape: "number",
+    prompt_version: "v1",
+  },
+  {
+    attribute: "vehicle.torque",
+    subject_kind: "vehicle",
+    result_kind: "substrate",
+    layer: 3,
+    modalities: ["context_atoms"],
+    admissible_evidence: ["vin_decode", "document", "owner_claim"],
+    prompt:
+      "Report the factory-rated gross torque (lb-ft) for this VIN's engine code. " +
+      "Cite the decode rule (e.g. 1966 Ford 289 2V C-code = 282 lb-ft). Return an integer.",
+    expected_shape: "number",
+    prompt_version: "v1",
+  },
+  {
+    attribute: "vehicle.displacement",
+    subject_kind: "vehicle",
+    result_kind: "substrate",
+    layer: 3,
+    modalities: ["context_atoms"],
+    admissible_evidence: ["vin_decode", "document", "owner_claim"],
+    prompt:
+      "Report the factory engine displacement for this VIN's engine code, as cubic " +
+      "inches or liters (e.g. '289' or '4.7L'). Cite the decode rule. Return a string.",
+    expected_shape: "string",
+    prompt_version: "v1",
+  },
+  {
+    attribute: "vehicle.seat_count",
+    subject_kind: "vehicle",
+    result_kind: "substrate",
+    layer: 3,
+    modalities: ["image", "context_atoms"],
+    admissible_evidence: ["image", "vin_decode", "document", "owner_claim"],
+    prompt:
+      "Report the number of factory seating positions. May be counted from an interior " +
+      "photo OR derived from the body style via VIN decode (e.g. 1966 Mustang hardtop " +
+      "coupe = 4). Return an integer.",
+    expected_shape: "number",
+    prompt_version: "v1",
+  },
+  {
+    // Market disposition. The single most fraud-prone and contamination-prone field on an
+    // asset: "sold" vs "for sale" vs "owner-retained" drives value perception AND leaks across
+    // records in bulk auction scrapes. Admissible evidence is a DOCUMENT (title / bill of sale —
+    // who legally holds it), an IMAGE (ongoing possession / restoration), or an owner_claim.
+    attribute: "vehicle.sale_disposition",
+    subject_kind: "vehicle",
+    result_kind: "substrate",
+    layer: 3,
+    modalities: ["ocr", "image", "context_atoms"],
+    admissible_evidence: ["document", "image", "owner_claim"],
+    expected_shape: "enum",
+    enum_values: ["for_sale", "sold", "owner_retained", "in_restoration", "withdrawn", "unknown"],
+    prompt:
+      "What is the asset's true market disposition RIGHT NOW? 'sold' means it changed hands to a " +
+      "new owner; 'owner_retained' / 'in_restoration' mean the current owner still holds it (a " +
+      "title in their name + ongoing possession/build photos prove this and OVERRIDE a stale " +
+      "auction-scrape 'sold'). Cite the title/bill-of-sale (document) or possession photos (image).",
+    prompt_version: "v1",
+  },
   {
     attribute: "vehicle.exterior_color",
     subject_kind: "vehicle",
@@ -304,6 +414,42 @@ const L3: AttributeDefinition[] = [
       "raw_metal, primer, satin_black, etc.) and a sRGB hex approximation. " +
       "If the vehicle is mid-restoration with multiple panel colors, list each " +
       "panel and its color separately.",
+    expected_shape: "structured",
+    prompt_version: "v1",
+  },
+  // ── Color decomposition (time-varying) ─────────────────────────────────────
+  // The single `exterior_color` field conflates two different facts with different
+  // evidence: what color it IS now (a photo shows it) vs what color it LEFT THE
+  // FACTORY (only a document — Marti report / door tag — can prove it). They are
+  // separate claims; a refinish_event links them. The canonical profile projects
+  // current as the headline and retains original + the change history.
+  {
+    attribute: "vehicle.current_color",
+    subject_kind: "vehicle",
+    result_kind: "substrate",
+    layer: 3,
+    modalities: ["image"],
+    admissible_evidence: ["image", "owner_claim"],
+    depends_on: ["image.vehicle_bboxes", "vehicle.viewpoint"],
+    prompt:
+      "What color IS the vehicle now? Read it from the body panels in a current " +
+      "photograph (ignore background, glass, wheels). Return { color, hex }. This is " +
+      "present-state — a refinished car reports its refinished color, not the factory color.",
+    expected_shape: "structured",
+    prompt_version: "v1",
+  },
+  {
+    attribute: "vehicle.original_color",
+    subject_kind: "vehicle",
+    result_kind: "substrate",
+    layer: 3,
+    modalities: ["ocr", "context_atoms"],
+    admissible_evidence: ["document", "owner_claim"],
+    prompt:
+      "What color did the vehicle LEAVE THE FACTORY? This is NOT visible in a photo of " +
+      "a refinished car — it requires a document: a Marti report, build sheet, window " +
+      "sticker, or the door-jamb paint code. Return { color, code, source_doc }. If you " +
+      "only have a photo, you cannot answer this — submit it as vehicle.current_color instead.",
     expected_shape: "structured",
     prompt_version: "v1",
   },
@@ -366,6 +512,26 @@ const L3: AttributeDefinition[] = [
 // ============================================================================
 
 const L4: AttributeDefinition[] = [
+  {
+    // Links original_color → current_color as an explicit state-change in the append-only
+    // log. result_kind 'projection' — it's an inference ABOUT a change in the world, not a
+    // direct measurement. Evidence can be a before/after image pair, a paint receipt
+    // (document), or the owner's account.
+    attribute: "vehicle.refinish_event",
+    subject_kind: "vehicle",
+    result_kind: "projection",
+    layer: 4,
+    modalities: ["image", "ocr", "context_atoms"],
+    admissible_evidence: ["image", "document", "owner_claim"],
+    depends_on: ["vehicle.current_color"],
+    prompt:
+      "Record a documented repaint/refinish as a state change. Return " +
+      "{ from_color, to_color, observed_change_date?, method? (respray|wrap|patina_preserve), " +
+      "shop? }. Cite the evidence: a before/after image pair, a paint/body invoice, or the " +
+      "owner's statement. This is what reconciles a 'factory blue' original with a 'black now' current.",
+    expected_shape: "structured",
+    prompt_version: "v1",
+  },
   {
     attribute: "image.location_class",
     subject_kind: "image",
@@ -487,7 +653,188 @@ const COMPOUND: AttributeDefinition[] = [
   },
 ];
 
-const REGISTRY: AttributeDefinition[] = [...L1, ...L2, ...L3, ...L4, ...L5, ...COMPOUND];
+// ============================================================================
+// USER — first-class subject_kind added 2026-05-24 per Skylar directive:
+// "user profiles are the drivers of progress on the platform otherwise the
+// system is dead. its a shell without a driver just a bunch of boring useless
+// assets." Vehicles/images are derivative; users are the source-of-truth subject.
+// These attributes are answerable by a caller agent reading the user-substrate
+// (user_profiles + user_emails + user_phones + user_addresses + user_roles +
+// user_observations + user_contributions + vehicle_images.user_id), not from
+// an image directly. Modality is predominantly context_atoms.
+// ============================================================================
+const USER: AttributeDefinition[] = [
+  // L1 — existence/identity baseline
+  {
+    attribute: "user.has_profile",
+    subject_kind: "user",
+    result_kind: "substrate",
+    layer: 1,
+    modalities: ["context_atoms"],
+    prompt:
+      "Does this user have a `user_profiles` row with at minimum a display_name " +
+      "and a primary email? Answer true if both exist and verified, false otherwise. " +
+      "This is the gate for whether any higher-layer user attribute can be queried.",
+    expected_shape: "boolean",
+    prompt_version: "v1",
+  },
+  // L2 — identity surface
+  {
+    attribute: "user.display_identity",
+    subject_kind: "user",
+    result_kind: "substrate",
+    layer: 2,
+    modalities: ["context_atoms"],
+    depends_on: ["user.has_profile"],
+    prompt:
+      "Return the user's display identity: display_name + preferred_username + " +
+      "primary email + locale + timezone. Pull from user_profiles + user_emails. " +
+      "All directly from substrate — no inference.",
+    expected_shape: "structured",
+    prompt_version: "v1",
+  },
+  {
+    attribute: "user.contact_surface",
+    subject_kind: "user",
+    result_kind: "substrate",
+    layer: 2,
+    modalities: ["context_atoms"],
+    depends_on: ["user.has_profile"],
+    prompt:
+      "Enumerate all multi-valued contact rows: every email in user_emails, " +
+      "every phone in user_phones, every address in user_addresses. Return as " +
+      "structured arrays with type, primary flag, verified flag. Substrate only.",
+    expected_shape: "structured",
+    prompt_version: "v1",
+  },
+  // L3 — derived profile/state
+  {
+    attribute: "user.role_set",
+    subject_kind: "user",
+    result_kind: "substrate",
+    layer: 3,
+    modalities: ["context_atoms"],
+    depends_on: ["user.has_profile"],
+    prompt:
+      "List all active user_roles for this user — role + scope_type + scope_id + " +
+      "granted_at. Exclude revoked_at IS NOT NULL. This answers 'what can this " +
+      "user do, and inside which organizations/vehicles.'",
+    expected_shape: "structured",
+    prompt_version: "v1",
+  },
+  {
+    attribute: "user.possession_set",
+    subject_kind: "user",
+    result_kind: "substrate",
+    layer: 3,
+    modalities: ["context_atoms"],
+    depends_on: ["user.has_profile"],
+    prompt:
+      "List all vehicles this user owns or stewards via vehicle_user_permissions " +
+      "(verified_owner / previous_owner / contributor / etc). Include vehicle_id, " +
+      "year/make/model, permission_level, evidence_count. Substrate join, no inference.",
+    expected_shape: "structured",
+    prompt_version: "v1",
+  },
+  // L4 — projection (inference about behavior/pattern)
+  {
+    attribute: "user.vendor_preference_signal",
+    subject_kind: "user",
+    result_kind: "projection",
+    layer: 4,
+    modalities: ["context_atoms"],
+    depends_on: ["user.has_profile"],
+    prompt:
+      "From user_observations of kind='vendor_preference' joined with " +
+      "user_contributions (qb_txn, email, imessage), produce the user's top-N " +
+      "vendors by spend + frequency, with recency-decay weighting. Return ranked " +
+      "list with (vendor, spend_total, txn_count, last_txn_date, signal_score). " +
+      "Per Skylar 2026-05-23: $ totals from QB are flagged unverified — surface " +
+      "qualitative ranking (vendor exists / frequency / recency) as primary; " +
+      "dollars as secondary with .unverified suffix.",
+    expected_shape: "structured",
+    prompt_version: "v1",
+  },
+  {
+    attribute: "user.daily_activity_density",
+    subject_kind: "user",
+    result_kind: "projection",
+    layer: 4,
+    modalities: ["context_atoms"],
+    depends_on: ["user.has_profile"],
+    prompt:
+      "Compose a GitHub-style 365-day activity heatmap from v_user_daily_activity. " +
+      "Return per-day (date, contribution_count, dominant_kind, subject_breakdown). " +
+      "This is THE product per Skylar (session 5d0848ba): 'once we're able to fully " +
+      "establish user behavior then we're able to establish asset growth.'",
+    expected_shape: "structured",
+    prompt_version: "v1",
+  },
+  {
+    attribute: "user.relationship_map",
+    subject_kind: "user",
+    result_kind: "projection",
+    layer: 4,
+    modalities: ["context_atoms"],
+    depends_on: ["user.has_profile"],
+    prompt:
+      "From user_observations of kind='counterparty_relationship' joined with " +
+      "contacts + payment_events + apple_cash data, produce the user's " +
+      "relationship graph: per-counterparty (name, relationship_type, txn_count, " +
+      "total_value, last_interaction, evidence_sources). Tag spouse/family/" +
+      "contractor/vendor/customer where determinable. Per Skylar: Jenny is wife, " +
+      "Apple Cash to her is spousal not commercial.",
+    expected_shape: "structured",
+    prompt_version: "v1",
+  },
+];
+
+// ============================================================================
+// CLUSTER — temporal-change (dT) over the work-session chain. Added 2026-05-31.
+// The transition unit is a `work_sessions` row (the labor ledger — "work story
+// lives in work_sessions"). Consecutive sessions for one vehicle are ordered by
+// `session_date`; the predecessor is simply the prior work_sessions row for that
+// vehicle_id (no predecessor/successor columns needed — ORDER BY session_date IS
+// the chain). Member photos resolve via `vehicle_images.work_session_id`; per-
+// image state lives at ai_scan_metadata->'byok_deep_analysis'->'state_observations'.
+// The dT signal — what WORK happened — lives in the transition between a session
+// and the prior one, not in any single frame (per engineering-manual ch.19 and
+// feedback_photo_intent_must_be_confirmed_not_assumed). subject_kind="cluster",
+// subject_id = the later work_session.id. It is a HYPOTHESIS generator:
+// result_kind=projection, owner-confirmation gated downstream — value accrues to
+// work_sessions only from confirmed labor, never from the delta alone.
+// ============================================================================
+const CLUSTER: AttributeDefinition[] = [
+  {
+    attribute: "cluster.work_transition",
+    subject_kind: "cluster",
+    result_kind: "projection",
+    layer: 5,
+    modalities: ["image", "context_atoms"],
+    // Consumes the state atoms on THIS work_session's images and on the prior
+    // work_session (same vehicle_id, previous session_date). Dependency is
+    // encoded in the prompt rather than via depends_on because the per-image
+    // condition atoms live in ai_scan_metadata, not declared as registry attrs.
+    prompt:
+      "You are given two consecutive work_sessions for one vehicle, ordered by " +
+      "session_date: THIS session (subject_id) and the prior session for the same " +
+      "vehicle_id. For each, you have the member photos (vehicle_images where " +
+      "work_session_id = the session) and their already-extracted state atoms from " +
+      "ai_scan_metadata.byok_deep_analysis.state_observations (rust_severity, " +
+      "paint_state, completeness, build_phase_guess, damage_callouts, scene_type). " +
+      "Diff them and return the TRANSITION: { state_before, state_after, change_type " +
+      "one of [teardown|repair|fabrication|surface_prep|paint|assembly|wiring|" +
+      "interior|diagnosis|none], zones_changed[], evidence_image_ids[], confidence }. " +
+      "Report ONLY change you can see across the pair. If nothing changed, return " +
+      "change_type='none'. Do NOT estimate labor hours or value — that is decided " +
+      "by owner confirmation downstream, not by you. If there is no prior session or " +
+      "the pair is not comparable (different vehicle/zone), return null.",
+    expected_shape: "structured",
+    prompt_version: "v1",
+  },
+];
+
+const REGISTRY: AttributeDefinition[] = [...L1, ...L2, ...L3, ...L4, ...L5, ...USER, ...COMPOUND, ...CLUSTER];
 
 const BY_NAME: Record<string, AttributeDefinition> = Object.fromEntries(
   REGISTRY.map((a) => [a.attribute, a])
@@ -523,6 +870,85 @@ export function getAttribute(name: string): AttributeDefinition | null {
 
 export function listAttributes(): string[] {
   return REGISTRY.map((a) => a.attribute);
+}
+
+// ── Evidence-class binding (authoritative table) ─────────────────────────────
+// One auditable block (Skylar's call: registry code is source of truth, not a DB
+// table). Attributes whose definitions carry an inline `admissible_evidence` win;
+// this map covers the rest. The anti-laundering invariant to eyeball here: no
+// spec fact (hp/torque/displacement/codes) lists "image".
+const ADMISSIBLE_EVIDENCE: Record<string, EvidenceClass[]> = {
+  // Pure vision tasks — only a photo can answer them.
+  "image.has_vehicle": ["image"],
+  "image.classification": ["image"],
+  "image.vehicle_bboxes": ["image"],
+  "image.ocr_regions": ["image"],
+  "image.location_class": ["image"],
+  "image.in_progress_work": ["image"],
+  "image.likely_vehicle_id": ["image", "context_atoms"],
+  "vehicle.viewpoint": ["image"],
+  "vehicle.vin_visible": ["image"],
+  "vehicle.plate_redacted": ["image"],
+  // Identity — establishable from a badge (image), the VIN, a document, or the owner.
+  "vehicle.year_range": ["image", "vin_decode", "document", "owner_claim"],
+  "vehicle.make": ["image", "vin_decode", "document", "owner_claim"],
+  "vehicle.model": ["image", "vin_decode", "document", "owner_claim"],
+  // Observed present-state — what a photo (or the owner) shows now.
+  "vehicle.exterior_color": ["image", "owner_claim"],
+  "vehicle.condition_cues": ["image", "owner_claim"],
+  "vehicle.modifications": ["image", "owner_claim"],
+  // Mileage — read off the odometer (image), a title/service doc, or owner.
+  "vehicle.odometer_reading": ["image", "document", "owner_claim"],
+  // Artifacts — documents (optionally photographed).
+  "vehicle.invoice_artifact": ["document", "image"],
+  "vehicle.work_log_artifact": ["document", "image", "owner_claim"],
+  // User / cluster — substrate joins over Nuke's own attributed graph.
+  "user.has_profile": ["context_atoms"],
+  "user.display_identity": ["context_atoms", "owner_claim"],
+  "user.contact_surface": ["context_atoms", "owner_claim"],
+  "user.role_set": ["context_atoms", "owner_claim"],
+  "user.possession_set": ["context_atoms"],
+  "user.vendor_preference_signal": ["context_atoms"],
+  "user.daily_activity_density": ["context_atoms"],
+  "user.relationship_map": ["context_atoms"],
+  "cluster.work_transition": ["context_atoms", "image"],
+};
+
+/**
+ * Resolve the admissible evidence classes for an attribute:
+ *   1. inline `admissible_evidence` on the definition (spec attrs use this)
+ *   2. the ADMISSIBLE_EVIDENCE table
+ *   3. a conservative default derived from modalities (image→[image,owner_claim],
+ *      else [context_atoms]) — never silently confers vin_decode/document.
+ * Returns [] for an unknown attribute (caller treats as reject).
+ */
+export function admissibleEvidence(attribute: string): EvidenceClass[] {
+  const def = BY_NAME[attribute];
+  if (!def) return [];
+  if (def.admissible_evidence && def.admissible_evidence.length) return def.admissible_evidence;
+  if (ADMISSIBLE_EVIDENCE[attribute]) return ADMISSIBLE_EVIDENCE[attribute];
+  return def.modalities.includes("image") ? ["image", "owner_claim"] : ["context_atoms"];
+}
+
+/**
+ * The anti-laundering gate. Returns null if `evidenceClass` may legitimately cite
+ * `attribute`, else an error string. This is what makes a photo-cited horsepower
+ * claim fail: "image" is not in horsepower's admissible set.
+ */
+export function validateEvidenceClass(
+  attribute: string,
+  evidenceClass: unknown,
+): string | null {
+  const def = BY_NAME[attribute];
+  if (!def) return `unknown attribute: ${attribute}`;
+  if (typeof evidenceClass !== "string" || !EVIDENCE_CLASSES.includes(evidenceClass as EvidenceClass)) {
+    return `unknown evidence class '${String(evidenceClass)}'; must be one of [${EVIDENCE_CLASSES.join(", ")}]`;
+  }
+  const adm = admissibleEvidence(attribute);
+  if (!adm.includes(evidenceClass as EvidenceClass)) {
+    return `evidence class '${evidenceClass}' is not admissible for ${attribute} (a ${evidenceClass} can't establish it); admissible: [${adm.join(", ")}]`;
+  }
+  return null;
 }
 
 /**

--- a/supabase/functions/_shared/connector-schema-regression.test.ts
+++ b/supabase/functions/_shared/connector-schema-regression.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Connector ↔ schema regression test.
+ *
+ * The recurring bug class: a tool query SELECTs a column that does not exist
+ * (vehicle_images.url → "column does not exist"; organizations.type vs business_type).
+ * This test pins every column the mcp-connector reads/writes against the LIVE
+ * information_schema, so a drift fails CI instead of a production tool call.
+ *
+ * Run: dotenvx run -f .env -f .env.local -- deno test --allow-env --allow-net \
+ *        supabase/functions/_shared/connector-schema-regression.test.ts
+ *
+ * Skips (does not fail) when SUPABASE_URL / SERVICE_ROLE_KEY are absent, so a
+ * secret-less CI lane is green; the dotenvx lane is the enforcing one.
+ */
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { assert } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+// Exact columns the connector depends on, per table. Keep in sync with the SELECTs in index.ts.
+// When you add a column to a connector query, add it here too.
+const REQUIRED: Record<string, string[]> = {
+  vehicle_images: [
+    "id", "image_url", "thumbnail_url", "medium_url", "large_url", "storage_path",
+    "angle", "condition_score", "photo_quality_score", "ai_processing_status",
+    "damage_flags", "modification_flags", "fabrication_stage", "vision_analyzed_at",
+    "created_at", "exif_data", "taken_at", "latitude", "longitude", "camera_pose", "caption",
+  ],
+  vehicles: [
+    "id", "year", "make", "model", "vin", "body_style", "color", "color_primary",
+    "displacement", "engine_displacement", "horsepower", "torque", "seats",
+    "canonical_outcome", "is_for_sale", "status",
+  ],
+  projection_event: [
+    "id", "request_envelope", "result_envelope", "result_kind", "model_id",
+    "model_caller", "prompt_sha256", "observation_ids", "observed_at", "recorded_at",
+  ],
+  model_registry: ["id", "slug", "provider", "version", "caller_kind", "base_trust", "last_seen"],
+  prompt_template_registry: ["prompt_sha256", "template_name", "template_body", "schema_hint", "last_used_at"],
+};
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+Deno.test({
+  name: "connector queries reference only columns that exist in the live schema",
+  ignore: !SUPABASE_URL || !SERVICE_ROLE_KEY,
+  async fn() {
+    const sb = createClient(SUPABASE_URL!, SERVICE_ROLE_KEY!, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+
+    // Exercise the SAME resolution path the connector uses: PostgREST column selection.
+    // A non-existent column (e.g. the old vehicle_images.url) makes PostgREST return error
+    // code 42703 — exactly the production failure this test guards against. limit(0) means
+    // no rows transferred; we only care whether the column list resolves.
+    const failures: string[] = [];
+    for (const [table, cols] of Object.entries(REQUIRED)) {
+      const { error } = await sb.from(table).select(cols.join(",")).limit(0);
+      if (error) failures.push(`${table}: ${error.message} (code ${error.code ?? "?"})`);
+    }
+
+    assert(
+      failures.length === 0,
+      `Connector column lists do not resolve against the live schema:\n  ${failures.join("\n  ")}`,
+    );
+  },
+});

--- a/supabase/functions/_shared/scopeGrammar.test.ts
+++ b/supabase/functions/_shared/scopeGrammar.test.ts
@@ -9,6 +9,8 @@ import {
   parseScope,
   scopeMatches,
   vinFromScope,
+  scopeAllowsWriteTier,
+  isWriteTierScope,
   type ScopeRequest,
 } from './scopeGrammar.ts';
 
@@ -197,4 +199,42 @@ Deno.test('scopeMatches: mixed grants — first matching wins', () => {
     `events:write:vehicle:${MUSTANG_VIN}`,
   ];
   if (!scopeMatches(granted, writeMustang)) throw new Error('expected match');
+});
+
+// ── Write-tier scopes (governed agent-write pipeline) ──────────────────────
+
+Deno.test('isWriteTierScope: recognizes tier scopes only', () => {
+  if (!isWriteTierScope('write:observations')) throw new Error('observations should be a tier scope');
+  if (!isWriteTierScope('write:canonical')) throw new Error('canonical should be a tier scope');
+  if (isWriteTierScope('read')) throw new Error('read is not a tier scope');
+  if (isWriteTierScope('events:write:all')) throw new Error('events scope is not a tier scope');
+});
+
+Deno.test('scopeAllowsWriteTier: write:observations is autonomous for observations, blocked for canonical', () => {
+  const t = ['read', 'write:observations'];
+  if (!scopeAllowsWriteTier(t, 'observations')) throw new Error('observations should be allowed');
+  if (scopeAllowsWriteTier(t, 'canonical')) throw new Error('canonical must be HUMAN-GATED — observations token cannot reach it');
+});
+
+Deno.test('scopeAllowsWriteTier: write:canonical subsumes observations', () => {
+  const t = ['write:canonical'];
+  if (!scopeAllowsWriteTier(t, 'canonical')) throw new Error('canonical scope → canonical');
+  if (!scopeAllowsWriteTier(t, 'observations')) throw new Error('canonical should subsume observations');
+});
+
+Deno.test('scopeAllowsWriteTier: admin allows every tier', () => {
+  if (!scopeAllowsWriteTier(['admin'], 'observations')) throw new Error('admin → observations');
+  if (!scopeAllowsWriteTier(['admin'], 'canonical')) throw new Error('admin → canonical');
+});
+
+Deno.test('scopeAllowsWriteTier: legacy "write" → observations only, never canonical', () => {
+  if (!scopeAllowsWriteTier(['write'], 'observations')) throw new Error('legacy write → observations');
+  if (scopeAllowsWriteTier(['write'], 'canonical')) throw new Error('legacy write must NOT confer canonical');
+});
+
+Deno.test('scopeAllowsWriteTier: read-only / empty / unknown never authorize writes', () => {
+  if (scopeAllowsWriteTier(['read'], 'observations')) throw new Error('read must not write');
+  if (scopeAllowsWriteTier([], 'observations')) throw new Error('empty must not write');
+  if (scopeAllowsWriteTier(null, 'canonical')) throw new Error('null must not write');
+  if (scopeAllowsWriteTier(['events:write:all'], 'observations')) throw new Error('events scope is a different resource, not a write tier');
 });

--- a/supabase/functions/_shared/scopeGrammar.ts
+++ b/supabase/functions/_shared/scopeGrammar.ts
@@ -151,3 +151,54 @@ export function scopeMatches(
 
   return false;
 }
+
+// ============================================================================
+// Write-tier scopes — the governed agent-write pipeline (v2, 2026-06)
+//
+// Grammar:
+//   write:observations  → append-only governed claims (projection_event / observations).
+//                         Autonomous: an external agent token carrying this can submit
+//                         evidence-cited claims with no human in the loop.
+//   write:canonical     → mutate a canonical field directly. HUMAN-GATED: only granted to a
+//                         token that passed owner login (or service-role). External / walk-in
+//                         tokens are clamped below this and can never escalate to it.
+//
+// Tier ladder: admin ⊃ write:canonical ⊃ write:observations.
+// Legacy "write" maps to write:observations ONLY (it must not silently confer canonical power).
+// ============================================================================
+
+export type WriteTier = 'observations' | 'canonical';
+
+const WRITE_TIER_SCOPES: ReadonlySet<string> = new Set([
+  'write:observations',
+  'write:canonical',
+]);
+
+/** True if `s` is a recognized write-tier scope string. */
+export function isWriteTierScope(s: string | null | undefined): boolean {
+  return typeof s === 'string' && WRITE_TIER_SCOPES.has(s.trim());
+}
+
+/**
+ * Does the granted scope set authorize writes at the requested tier?
+ *
+ *   admin              → any tier
+ *   write:canonical    → canonical AND observations (higher tier subsumes lower)
+ *   write:observations → observations only
+ *   legacy "write"     → observations only (never canonical)
+ *   read / events:*     → never authorize a write tier
+ */
+export function scopeAllowsWriteTier(
+  granted: readonly string[] | null | undefined,
+  tier: WriteTier,
+): boolean {
+  if (!granted || granted.length === 0) return false;
+  for (const raw of granted) {
+    const s = typeof raw === 'string' ? raw.trim() : '';
+    if (s === 'admin') return true;
+    if (s === 'write:canonical') return true; // subsumes observations
+    if (s === 'write:observations' && tier === 'observations') return true;
+    if (s === 'write' && tier === 'observations') return true; // legacy → observations only
+  }
+  return false;
+}

--- a/supabase/functions/mcp-connector/index.ts
+++ b/supabase/functions/mcp-connector/index.ts
@@ -4,8 +4,14 @@ import {
   getAttribute,
   getChecklist,
   validateSubmission,
+  validateEvidenceClass,
+  admissibleEvidence,
   type SubjectKind,
 } from "../_shared/cockpit/attribute-registry.ts";
+import {
+  scopeAllowsWriteTier,
+  type WriteTier,
+} from "../_shared/scopeGrammar.ts";
 
 // =============================================================================
 // NUKE MCP CONNECTOR — Full-Resolution Vehicle Digital Twin Access
@@ -120,23 +126,52 @@ function oauthServerMetadata(): Response {
   }), { headers: { ...CORS, "Content-Type": "application/json" } });
 }
 
+// Allowed scope universe for OAuth-issued tokens. read is implicit (read tools are public),
+// but we carry it for transparency. write:observations = autonomous governed claims.
+// write:canonical = direct canonical mutation, owner-login only.
+const ALLOWED_SCOPES = ["read", "write:observations", "write:canonical"];
+
+/**
+ * Compute the scope string to grant. Requested scopes are intersected with the allowed universe;
+ * a non-owner (external/walk-in) leg is clamped to strip write:canonical so it can never escalate.
+ * With nothing requested, owner login defaults to full power, external defaults to read + observations.
+ */
+function grantedScope(requested: string | null | undefined, ownerLogin: boolean): string {
+  const universe = ownerLogin ? ALLOWED_SCOPES : ALLOWED_SCOPES.filter((s) => s !== "write:canonical");
+  let grants: string[];
+  if (requested && requested.trim()) {
+    const want = requested.trim().split(/\s+/);
+    grants = universe.filter((s) => want.includes(s));
+    if (grants.length === 0) grants = ["read"]; // requested only unknown scopes → minimal
+  } else {
+    grants = ownerLogin ? universe.slice() : ["read", "write:observations"];
+  }
+  if (!grants.includes("read")) grants.unshift("read");
+  return grants.join(" ");
+}
+
 async function oauthAuthorize(req: Request): Promise<Response> {
   const url = new URL(req.url);
   const redirectUri = url.searchParams.get("redirect_uri");
   const state = url.searchParams.get("state");
   const codeChallenge = url.searchParams.get("code_challenge");
   const clientId = url.searchParams.get("client_id");
+  const requestedScope = url.searchParams.get("scope");
 
   if (!redirectUri) {
     return new Response("Missing redirect_uri", { status: 400, headers: CORS });
   }
 
-  // Generate auth code as signed JWT (stateless, 5-min expiry)
+  // This /authorize is the owner-login (single-owner, auto-approved) leg. Completing it IS the
+  // human gate, so the owner may be granted write:canonical. An external agent that wants an
+  // autonomous token requests a narrower scope (e.g. "read write:observations") and is clamped to
+  // it by grantedScope() below — it can never escalate to canonical.
   const code = await signJwt({
     type: "auth_code",
     client_id: clientId,
     redirect_uri: redirectUri,
     code_challenge: codeChallenge,
+    scope: grantedScope(requestedScope, /* ownerLogin */ true),
   }, 300);
 
   // Auto-approve (single-owner system) — redirect back with code
@@ -185,17 +220,22 @@ async function oauthToken(req: Request): Promise<Response> {
       }
     }
 
-    // Issue access token (90-day JWT)
+    // Issue access token (90-day JWT). Carry the scope minted at /authorize so the write-tier
+    // gate can enforce it. Fall back to read+observations for legacy auth codes lacking a scope.
+    const tokenScope = typeof payload.scope === "string" && payload.scope.trim()
+      ? payload.scope
+      : "read write:observations";
     const accessToken = await signJwt({
       type: "access_token",
       sub: payload.client_id || "claude-ai",
-      scope: "mcp:tools",
+      scope: tokenScope,
     }, 90 * 24 * 3600);
 
     return new Response(JSON.stringify({
       access_token: accessToken,
       token_type: "Bearer",
       expires_in: 90 * 24 * 3600,
+      scope: tokenScope,
     }), { headers: { ...CORS, "Content-Type": "application/json" } });
   }
 
@@ -237,6 +277,7 @@ async function hashApiKey(key: string): Promise<string> {
 interface AuthResult {
   ok: boolean;
   userId?: string;
+  scopes?: string[];
   error?: string;
   status?: number;
 }
@@ -249,17 +290,23 @@ async function authenticate(req: Request): Promise<AuthResult> {
   if (authHeader?.startsWith("Bearer ")) {
     const token = authHeader.slice(7);
     if (token === SERVICE_ROLE_KEY) {
-      return { ok: true, userId: "service-role" };
+      return { ok: true, userId: "service-role", scopes: ["admin"] };
     }
     const alt = Deno.env.get("SERVICE_ROLE_KEY");
     if (alt && token === alt) {
-      return { ok: true, userId: "service-role" };
+      return { ok: true, userId: "service-role", scopes: ["admin"] };
     }
 
-    // 1b. OAuth JWT access token
+    // 1b. OAuth JWT access token — carry its minted scope through to the write-tier gate.
     const jwt = await verifyJwt(token);
     if (jwt && jwt.type === "access_token") {
-      return { ok: true, userId: String(jwt.sub || "oauth-user") };
+      const scope = typeof jwt.scope === "string" ? jwt.scope : "";
+      // Legacy "mcp:tools" tokens predate the tier grammar; treat as read + observations
+      // (NOT canonical — tightening is intentional; canonical now needs an explicit grant).
+      const scopes = scope && scope !== "mcp:tools"
+        ? scope.split(/\s+/).filter(Boolean)
+        : ["read", "write:observations"];
+      return { ok: true, userId: String(jwt.sub || "oauth-user"), scopes };
     }
   }
 
@@ -282,7 +329,12 @@ async function authenticate(req: Request): Promise<AuthResult> {
           : "Invalid API key";
       return { ok: false, error: msg, status: data?.error === "rate_limit_exceeded" ? 429 : 401 };
     }
-    return { ok: true, userId: data.user_id || `agent:${data.agent_registration_id || "anon"}` };
+    // API-key scopes: honor a `scopes` array from the rate-limit RPC if present, else default to
+    // autonomous-observations (read + write:observations). Canonical needs an explicit grant.
+    const keyScopes = Array.isArray(data.scopes) && data.scopes.length
+      ? data.scopes.map((s: unknown) => String(s))
+      : ["read", "write:observations"];
+    return { ok: true, userId: data.user_id || `agent:${data.agent_registration_id || "anon"}`, scopes: keyScopes };
   }
 
   // 3. No auth — reject
@@ -723,6 +775,18 @@ const TOOLS: ToolDef[] = [
     },
   },
   {
+    name: "get_vehicle_wiki",
+    description:
+      "The finite-asset wiki for one VIN: a readable, fully-sourced page where every field is the weighted consensus of evidence-cited claims (evidence_class × contributor reputation × confidence × recency). Each cited field carries its value, citation, confidence, contributors, and any conflict (surfaced inline, never silently resolved). The canonical header is the denormalized cache; cited_fields are the live projection — the truth. This is the read-side product surface of the agent-write loop: a Wikipedia for one physical object, every line cited.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        vehicle_id: { type: "string", description: "Vehicle UUID" },
+      },
+      required: ["vehicle_id"],
+    },
+  },
+  {
     name: "get_attribute_checklist",
     description:
       "Return the checklist of attributes a caller agent can answer about a subject (image, vehicle, person, cluster). Each entry includes the prompt to run, the expected_shape of the answer, the L1–L5 layer, modality hints, and depends_on so callers can iterate in dependency order. " +
@@ -733,8 +797,8 @@ const TOOLS: ToolDef[] = [
       properties: {
         subject_kind: {
           type: "string",
-          enum: ["image", "vehicle", "person", "cluster"],
-          description: "What kind of subject the caller is observing",
+          enum: ["image", "vehicle", "person", "cluster", "user"],
+          description: "What kind of subject the caller is observing. 'user' added 2026-05-24 — exposes user.has_profile / display_identity / contact_surface / role_set / possession_set / vendor_preference_signal / daily_activity_density / relationship_map.",
         },
         layers: {
           type: "array",
@@ -759,9 +823,18 @@ const TOOLS: ToolDef[] = [
       type: "object",
       properties: {
         attribute: { type: "string", description: "Canonical attribute name from get_attribute_checklist (e.g. 'image.has_vehicle', 'vehicle.exterior_color')" },
-        subject_id: { type: "string", description: "UUID of the subject (vehicle_id, image_id, person_id, cluster_id) the answer applies to" },
-        subject_kind: { type: "string", enum: ["image", "vehicle", "person", "cluster"] },
+        subject_id: { type: "string", description: "UUID of the subject (vehicle_id, image_id, person_id, cluster_id, user_id) the answer applies to" },
+        subject_kind: { type: "string", enum: ["image", "vehicle", "person", "cluster", "user"] },
         value: { description: "The caller's answer. Shape must match the registry's expected_shape; enums must match enum_values; will be validated before insert." },
+        evidence: {
+          type: "object",
+          description: "REQUIRED. The citation backing this claim. {class, ref}. class must be one of the attribute's admissible_evidence (see get_attribute_checklist) — image | vin_decode | document | owner_claim | context_atoms. A photo cannot cite a VIN-decode fact (hp/torque/displacement); such a claim is rejected. ref points at the evidence: {image_ids:[...]} for image, {rule, vin} for vin_decode, {document_id|url, page} for document, {statement} for owner_claim.",
+          properties: {
+            class: { type: "string", enum: ["image", "vin_decode", "document", "owner_claim", "context_atoms"] },
+            ref: { description: "Structured reference to the cited evidence (object or non-empty string)." },
+          },
+          required: ["class", "ref"],
+        },
         model_slug: { type: "string", description: "Identifier for the caller's model (e.g. 'claude-opus-4-7-via-byok', 'gpt-4o-mini', 'custom-yolo-v8'). Used to attribute the projection." },
         model_version: { type: "string", description: "Optional version string for the caller's model" },
         confidence: { type: "number", description: "Caller's confidence in their answer, 0..1" },
@@ -770,7 +843,29 @@ const TOOLS: ToolDef[] = [
         basis_signals: { type: "array", description: "Optional list of signals the caller's reasoning fired on" },
         declared_observed_at: { type: "string", description: "Optional ISO-8601 timestamp when the caller's model produced the answer (defaults to now)" },
       },
-      required: ["attribute", "subject_id", "subject_kind", "value", "model_slug", "confidence"],
+      required: ["attribute", "subject_id", "subject_kind", "value", "evidence", "model_slug", "confidence"],
+    },
+  },
+  {
+    name: "confirm_work_session",
+    description:
+      "Owner-confirmation gate for the labor ledger. Turns an inferred work_session (status auto_inferred/completed — produced by the photo→labor pipeline or the dT cluster.work_transition operator, base_trust ~0.30) into an owner-confirmed FACT. Per the value-accrual rule, labor value reaches the ledger ONLY on confirm/amend, never from inference alone. " +
+      "decision='confirm' accepts the existing inferred numbers; 'amend' applies owner-supplied labor_hours/labor_rate/parts (recomputes total_job_cost); 'reject' records that no billable labor happened (no value; the row is NOT deleted). Sets work_sessions.status + finalized_at + metadata.owner_confirmation, and logs the decision as a high-trust projection_event atom (attribute cluster.work_transition_confirmed) for the audit trail.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        work_session_id: { type: "string", description: "UUID of the work_sessions row to confirm" },
+        decision: { type: "string", enum: ["confirm", "amend", "reject"], description: "confirm = accept inferred values; amend = override with owner numbers; reject = no billable labor (default: confirm)" },
+        confirmed_by: { type: "string", description: "Who confirmed (default 'skylar')" },
+        labor_hours: { type: "number", description: "Owner-supplied labor hours (amend)" },
+        labor_rate: { type: "number", description: "Owner-supplied $/hr (amend)" },
+        total_labor_cost: { type: "number", description: "Override labor cost directly (else hours*rate or existing)" },
+        total_parts_cost: { type: "number", description: "Override parts cost (amend)" },
+        zones_confirmed: { type: "array", items: { type: "string" }, description: "Zones the owner confirms work touched" },
+        source_projection_event_id: { type: "string", description: "The dT cluster.work_transition atom this confirms, if any (lineage)" },
+        note: { type: "string", description: "Optional owner note" },
+      },
+      required: ["work_session_id"],
     },
   },
   {
@@ -849,12 +944,12 @@ const TOOLS: ToolDef[] = [
   {
     name: "find_subjects_needing_atoms",
     description:
-      "Discovery surface for walk-in callers: given a subject_kind (image / vehicle), return subjects with thin atom coverage (fewer than min_atoms in projection_event). Activates the laser-tag harness at scale — any caller can hit this, get a worklist, run get_attribute_checklist for each subject, submit answers via submit_attribute_value. " +
-      "Without this, callers don't know where to start. With it, the entire third-party-LLM compute base can attack thin substrate spots in priority order. Defaults: subject_kind=image, min_atoms=3, limit=20, recent_only=true (last 90 days).",
+      "Discovery surface for walk-in callers: given a subject_kind (image / vehicle / user), return subjects with thin atom coverage (fewer than min_atoms in projection_event). Activates the laser-tag harness at scale — any caller can hit this, get a worklist, run get_attribute_checklist for each subject, submit answers via submit_attribute_value. " +
+      "Without this, callers don't know where to start. With it, the entire third-party-LLM compute base can attack thin substrate spots in priority order. Defaults: subject_kind=image, min_atoms=3, limit=20, recent_only=true (last 90 days). 'user' was added 2026-05-24 per Skylar directive — surfaces auth.users rows whose user-profile attributes (display_identity / contact_surface / role_set / possession_set / etc.) need filling.",
     inputSchema: {
       type: "object",
       properties: {
-        subject_kind: { type: "string", enum: ["image", "vehicle"], description: "What kind of subject to surface (default image)" },
+        subject_kind: { type: "string", enum: ["image", "vehicle", "user"], description: "What kind of subject to surface (default image)" },
         vehicle_id: { type: "string", description: "Optional vehicle UUID — for image discovery, scopes to a single build (uses composite index, fast). Without it, samples by primary key (no date sort)." },
         min_atoms: { type: "number", description: "Subjects with fewer than this many atoms qualify (default 3)" },
         limit: { type: "number", description: "Max subjects to return (default 20, max 200)" },
@@ -887,7 +982,7 @@ const TOOLS: ToolDef[] = [
       type: "object",
       properties: {
         subject_id: { type: "string" },
-        subject_kind: { type: "string", enum: ["image", "vehicle", "person", "cluster"] },
+        subject_kind: { type: "string", enum: ["image", "vehicle", "person", "cluster", "user"] },
         model_slug: { type: "string" },
         model_version: { type: "string" },
         declared_observed_at: { type: "string" },
@@ -899,12 +994,21 @@ const TOOLS: ToolDef[] = [
               attribute: { type: "string" },
               value: {},
               confidence: { type: "number" },
+              evidence: {
+                type: "object",
+                description: "REQUIRED per atom. {class, ref} — class must be admissible for the attribute (see get_attribute_checklist). Same anti-laundering rule as submit_attribute_value.",
+                properties: {
+                  class: { type: "string", enum: ["image", "vin_decode", "document", "owner_claim", "context_atoms"] },
+                  ref: {},
+                },
+                required: ["class", "ref"],
+              },
               candidates: { type: "array" },
               basis_signals: { type: "array" },
             },
-            required: ["attribute", "value", "confidence"],
+            required: ["attribute", "value", "confidence", "evidence"],
           },
-          description: "Array of atoms to submit. Each atom shares the subject + caller from the top-level params.",
+          description: "Array of atoms to submit. Each atom shares the subject + caller from the top-level params, and each carries its own evidence citation.",
         },
       },
       required: ["subject_id", "subject_kind", "model_slug", "atoms"],
@@ -2235,12 +2339,74 @@ async function handleSearchServiceManuals(args: Record<string, unknown>): Promis
 
 // ── Vision ──────────────────────────────────────────────────────────────────
 
+// Best-effort: flag a known image for re-analysis when vision is down. Pipeline-state only, never
+// a testimony-value overwrite. No-op if the URL isn't one of ours.
+// IMPORTANT: process-all-images-cron re-appraises images where ai_scan_metadata->appraiser->
+// primary_label IS NULL — NOT off ai_processing_status. So we must clear that gate (null out
+// ai_scan_metadata) for re-analysis to actually fire; the cron repopulates it on re-appraisal.
+async function queueImageForReanalysis(image_url: string): Promise<boolean> {
+  try {
+    const { data, error } = await sb()
+      .from("vehicle_images")
+      .update({ ai_scan_metadata: null, ai_processing_status: "pending" })
+      .eq("image_url", image_url)
+      .select("id");
+    return !error && (data?.length ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}
+
 async function handleAnalyzeImage(args: Record<string, unknown>): Promise<ToolResult> {
-  const data = await callEdgeApi("vision", "/analyze", "POST", {
-    image_url: args.image_url,
-    include_comps: args.include_comps ?? false,
+  const image_url = String(args.image_url ?? "");
+  if (!image_url) return toolErr("image_url is required");
+
+  // Retry with backoff on transient vision outages (YONO sidecar 503 / network). A vision outage
+  // must NOT block the rest of the agent loop — on persistent failure we degrade gracefully:
+  // queue the image and tell the caller to mark vision-dependent claims evidence_pending.
+  const delays = [0, 300, 900];
+  let lastErr = "";
+  for (let i = 0; i < delays.length; i++) {
+    if (delays[i]) await new Promise((r) => setTimeout(r, delays[i]));
+    try {
+      const res = await fetch(`${SUPABASE_URL}/functions/v1/api-v1-vision/analyze`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${SERVICE_ROLE_KEY}` },
+        body: JSON.stringify({ image_url, include_comps: args.include_comps ?? false }),
+      });
+      if (res.ok) {
+        const data = await res.json().catch(() => null) as Record<string, unknown> | null;
+        // The API can return 200 while the sidecar is down (source:"unavailable"). Treat as degraded.
+        if (data && data.source !== "unavailable" && data.status !== 503) {
+          return toolOk(data);
+        }
+        lastErr = "vision sidecar reported unavailable";
+      } else if (res.status < 500 && res.status !== 429) {
+        // Genuine client error (bad URL etc.) — not transient, don't retry.
+        const txt = await res.text();
+        return toolErr(`analyze_image failed (${res.status}): ${txt.slice(0, 300)}`);
+      } else {
+        lastErr = `vision returned ${res.status}`;
+      }
+    } catch (e) {
+      lastErr = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  const queued = await queueImageForReanalysis(image_url);
+  return toolOk({
+    source: "unavailable",
+    status: "vision_degraded",
+    evidence_status: "evidence_pending",
+    queued,
+    image_url,
+    error: lastErr,
+    guidance:
+      "Vision (YONO) is temporarily unavailable; this is not a hard failure. The image was " +
+      (queued ? "re-queued for analysis (ai_processing_status=pending)" : "not found in our store (pass a Nuke image_url to queue it)") +
+      ". Continue with non-vision work. Any image-class claim submitted now should carry low confidence " +
+      "and evidence_status=evidence_pending; it will be re-scored when vision recovers.",
   });
-  return toolOk(data);
 }
 
 async function handleIdentifyVehicleImage(args: Record<string, unknown>): Promise<ToolResult> {
@@ -2256,9 +2422,19 @@ async function handleQueryVehicleImages(args: Record<string, unknown>): Promise<
   const vid = String(args.vehicle_id);
   const limit = Math.min(Number(args.limit) || 20, 100);
 
+  // NOTE: vehicle_images has NO `url` column. Real columns are image_url / large_url /
+  // medium_url / thumbnail_url / safe_preview_url / source_url / storage_path. Selecting a
+  // non-existent column is the recurring bug class (cf. organizations.type→business_type).
+  // The connector-schema-regression test asserts every column below exists in information_schema.
+  //
+  // Context-rich by design: an external agent must "weigh in with the context of the profile
+  // wherein the image exists and the EXIF data" — so we ship EXIF + capture metadata (taken_at,
+  // GPS, camera_pose, caption) alongside the URLs. Authoritative EXIF still requires exiftool on
+  // the storage object (DB columns can lie — see feedback_exhaust_evidence_before_owner_eyes);
+  // exif_data here is the stored best-effort and is labeled as such in the response.
   let query = supabase
     .from("vehicle_images")
-    .select("id, url, angle, condition_score, photo_quality_score, ai_processing_status, damage_flags, modification_flags, fabrication_stage, vision_analyzed_at, created_at")
+    .select("id, image_url, thumbnail_url, medium_url, large_url, storage_path, angle, condition_score, photo_quality_score, ai_processing_status, damage_flags, modification_flags, fabrication_stage, vision_analyzed_at, created_at, exif_data, taken_at, latitude, longitude, camera_pose, caption")
     .eq("vehicle_id", vid)
     .order("created_at", { ascending: false })
     .limit(limit);
@@ -2269,7 +2445,49 @@ async function handleQueryVehicleImages(args: Record<string, unknown>): Promise<
 
   const { data, error } = await query;
   if (error) return toolErr(error.message);
-  return toolOk({ vehicle_id: vid, count: data?.length ?? 0, images: data || [] });
+
+  // Expose a stable `url` alias (= image_url) for callers/wiki while preserving the real columns,
+  // and split out a labeled exif block so the caller knows it's stored best-effort, not exiftool ground-truth.
+  const images = (data || []).map((r) => {
+    const row = r as Record<string, unknown>;
+    return {
+      ...row,
+      url: (row.image_url as string) ?? null,
+      exif: {
+        source: "stored_best_effort",
+        note: "Authoritative EXIF requires exiftool on the storage object; treat GPS/taken_at as priors, not proof.",
+        exif_data: row.exif_data ?? null,
+        taken_at: row.taken_at ?? null,
+        latitude: row.latitude ?? null,
+        longitude: row.longitude ?? null,
+        camera_pose: row.camera_pose ?? null,
+      },
+    };
+  });
+
+  // The agent must weigh in WITH the context of the profile the image lives in. Ship the parent
+  // profile alongside the images so analysis is grounded, never cross-associated to another vehicle.
+  const { data: veh } = await supabase
+    .from("vehicles")
+    .select("id, year, make, model, vin, body_style, color, color_primary, displacement, engine_displacement, horsepower, torque, seats, canonical_outcome, is_for_sale, status")
+    .eq("id", vid)
+    .maybeSingle();
+
+  return toolOk({
+    vehicle_id: vid,
+    profile_context: veh ?? null,
+    count: images.length,
+    images,
+    analysis_contract: "Submit findings via submit_attribute_value with an evidence citation. Image-class claims must cite image id(s); never cross-associate to another VIN.",
+  });
+}
+
+async function handleGetVehicleWiki(args: Record<string, unknown>): Promise<ToolResult> {
+  const vid = String(args.vehicle_id ?? "");
+  if (!vid) return toolErr("vehicle_id is required");
+  const { data, error } = await sb().rpc("vehicle_wiki", { p_vehicle_id: vid });
+  if (error) return toolErr(`vehicle_wiki failed: ${error.message}`);
+  return toolOk(data);
 }
 
 async function sha256Hex(input: string): Promise<string> {
@@ -2302,6 +2520,27 @@ async function handleSubmitAttributeValue(args: Record<string, unknown>): Promis
   }
   const validation = validateSubmission(attribute, value);
   if (validation) return toolErr(`invalid value for ${attribute}: ${validation}`);
+
+  // ── Evidence-class binding (anti-laundering) ───────────────────────────────
+  // Every claim must cite evidence whose class is admissible for the attribute.
+  // A photo-cited horsepower claim dies here: "image" ∉ admissible(vehicle.horsepower).
+  const evidence = args.evidence as { class?: unknown; ref?: unknown } | undefined;
+  if (!evidence || typeof evidence !== "object") {
+    return toolErr(
+      `evidence is required: pass evidence={class, ref}. Admissible classes for ${attribute}: [${admissibleEvidence(attribute).join(", ")}]`,
+    );
+  }
+  const evidenceClassErr = validateEvidenceClass(attribute, evidence.class);
+  if (evidenceClassErr) return toolErr(evidenceClassErr);
+  const evidence_class = String(evidence.class);
+  const evidence_ref = evidence.ref;
+  if (evidence_ref === undefined || evidence_ref === null ||
+      (typeof evidence_ref === "object" && Object.keys(evidence_ref as object).length === 0) ||
+      (typeof evidence_ref === "string" && evidence_ref.trim() === "")) {
+    return toolErr(
+      `evidence.ref is required and must point at the citation (e.g. {image_ids:[...]} for image, {rule, vin} for vin_decode, {document_id|url} for document, {statement} for owner_claim).`,
+    );
+  }
 
   const supabase = sb();
 
@@ -2409,6 +2648,8 @@ async function handleSubmitAttributeValue(args: Record<string, unknown>): Promis
       prompt_sha256,
       observation_ids,
       observed_at,
+      evidence_class,
+      evidence_ref,
     })
     .select("id, recorded_at")
     .single();
@@ -2425,10 +2666,144 @@ async function handleSubmitAttributeValue(args: Record<string, unknown>): Promis
     subject_id,
     subject_kind,
     result_kind: def.result_kind,
+    evidence_class,
+    evidence_ref,
     prompt_sha256,
     note: existingModel
       ? "Walk-in model previously registered. Reputation accumulates by survival rate of your projections."
       : "First submission from this model_slug. Auto-registered at base_trust=0.30. Future projections accumulate reputation.",
+  });
+}
+
+// Owner-confirmation gate: turn an inferred work_session (status auto_inferred/completed,
+// base_trust ~0.30) into an owner-confirmed FACT. Per the $410-for-a-text-to-dad rule,
+// value accrues to the ledger ONLY on owner confirm/amend — never from inference alone.
+// confirm = owner accepts the existing inferred numbers; amend = owner supplies corrected
+// hours/rate/parts (recomputes cost); reject = owner says no labor happened (no value, not
+// deleted). The decision is logged as a high-trust projection_event atom for the audit trail.
+async function handleConfirmWorkSession(args: Record<string, unknown>): Promise<ToolResult> {
+  const work_session_id = String(args.work_session_id ?? "");
+  const decision = String(args.decision ?? "confirm");
+  const confirmed_by = typeof args.confirmed_by === "string" ? args.confirmed_by : "skylar";
+  if (!work_session_id) return toolErr("work_session_id is required");
+  if (!["confirm", "amend", "reject"].includes(decision)) {
+    return toolErr(`decision must be confirm | amend | reject, got '${decision}'`);
+  }
+
+  const supabase = sb();
+
+  const { data: ws, error: wsErr } = await supabase
+    .from("work_sessions")
+    .select("id, vehicle_id, status, total_labor_cost, total_parts_cost, total_job_cost, labor_rate_per_hour, metadata, session_date")
+    .eq("id", work_session_id)
+    .maybeSingle();
+  if (wsErr) return toolErr(`work_sessions lookup failed: ${wsErr.message}`);
+  if (!ws) return toolErr(`work_session not found: ${work_session_id}`);
+
+  const now = new Date().toISOString();
+  const num = (v: unknown, fallback: number | null): number | null =>
+    v === undefined || v === null || v === "" || Number.isNaN(Number(v)) ? fallback : Number(v);
+
+  const amend = decision === "amend";
+  const labor_hours = num(args.labor_hours, null);
+  const labor_rate = num(args.labor_rate, (ws.labor_rate_per_hour as number | null) ?? null);
+  let total_labor_cost = num(args.total_labor_cost, (ws.total_labor_cost as number | null) ?? null);
+  if (amend && labor_hours != null && labor_rate != null) total_labor_cost = labor_hours * labor_rate;
+  const total_parts_cost = num(args.total_parts_cost, (ws.total_parts_cost as number | null) ?? null);
+  const total_job_cost = amend
+    ? (total_labor_cost ?? 0) + (total_parts_cost ?? 0)
+    : num(args.total_job_cost, (ws.total_job_cost as number | null) ?? null);
+
+  const zones_confirmed = Array.isArray(args.zones_confirmed) ? args.zones_confirmed : null;
+  const source_projection_event_id = typeof args.source_projection_event_id === "string" ? args.source_projection_event_id : null;
+  const note = typeof args.note === "string" ? args.note : null;
+
+  const newStatus = decision === "reject" ? "rejected" : "confirmed";
+  const prior = (ws.metadata && typeof ws.metadata === "object") ? ws.metadata as Record<string, unknown> : {};
+  const metadata = {
+    ...prior,
+    owner_confirmation: {
+      decision, confirmed_by, confirmed_at: now,
+      prior_status: ws.status, source_projection_event_id,
+      labor_hours, labor_rate, zones_confirmed, note,
+    },
+  };
+
+  const update: Record<string, unknown> = { status: newStatus, metadata };
+  if (decision !== "reject") {
+    update.finalized_at = now;
+    if (amend) {
+      update.total_labor_cost = total_labor_cost;
+      update.total_parts_cost = total_parts_cost;
+      update.total_job_cost = total_job_cost;
+      if (labor_rate != null) update.labor_rate_per_hour = labor_rate;
+    }
+  }
+  const { error: updErr } = await supabase.from("work_sessions").update(update).eq("id", work_session_id);
+  if (updErr) return toolErr(`work_sessions update failed: ${updErr.message}`);
+
+  // Owner decision is authoritative testimony — log it as a high-trust projection_event atom.
+  let confirmation_event_id: string | null = null;
+  let atomNote = "confirmation written to work_sessions";
+  try {
+    const ownerSlug = "owner-confirmation";
+    let model_id: string;
+    const { data: existing } = await supabase.from("model_registry").select("id").eq("slug", ownerSlug).maybeSingle();
+    if (existing) {
+      model_id = existing.id;
+      await supabase.from("model_registry").update({ last_seen: now }).eq("id", model_id);
+    } else {
+      const { data: ins, error: insErr } = await supabase.from("model_registry")
+        .insert({ slug: ownerSlug, provider: "owner", caller_kind: "platform", base_trust: 0.95, notes: "Owner-authoritative work-session confirmations (confirm_work_session)" })
+        .select("id").single();
+      if (insErr || !ins) throw new Error(insErr?.message ?? "model_registry insert failed");
+      model_id = ins.id;
+    }
+
+    const prompt_input = "cluster.work_transition_confirmed:v1:owner work-session confirmation";
+    const prompt_sha256 = "sha256:" + (await sha256Hex(prompt_input));
+    await supabase.from("prompt_template_registry").upsert({
+      prompt_sha256,
+      template_name: "cluster.work_transition_confirmed",
+      template_body: "Owner confirms / amends / rejects an inferred work session. Value accrues to the ledger only on confirm or amend.",
+      schema_hint: { expected_shape: "structured" },
+      last_used_at: now,
+    }, { onConflict: "prompt_sha256", ignoreDuplicates: false });
+
+    const token = await sha256Hex(`${ownerSlug}:${work_session_id}:${now}`);
+    const { data: ev, error: evErr } = await supabase.from("projection_event").insert({
+      request_envelope: { audience: "owner", subject_id: work_session_id, subject_kind: "cluster", attribute: "cluster.work_transition_confirmed", as_of: now },
+      result_envelope: {
+        label: { decision, total_labor_cost, total_parts_cost, total_job_cost, labor_hours, labor_rate, zones_confirmed, source_projection_event_id, vehicle_id: ws.vehicle_id, session_date: ws.session_date, confirmed_by },
+        confidence: decision === "reject" ? 0 : 1,
+        basis: { signals: ["owner_confirmation"], agent_version: `owner:${confirmed_by}`, applied_priors: ["owner_authoritative"] },
+        envelope: { model_id, model_caller: { kind: "platform", token }, observed_at: now, submitted_at: now },
+      },
+      result_kind: "substrate",
+      model_id,
+      model_caller: `owner:${confirmed_by}`,
+      prompt_sha256,
+      observation_ids: source_projection_event_id ? [source_projection_event_id] : [],
+      observed_at: now,
+    }).select("id").single();
+    if (evErr || !ev) throw new Error(evErr?.message ?? "no row");
+    confirmation_event_id = ev.id;
+    atomNote = "confirmation written to work_sessions + logged as projection_event atom";
+  } catch (e) {
+    atomNote = `work_sessions updated; confirmation atom skipped (${e instanceof Error ? e.message : String(e)})`;
+  }
+
+  return toolOk({
+    work_session_id,
+    vehicle_id: ws.vehicle_id,
+    decision,
+    new_status: newStatus,
+    prior_status: ws.status,
+    finalized_at: decision !== "reject" ? now : null,
+    total_job_cost: decision !== "reject" ? total_job_cost : null,
+    confirmation_event_id,
+    confirmed_by,
+    note: atomNote,
   });
 }
 
@@ -3311,6 +3686,7 @@ async function handleSubmitAttributeValues(args: Record<string, unknown>): Promi
       confidence: a.confidence,
       basis_signals: a.basis_signals,
       candidates: a.candidates,
+      evidence: a.evidence,
       declared_observed_at: args.declared_observed_at,
     });
     const text = single.content?.[0]?.type === "text" ? single.content[0].text : null;
@@ -3335,14 +3711,14 @@ async function handleSubmitAttributeValues(args: Record<string, unknown>): Promi
 }
 
 async function handleFindSubjectsNeedingAtoms(args: Record<string, unknown>): Promise<ToolResult> {
-  const subject_kind = (typeof args.subject_kind === "string" ? args.subject_kind : "image") as "image" | "vehicle";
+  const subject_kind = (typeof args.subject_kind === "string" ? args.subject_kind : "image") as "image" | "vehicle" | "user";
   const min_atoms = Math.max(0, Number(args.min_atoms) || 3);
   const limit = Math.min(Number(args.limit) || 20, 200);
   const recent_only = args.recent_only !== false;
   const attribute_filter = typeof args.attribute === "string" ? args.attribute : null;
 
-  if (!["image", "vehicle"].includes(subject_kind)) {
-    return toolErr(`subject_kind must be image or vehicle, got '${subject_kind}'`);
+  if (!["image", "vehicle", "user"].includes(subject_kind)) {
+    return toolErr(`subject_kind must be image, vehicle, or user, got '${subject_kind}'`);
   }
 
   const supabase = sb();
@@ -3363,19 +3739,30 @@ async function handleFindSubjectsNeedingAtoms(args: Record<string, unknown>): Pr
       candidatesQ = candidatesQ.eq("vehicle_id", vehicle_id_param).order("taken_at", { ascending: false });
       if (recent_only) candidatesQ = candidatesQ.gte("taken_at", ninetyDaysAgo);
     }
-  } else {
+  } else if (subject_kind === "vehicle") {
     candidatesQ = supabase
       .from("vehicles")
       .select("id, year, make, model")
       .order("created_at", { ascending: false })
       .limit(Math.min(limit * 5, 500));
     if (recent_only) candidatesQ = candidatesQ.gte("created_at", ninetyDaysAgo);
+  } else {
+    // subject_kind === "user" — surface auth.users that have minimal profile coverage.
+    // We query user_profiles (1:1 with auth.users post-2026-05-24 migration) so we get
+    // both the user_id and the existing display_name in one shot.
+    candidatesQ = supabase
+      .from("user_profiles")
+      .select("user_id, display_name, preferred_username, locale, timezone, created_at")
+      .order("updated_at", { ascending: false })
+      .limit(Math.min(limit * 5, 500));
   }
 
   const { data: candidates, error: candErr } = await candidatesQ;
   if (candErr) return toolErr(`candidate query: ${candErr.message}`);
 
-  const candIds = (candidates ?? []).map((c) => c.id);
+  // user_profiles uses user_id as PK; vehicles/vehicle_images use id.
+  const idField = subject_kind === "user" ? "user_id" : "id";
+  const candIds = (candidates ?? []).map((c: Record<string, any>) => c[idField]);
   if (candIds.length === 0) {
     return toolOk({ subject_kind, count: 0, subjects: [], note: "No candidate subjects matched the filters." });
   }
@@ -3397,7 +3784,7 @@ async function handleFindSubjectsNeedingAtoms(args: Record<string, unknown>): Pr
   }
 
   const needs = (candidates ?? [])
-    .map((c) => ({ ...c, atom_count: counts.get(c.id) ?? 0 }))
+    .map((c: Record<string, any>) => ({ ...c, atom_count: counts.get(c[idField]) ?? 0 }))
     .filter((c) => c.atom_count < min_atoms)
     .sort((a, b) => a.atom_count - b.atom_count)
     .slice(0, limit);
@@ -3492,8 +3879,8 @@ async function handleQuerySubjectAtoms(args: Record<string, unknown>): Promise<T
 
 async function handleGetAttributeChecklist(args: Record<string, unknown>): Promise<ToolResult> {
   const subject_kind = String(args.subject_kind ?? "") as SubjectKind;
-  if (!["image", "vehicle", "person", "cluster"].includes(subject_kind)) {
-    return toolErr(`subject_kind must be one of image | vehicle | person | cluster, got '${subject_kind}'`);
+  if (!["image", "vehicle", "person", "cluster", "user"].includes(subject_kind)) {
+    return toolErr(`subject_kind must be one of image | vehicle | person | cluster | user, got '${subject_kind}'`);
   }
   const layers = Array.isArray(args.layers)
     ? (args.layers as Array<unknown>)
@@ -3510,12 +3897,14 @@ async function handleGetAttributeChecklist(args: Record<string, unknown>): Promi
   return toolOk({
     subject_kind,
     count: checklist.length,
-    submission_endpoint: "submit_attribute_value (pending: Phase 1 §1.1 cockpit migration)",
+    submission_endpoint: "submit_attribute_value (LIVE — requires write:observations scope; each claim must carry an evidence citation whose class is admissible for the attribute)",
+    evidence_contract: "Each submit_attribute_value must carry evidence={class, ref}; class must be one of the attribute's admissible_evidence. A photo cannot cite a VIN-decode fact (hp/torque/displacement) — it will be rejected.",
     checklist: checklist.map((d) => ({
       attribute: d.attribute,
       layer: d.layer,
       result_kind: d.result_kind,
       modalities: d.modalities,
+      admissible_evidence: admissibleEvidence(d.attribute),
       depends_on: d.depends_on ?? [],
       prompt: d.prompt,
       expected_shape: d.expected_shape,
@@ -4518,12 +4907,15 @@ async function handlePrepareListing(
     ars = res.data;
   }
 
+  // Tier vocabulary single-sourced from compute_auction_readiness(): TIER_1_EXCEPTIONAL,
+  // TIER_2_COMPETITIVE, TIER_3_VIABLE, TIER_4_INCOMPLETE, DISCOVERY_ONLY.
+  const arsTier = (ars?.tier as string) || null;
   const tierWarning =
-    ars?.tier === "AUCTION_READY"
+    arsTier === "TIER_1_EXCEPTIONAL" || arsTier === "TIER_2_COMPETITIVE"
       ? null
-      : ars?.tier === "NEARLY_READY"
-        ? "Vehicle is NEARLY_READY — listing may have gaps. Review coaching plan."
-        : `Vehicle is ${ars?.tier || "UNKNOWN"} — not recommended for submission yet. Run get_coaching_plan first.`;
+      : arsTier === "TIER_3_VIABLE"
+        ? "Vehicle is TIER_3_VIABLE — listing-ready with minor gaps. Review coaching plan."
+        : `Vehicle is ${arsTier || "UNKNOWN"} — not recommended for submission yet. Run get_coaching_plan first.`;
 
   const { data: v, error: vErr } = await supabase
     .from("vehicles")
@@ -5572,9 +5964,11 @@ const TOOL_HANDLERS: Record<string, (args: Record<string, unknown>) => Promise<T
   analyze_image: handleAnalyzeImage,
   identify_vehicle_image: handleIdentifyVehicleImage,
   query_vehicle_images: handleQueryVehicleImages,
+  get_vehicle_wiki: handleGetVehicleWiki,
   get_attribute_checklist: handleGetAttributeChecklist,
   submit_attribute_value: handleSubmitAttributeValue,
   submit_attribute_values: handleSubmitAttributeValues,
+  confirm_work_session: handleConfirmWorkSession,
   query_subject_atoms: handleQuerySubjectAtoms,
   find_subjects_needing_atoms: handleFindSubjectsNeedingAtoms,
   synthesize_attribute: handleSynthesizeAttribute,
@@ -5760,21 +6154,25 @@ Deno.serve(async (req: Request) => {
   // pointing at the OAuth resource metadata. Claude.ai sees this and triggers the
   // OAuth flow at https://nuke.ag/oauth/authorize. After the user logs in via
   // magic link, Claude.ai gets a Bearer token that it includes on every retry.
-  const WRITE_TOOLS = new Set([
-    "submit_observation",
-    "submit_attribute_value",
-    "submit_attribute_values",
-    "submit_vehicle_event",
-    "create_profile",
-    "link_account",
-    "verify_account_link",
-    "ingest_photos",
-  ]);
+  // Write tools are tiered. Governed append-only claims need write:observations (autonomous for
+  // external agents). Canonical-record mutations (identity) need write:canonical, which is only
+  // grantable via owner login — an autonomous walk-in token can never reach them.
+  const WRITE_TIERS: Record<string, WriteTier> = {
+    submit_observation: "observations",
+    submit_attribute_value: "observations",
+    submit_attribute_values: "observations",
+    submit_vehicle_event: "observations",
+    ingest_photos: "observations",
+    create_profile: "canonical",
+    link_account: "canonical",
+    verify_account_link: "canonical",
+  };
   if (body.method === "tools/call") {
     const toolName = body?.params?.name as string | undefined;
     const authHeader = req.headers.get("Authorization");
     const apiKey = req.headers.get("X-API-Key");
-    const isWrite = toolName && WRITE_TOOLS.has(toolName);
+    const requiredTier: WriteTier | undefined = toolName ? WRITE_TIERS[toolName] : undefined;
+    const isWrite = Boolean(requiredTier);
 
     // If auth is provided, always validate it (so a bad key fails fast even on read tools).
     if (authHeader || apiKey) {
@@ -5790,6 +6188,16 @@ Deno.serve(async (req: Request) => {
               "WWW-Authenticate": `Bearer realm="nuke", resource_metadata="https://nuke.ag/.well-known/oauth-protected-resource"`,
             },
           },
+        );
+      }
+      // Authenticated, but does the token carry the required write tier?
+      if (requiredTier && !scopeAllowsWriteTier(auth.scopes, requiredTier)) {
+        const msg = requiredTier === "canonical"
+          ? `Tool '${toolName}' mutates a canonical record and requires the human-gated 'write:canonical' scope. Your token holds [${(auth.scopes ?? []).join(", ") || "none"}]. Submit your finding as a governed claim via submit_attribute_value / submit_observation (write:observations) instead — canonical fields are projected from claims, not written directly.`
+          : `Tool '${toolName}' requires the 'write:observations' scope. Your token holds [${(auth.scopes ?? []).join(", ") || "none"}]. Re-authorize requesting scope=write:observations.`;
+        return new Response(
+          JSON.stringify(rpcError(body.id, -32003, msg)),
+          { status: 403, headers: { ...CORS, "Content-Type": "application/json" } },
         );
       }
     } else if (isWrite) {

--- a/supabase/migrations/20260615000000_projection_event_evidence_class.sql
+++ b/supabase/migrations/20260615000000_projection_event_evidence_class.sql
@@ -1,0 +1,52 @@
+-- Phase 1 — evidence-class binding for the agent-write pipeline.
+--
+-- Every projection_event (governed agent claim) now carries the CLASS of evidence
+-- that cites it (image / vin_decode / document / owner_claim / context_atoms) and a
+-- structured reference to that evidence. The admissibility rule (a photo can't cite
+-- horsepower) is enforced in the connector against the registry binding; these columns
+-- make the citation queryable for the wiki view and for projection weighting (Phase 3).
+--
+-- Backfill is intentionally absent: existing rows predate the binding and stay NULL
+-- (testimony is append-only; we don't rewrite history). New claims must populate them.
+
+ALTER TABLE public.projection_event
+  ADD COLUMN IF NOT EXISTS evidence_class text,
+  ADD COLUMN IF NOT EXISTS evidence_ref   jsonb;
+
+COMMENT ON COLUMN public.projection_event.evidence_class IS
+  'Admissible evidence class that cites this claim: image | vin_decode | document | owner_claim | context_atoms. Enforced at submit time against the attribute registry binding (anti-laundering).';
+COMMENT ON COLUMN public.projection_event.evidence_ref IS
+  'Structured citation for the evidence: e.g. {image_ids:[...]} for image, {rule, vin} for vin_decode, {document_id|url, page} for document, {statement} for owner_claim.';
+
+-- The append-only freeze trigger enumerates the frozen columns by name. We extend it to
+-- cover the two new columns so a claim's citation can never be silently rewritten after the
+-- fact — the citation is as load-bearing as the value it backs.
+CREATE OR REPLACE FUNCTION public.projection_event_freeze_trigger()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+  IF (
+    NEW.id <> OLD.id OR
+    NEW.request_envelope <> OLD.request_envelope OR
+    NEW.result_envelope <> OLD.result_envelope OR
+    NEW.result_kind <> OLD.result_kind OR
+    NEW.model_id <> OLD.model_id OR
+    NEW.model_caller <> OLD.model_caller OR
+    NEW.prompt_sha256 <> OLD.prompt_sha256 OR
+    NEW.observation_ids <> OLD.observation_ids OR
+    NEW.observed_at <> OLD.observed_at OR
+    NEW.recorded_at <> OLD.recorded_at OR
+    NEW.evidence_class IS DISTINCT FROM OLD.evidence_class OR
+    NEW.evidence_ref   IS DISTINCT FROM OLD.evidence_ref
+  ) THEN
+    RAISE EXCEPTION 'projection_event rows are append-only.';
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+-- Queryable: "show me every image-cited claim for this vehicle", etc.
+CREATE INDEX IF NOT EXISTS idx_projection_event_evidence_class
+  ON public.projection_event (evidence_class)
+  WHERE evidence_class IS NOT NULL;

--- a/supabase/migrations/20260615010000_project_vehicle_color.sql
+++ b/supabase/migrations/20260615010000_project_vehicle_color.sql
@@ -1,0 +1,113 @@
+-- Phase 2 — time-varying color projection.
+--
+-- The `vehicles` color columns were written ad-hoc by extractors (no pipeline_registry
+-- owner), which is how a blue/black Mustang ended up with color_family='Red'. This makes
+-- the PROJECTION the owner: canonical color is recomputed FROM the evidence-cited claim set
+-- (vehicle.current_color / vehicle.original_color / vehicle.refinish_event atoms), with
+-- provenance. It supersedes the corrupt derived value instead of an agent raw-overwriting it.
+--
+-- Read-mostly: it only mutates vehicles when a current_color claim actually exists, and it
+-- stamps color_source='nuke_projection:claims' so the number carries its source DNA.
+
+CREATE OR REPLACE FUNCTION public.project_vehicle_color(p_vehicle_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_current        jsonb;
+  v_original       jsonb;
+  v_history        jsonb;
+  v_current_color  text;
+  v_original_color text;
+  v_family         text;
+  v_prior_color    text;
+  v_prior_family   text;
+BEGIN
+  -- Weighted pick (base_trust * confidence) of the current_color claims; latest breaks ties.
+  SELECT to_jsonb(t) INTO v_current FROM (
+    SELECT pe.result_envelope->'label' AS label, pe.evidence_class, pe.observed_at,
+           (COALESCE(mr.base_trust, 0.3) * COALESCE((pe.result_envelope->>'confidence')::numeric, 0.5)) AS weight
+    FROM projection_event pe
+    LEFT JOIN model_registry mr ON mr.id = pe.model_id
+    WHERE pe.request_envelope->>'subject_id' = p_vehicle_id::text
+      AND pe.request_envelope->>'attribute' = 'vehicle.current_color'
+      AND pe.retracted_at IS NULL
+    ORDER BY weight DESC, pe.observed_at DESC
+    LIMIT 1
+  ) t;
+
+  SELECT to_jsonb(t) INTO v_original FROM (
+    SELECT pe.result_envelope->'label' AS label, pe.evidence_class, pe.observed_at,
+           (COALESCE(mr.base_trust, 0.3) * COALESCE((pe.result_envelope->>'confidence')::numeric, 0.5)) AS weight
+    FROM projection_event pe
+    LEFT JOIN model_registry mr ON mr.id = pe.model_id
+    WHERE pe.request_envelope->>'subject_id' = p_vehicle_id::text
+      AND pe.request_envelope->>'attribute' = 'vehicle.original_color'
+      AND pe.retracted_at IS NULL
+    ORDER BY weight DESC, pe.observed_at DESC
+    LIMIT 1
+  ) t;
+
+  -- Full change history: every color/refinish atom, newest first, with its citation.
+  SELECT jsonb_agg(h ORDER BY h.observed_at DESC) INTO v_history FROM (
+    SELECT jsonb_build_object(
+             'attribute', pe.request_envelope->>'attribute',
+             'value', pe.result_envelope->'label',
+             'evidence_class', pe.evidence_class,
+             'evidence_ref', pe.evidence_ref,
+             'confidence', (pe.result_envelope->>'confidence'),
+             'observed_at', pe.observed_at
+           ) AS h, pe.observed_at
+    FROM projection_event pe
+    WHERE pe.request_envelope->>'subject_id' = p_vehicle_id::text
+      AND pe.request_envelope->>'attribute' IN
+          ('vehicle.current_color','vehicle.original_color','vehicle.refinish_event')
+      AND pe.retracted_at IS NULL
+  ) h;
+
+  -- Labels may be structured ({color, hex}) or a bare string.
+  v_current_color  := lower(COALESCE(v_current->'label'->>'color',  v_current->>'label'));
+  v_original_color := lower(COALESCE(v_original->'label'->>'color', v_original->>'label'));
+
+  v_family := CASE
+    WHEN v_current_color IS NULL THEN NULL
+    WHEN v_current_color ~ 'black|satin_black|gloss_black' THEN 'Black'
+    WHEN v_current_color ~ 'white|pearl' THEN 'White'
+    WHEN v_current_color ~ 'silver|gray|grey|gunmetal|raw_metal|primer' THEN 'Silver'
+    WHEN v_current_color ~ 'blue|turquoise|teal' THEN 'Blue'
+    WHEN v_current_color ~ 'red|maroon|burgundy' THEN 'Red'
+    WHEN v_current_color ~ 'green|olive' THEN 'Green'
+    WHEN v_current_color ~ 'yellow|gold' THEN 'Yellow'
+    WHEN v_current_color ~ 'orange' THEN 'Orange'
+    WHEN v_current_color ~ 'brown|tan|beige|bronze' THEN 'Brown'
+    ELSE initcap(split_part(v_current_color, '_', 1))
+  END;
+
+  -- Only the projection touches canonical color, and only when a claim backs it.
+  IF v_current_color IS NOT NULL THEN
+    SELECT color, color_family INTO v_prior_color, v_prior_family FROM vehicles WHERE id = p_vehicle_id;
+    UPDATE vehicles
+       SET color = initcap(replace(v_current_color, '_', ' ')),
+           color_family = v_family,
+           color_source = 'nuke_projection:claims'
+     WHERE id = p_vehicle_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'vehicle_id', p_vehicle_id,
+    'current_color', v_current_color,
+    'current_evidence_class', v_current->>'evidence_class',
+    'original_color', v_original_color,
+    'original_evidence_class', v_original->>'evidence_class',
+    'color_family', v_family,
+    'prior_canonical', jsonb_build_object('color', v_prior_color, 'color_family', v_prior_family),
+    'superseded_corrupt_family', (v_prior_family IS DISTINCT FROM v_family AND v_current_color IS NOT NULL),
+    'history', COALESCE(v_history, '[]'::jsonb)
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.project_vehicle_color(uuid) IS
+  'Phase 2: projects canonical vehicle color (current + family) from the evidence-cited claim set (current_color/original_color/refinish_event projection_event atoms). Owner of vehicles.color/color_family/color_source going forward; supersedes ad-hoc extractor writes. Returns the projection incl. original_color, change history, and whether it superseded a contradicted family.';

--- a/supabase/migrations/20260615020000_consensus_and_reputation.sql
+++ b/supabase/migrations/20260615020000_consensus_and_reputation.sql
@@ -1,0 +1,136 @@
+-- Phase 3 — attribution, confidence, reputation, conflict surfacing.
+--
+-- The north star is ACCURACY, and accuracy emerges at scale: anyone* can submit an
+-- evidence-cited claim, and the canonical value is the WEIGHTED CONSENSUS of all
+-- non-retracted claims — weighted by evidence class × contributor reputation × recency
+-- × corroboration. No single contributor (and no single bad actor) decides the truth;
+-- the crowd, weighted by earned trust, does. Contradictions surface as conflicts, never
+-- silently overwrite. A liar's claims accumulate as down-weighted liabilities against them.
+
+-- Evidence-class tier weight. Primary evidence (a document, a VIN decode, a photo of the
+-- thing) outweighs an owner's bare assertion, which is upgradable but lowest.
+CREATE OR REPLACE FUNCTION public.nuke_evidence_weight(p_class text)
+RETURNS numeric LANGUAGE sql IMMUTABLE AS $$
+  SELECT CASE p_class
+    WHEN 'document'      THEN 1.00
+    WHEN 'vin_decode'    THEN 1.00
+    WHEN 'image'         THEN 0.90
+    WHEN 'context_atoms' THEN 0.60
+    WHEN 'owner_claim'   THEN 0.45
+    ELSE 0.25  -- null / legacy / unknown class
+  END;
+$$;
+
+-- The consensus engine. Returns the weighted-winner value for one (subject, attribute),
+-- its support, corroboration (distinct contributors), whether it's CONFLICTED (a runner-up
+-- with comparable support), and the full candidate breakdown with per-contributor weights.
+CREATE OR REPLACE FUNCTION public.project_attribute(p_subject_id uuid, p_attribute text)
+RETURNS jsonb LANGUAGE plpgsql STABLE AS $$
+DECLARE v jsonb;
+BEGIN
+  WITH atoms AS (
+    SELECT pe.id,
+           pe.result_envelope->'label'             AS label,
+           pe.result_envelope->>'label'            AS label_text,
+           pe.evidence_class,
+           COALESCE((pe.result_envelope->>'confidence')::numeric, 0.5) AS confidence,
+           COALESCE(mr.base_trust, 0.3)            AS actor_trust,
+           COALESCE(mr.slug, 'unknown')           AS actor,
+           pe.observed_at,
+           greatest(0.3, 1.0 - (extract(epoch FROM (now() - pe.observed_at)) / (3*365*86400.0))) AS recency
+    FROM projection_event pe
+    LEFT JOIN model_registry mr ON mr.id = pe.model_id
+    WHERE pe.request_envelope->>'subject_id' = p_subject_id::text
+      AND pe.request_envelope->>'attribute'  = p_attribute
+      AND pe.retracted_at IS NULL
+  ),
+  weighted AS (
+    SELECT *, public.nuke_evidence_weight(evidence_class) * actor_trust * confidence * recency AS weight
+    FROM atoms
+  ),
+  tally AS (
+    SELECT label_text, min(label::text)::jsonb AS label,
+           sum(weight) AS support, count(*) AS n, count(DISTINCT actor) AS distinct_actors,
+           jsonb_agg(jsonb_build_object(
+             'actor', actor, 'evidence_class', evidence_class,
+             'confidence', confidence, 'weight', round(weight, 4), 'observed_at', observed_at
+           ) ORDER BY weight DESC) AS contributors
+    FROM weighted GROUP BY label_text
+  ),
+  ranked AS (SELECT *, row_number() OVER (ORDER BY support DESC) AS rk FROM tally)
+  SELECT jsonb_build_object(
+    'subject_id', p_subject_id,
+    'attribute', p_attribute,
+    'consensus', (SELECT label FROM ranked WHERE rk = 1),
+    'consensus_support', (SELECT round(support, 4) FROM ranked WHERE rk = 1),
+    'total_support', (SELECT round(coalesce(sum(support),0), 4) FROM tally),
+    'corroboration', (SELECT distinct_actors FROM ranked WHERE rk = 1),
+    'distinct_values', (SELECT count(*) FROM tally),
+    'observation_count', (SELECT coalesce(sum(n),0) FROM tally),
+    'conflict', COALESCE(
+      (SELECT (SELECT support FROM ranked WHERE rk = 2)
+              / NULLIF((SELECT support FROM ranked WHERE rk = 1), 0) > 0.5), false),
+    'candidates', (SELECT jsonb_agg(jsonb_build_object(
+        'value', label, 'support', round(support, 4),
+        'distinct_actors', distinct_actors, 'contributors', contributors
+      ) ORDER BY support DESC) FROM tally)
+  ) INTO v;
+  RETURN v;
+END;
+$$;
+
+-- Reputation movement. A contributor's trust rises when its claims AGREE with the weighted
+-- consensus of OTHER contributors, and falls when it contradicts them. Only claims that have
+-- peers (corroboration possible) move the needle — a lone voice stays at base. This is what
+-- makes the open write API safe: bad actors get tracked and down-weighted, reversibly.
+-- NOTE: OUT params are prefixed (o_*) and CTE columns aliased to avoid plpgsql name
+-- collisions with table columns (model_id/slug). full_consensus is the WEIGHTED consensus
+-- over ALL claims (incl. self) — evidence weighting means a lone low-tier claim can't tip it.
+DROP FUNCTION IF EXISTS public.recompute_model_reputation(uuid);
+CREATE FUNCTION public.recompute_model_reputation(p_model_id uuid DEFAULT NULL)
+RETURNS TABLE(o_model_id uuid, o_slug text, o_new_trust numeric, o_agreements bigint, o_disagreements bigint)
+LANGUAGE plpgsql AS $$
+BEGIN
+  RETURN QUERY
+  WITH my_claims AS (
+    SELECT pe.id, pe.model_id AS mid,
+           pe.request_envelope->>'subject_id' AS subject_id,
+           pe.request_envelope->>'attribute'  AS attribute,
+           pe.result_envelope->>'label'       AS my_label
+    FROM projection_event pe
+    WHERE pe.retracted_at IS NULL
+      AND (p_model_id IS NULL OR pe.model_id = p_model_id)
+      AND pe.model_id IS NOT NULL
+  ),
+  judged AS (
+    SELECT c.mid,
+           (public.project_attribute(c.subject_id::uuid, c.attribute)->>'consensus') AS full_consensus,
+           c.my_label,
+           (SELECT count(DISTINCT pe2.model_id) FROM projection_event pe2
+             WHERE pe2.request_envelope->>'subject_id' = c.subject_id
+               AND pe2.request_envelope->>'attribute' = c.attribute
+               AND pe2.retracted_at IS NULL AND pe2.model_id <> c.mid) AS peers
+    FROM my_claims c
+  ),
+  scored AS (
+    SELECT mid,
+      count(*) FILTER (WHERE peers > 0 AND full_consensus = my_label)  AS agr,
+      count(*) FILTER (WHERE peers > 0 AND full_consensus <> my_label) AS dis
+    FROM judged GROUP BY mid
+  ),
+  upd AS (
+    UPDATE model_registry mr
+       SET base_trust = CASE WHEN s.agr + s.dis = 0 THEN mr.base_trust  -- no peers: unchanged
+             ELSE least(0.95, greatest(0.10, round(0.15 + 0.75 * (s.agr::numeric/(s.agr+s.dis)), 3))) END,
+           last_seen = now()
+      FROM scored s WHERE mr.id = s.mid
+      RETURNING mr.id AS rid, mr.slug AS rslug, mr.base_trust AS rtrust, s.agr AS ragr, s.dis AS rdis
+  )
+  SELECT upd.rid, upd.rslug, upd.rtrust, upd.ragr, upd.rdis FROM upd;
+END;
+$$;
+
+COMMENT ON FUNCTION public.project_attribute(uuid, text) IS
+  'Phase 3 consensus engine: weighted-consensus value for one (subject, attribute) over all non-retracted claims. weight = evidence_class × actor reputation × confidence × recency. Surfaces conflict (comparable runner-up) and full per-contributor breakdown. The read-side truth the wiki renders.';
+COMMENT ON FUNCTION public.recompute_model_reputation(uuid) IS
+  'Phase 3 reputation: moves model_registry.base_trust by agreement-with-peer-consensus rate. Claims without peers do not move trust. Down-weights contradicted contributors; reversible.';

--- a/supabase/migrations/20260615030000_vehicle_wiki_view.sql
+++ b/supabase/migrations/20260615030000_vehicle_wiki_view.sql
@@ -1,0 +1,94 @@
+-- Phase 4 — the finite-asset wiki.
+--
+-- A readable, fully-sourced page for one physical VIN. Every field is the weighted
+-- consensus of evidence-cited claims (project_attribute), carrying its citation, evidence
+-- class, confidence, contributors, and any conflict. The canonical header is the
+-- denormalized cache; cited_fields are the live projection — the actual truth the page renders.
+-- A Wikipedia for one physical object, maintained by agents, every line cited.
+
+CREATE OR REPLACE FUNCTION public.vehicle_wiki(p_vehicle_id uuid)
+RETURNS jsonb LANGUAGE plpgsql STABLE AS $$
+DECLARE v_header jsonb; v_fields jsonb;
+BEGIN
+  SELECT to_jsonb(t) INTO v_header FROM (
+    SELECT id, year, make, model, vin, body_style,
+           color, color_family, color_source,
+           horsepower, torque, displacement, seats,
+           canonical_outcome, is_for_sale, status
+    FROM vehicles WHERE id = p_vehicle_id
+  ) t;
+
+  SELECT jsonb_agg(public.project_attribute(p_vehicle_id, attr) ORDER BY attr) INTO v_fields
+  FROM (
+    SELECT DISTINCT request_envelope->>'attribute' AS attr
+    FROM projection_event
+    WHERE request_envelope->>'subject_id' = p_vehicle_id::text
+      AND retracted_at IS NULL
+  ) a;
+
+  RETURN jsonb_build_object(
+    'vehicle_id', p_vehicle_id,
+    'canonical', v_header,
+    'cited_fields', COALESCE(v_fields, '[]'::jsonb),
+    'field_count', COALESCE(jsonb_array_length(v_fields), 0),
+    'note', 'Each cited field is the weighted consensus of evidence-cited claims (evidence_class × contributor reputation × confidence × recency). Conflicts are surfaced inline, never silently resolved. Canonical header is the denormalized cache.'
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.vehicle_wiki(uuid) IS
+  'Phase 4 finite-asset wiki: full claim graph for one VIN as a readable, sourced page. Each field = project_attribute consensus with citation + confidence + contributors + conflict. Backs the get_vehicle_wiki MCP tool and the public wiki page.';
+
+-- Generic canonical projector: sync the denormalized spec columns FROM the claim consensus,
+-- with provenance. Only writes a column when a NON-CONFLICTED consensus claim backs it. This
+-- makes the canonical row a materialized projection of the claim set — never a hand-overwrite,
+-- which is the anti-pattern that produced color_family='Red' in the first place. Color routes
+-- through its dedicated projector (current/original/refinish + family).
+CREATE OR REPLACE FUNCTION public.project_vehicle_canonical(p_vehicle_id uuid)
+RETURNS jsonb LANGUAGE plpgsql AS $$
+DECLARE r record; applied jsonb := '[]'::jsonb; m jsonb; v text; conflict boolean;
+  col_map jsonb := '{"vehicle.horsepower":"horsepower","vehicle.torque":"torque","vehicle.displacement":"displacement","vehicle.seat_count":"seats"}';
+  col text;
+BEGIN
+  PERFORM public.project_vehicle_color(p_vehicle_id);
+
+  FOR r IN SELECT key AS attr, value::text AS column_name FROM jsonb_each_text(col_map) LOOP
+    m := public.project_attribute(p_vehicle_id, r.attr);
+    IF m->>'consensus' IS NULL THEN CONTINUE; END IF;
+    conflict := COALESCE((m->>'conflict')::boolean, false);
+    IF conflict THEN
+      applied := applied || jsonb_build_object('attribute', r.attr, 'skipped', 'conflict');
+      CONTINUE;
+    END IF;
+    v := m->>'consensus';
+    col := r.column_name;
+    IF col IN ('horsepower','torque','seats') THEN
+      EXECUTE format('UPDATE vehicles SET %I = $1::int WHERE id = $2', col) USING v, p_vehicle_id;
+    ELSE
+      EXECUTE format('UPDATE vehicles SET %I = $1 WHERE id = $2', col) USING v, p_vehicle_id;
+    END IF;
+    applied := applied || jsonb_build_object('attribute', r.attr, 'column', col, 'value', v);
+  END LOOP;
+
+  -- Market disposition maps one enum claim onto two canonical columns. A title/possession-backed
+  -- 'owner_retained'/'in_restoration' clears a contaminated auction-scrape 'sold'.
+  m := public.project_attribute(p_vehicle_id, 'vehicle.sale_disposition');
+  IF m->>'consensus' IS NOT NULL AND NOT COALESCE((m->>'conflict')::boolean, false) THEN
+    v := m->>'consensus';
+    UPDATE vehicles SET
+      canonical_outcome = CASE v WHEN 'sold' THEN 'sold' WHEN 'withdrawn' THEN 'withdrawn'
+                                 WHEN 'owner_retained' THEN 'owner_retained' WHEN 'in_restoration' THEN 'owner_retained'
+                                 ELSE canonical_outcome END,
+      is_for_sale = CASE v WHEN 'for_sale' THEN true WHEN 'sold' THEN false
+                           WHEN 'owner_retained' THEN false WHEN 'in_restoration' THEN false
+                           ELSE is_for_sale END
+    WHERE id = p_vehicle_id;
+    applied := applied || jsonb_build_object('attribute', 'vehicle.sale_disposition', 'disposition', v);
+  END IF;
+
+  RETURN jsonb_build_object('vehicle_id', p_vehicle_id, 'applied', applied);
+END;
+$$;
+
+COMMENT ON FUNCTION public.project_vehicle_canonical(uuid) IS
+  'Phase 4: materializes the denormalized vehicles spec columns (hp/torque/displacement/seats + color via project_vehicle_color) from the non-conflicted claim consensus, with provenance. Canonical = projection of claims, not hand-overwrite. Skips conflicted fields.';

--- a/supabase/migrations/20260615040000_flag_suspicious_claims.sql
+++ b/supabase/migrations/20260615040000_flag_suspicious_claims.sql
@@ -1,0 +1,80 @@
+-- Bad-actor detection — the point of the whole thing.
+--
+-- People butter up asset books when selling (inflate hp, roll back miles, fake provenance).
+-- A working evidence+reputation system makes that EASY to catch: the liar's self-serving claim
+-- contradicts the weighted-evidence consensus, and the contradiction is the tell. This surface
+-- scores exactly that pattern — a low-trust contributor asserting a value that contradicts the
+-- higher-evidence consensus, weighted up when the asset is FOR SALE (motive) and when the claim
+-- INFLATES a value-bearing number (means). The fraud catches itself; we just rank the smoke.
+
+CREATE OR REPLACE FUNCTION public.flag_suspicious_claims(
+  p_vehicle_id uuid DEFAULT NULL,
+  p_min_score numeric DEFAULT 0.15
+)
+RETURNS TABLE(
+  vehicle_id uuid, attribute text, contributor text, contributor_trust numeric,
+  claimed jsonb, consensus jsonb, evidence_class text, for_sale boolean,
+  inflates boolean, suspicion_score numeric, reason text
+) LANGUAGE plpgsql STABLE AS $$
+BEGIN
+  RETURN QUERY
+  WITH claims AS (
+    SELECT pe.id,
+           (pe.request_envelope->>'subject_id')::uuid AS vid,
+           pe.request_envelope->>'attribute' AS attr,
+           pe.result_envelope->'label'  AS claimed_label,
+           pe.result_envelope->>'label' AS claimed_text,
+           pe.evidence_class,
+           COALESCE(mr.slug,'unknown') AS contributor,
+           COALESCE(mr.base_trust,0.3) AS trust
+    FROM projection_event pe
+    LEFT JOIN model_registry mr ON mr.id = pe.model_id
+    WHERE pe.retracted_at IS NULL
+      AND (p_vehicle_id IS NULL OR pe.request_envelope->>'subject_id' = p_vehicle_id::text)
+  ),
+  judged AS (
+    SELECT c.*,
+           public.project_attribute(c.vid, c.attr) AS proj,
+           v.is_for_sale,
+           -- peers exist?
+           (SELECT count(DISTINCT pe2.model_id) > 1 FROM projection_event pe2
+             WHERE pe2.request_envelope->>'subject_id' = c.vid::text
+               AND pe2.request_envelope->>'attribute' = c.attr
+               AND pe2.retracted_at IS NULL) AS has_peers
+    FROM claims c
+    JOIN vehicles v ON v.id = c.vid
+  ),
+  scored AS (
+    SELECT j.vid, j.attr, j.contributor, j.trust, j.claimed_label,
+           j.proj->'consensus' AS consensus_label,
+           j.proj->>'consensus' AS consensus_text,
+           j.evidence_class, COALESCE(j.is_for_sale,false) AS for_sale,
+           j.claimed_text, j.has_peers,
+           -- numeric inflation (claim > consensus) where both parse as numbers
+           CASE WHEN j.claimed_text ~ '^-?\d+(\.\d+)?$' AND (j.proj->>'consensus') ~ '^-?\d+(\.\d+)?$'
+                THEN j.claimed_text::numeric > (j.proj->>'consensus')::numeric ELSE false END AS inflates
+    FROM judged j
+    WHERE j.has_peers
+      AND j.claimed_text IS DISTINCT FROM (j.proj->>'consensus')  -- contradicts consensus
+  )
+  SELECT s.vid, s.attr, s.contributor, round(s.trust,3),
+         s.claimed_label, s.consensus_label, s.evidence_class, s.for_sale, s.inflates,
+         round(
+           (1.0 - s.trust)                       -- low trust contributor
+           * (CASE WHEN s.inflates THEN 1.4 ELSE 1.0 END)  -- inflating a number = motive
+           * (CASE WHEN s.for_sale THEN 1.5 ELSE 1.0 END)  -- asset on the market = incentive
+         , 3) AS suspicion_score,
+         concat_ws('; ',
+           s.contributor || ' (trust ' || round(s.trust,2) || ') contradicts consensus',
+           CASE WHEN s.inflates THEN 'INFLATES the value' END,
+           CASE WHEN s.for_sale THEN 'on a FOR-SALE asset' END,
+           'cited as ' || COALESCE(s.evidence_class,'unclassified')
+         ) AS reason
+  FROM scored s
+  WHERE (1.0 - s.trust) * (CASE WHEN s.inflates THEN 1.4 ELSE 1.0 END) * (CASE WHEN s.for_sale THEN 1.5 ELSE 1.0 END) >= p_min_score
+  ORDER BY suspicion_score DESC;
+END;
+$$;
+
+COMMENT ON FUNCTION public.flag_suspicious_claims(uuid, numeric) IS
+  'Bad-actor catcher: ranks claims that contradict the weighted-evidence consensus, weighted up for low contributor trust, value inflation, and for-sale assets — the book-cooking signature. The fraud catches itself; this ranks the smoke. Owner/platform surface, not for external callers.';

--- a/supabase/migrations/20260615050000_retract_projection_event.sql
+++ b/supabase/migrations/20260615050000_retract_projection_event.sql
@@ -1,0 +1,37 @@
+-- Retraction primitive — the "reversible" in the abuse-resistance story.
+--
+-- Testimony is never deleted. To retract a claim we APPEND a retracting event (carrying the
+-- reason + a pointer to the target) and set the target's retracted_at/retracted_by at it. The
+-- marker SELF-retracts so every consensus/projection read (all filter `retracted_at IS NULL`)
+-- ignores it — it exists only as the FK target + audit reason. Owner/high-trust op; not exposed
+-- on the public MCP connector. Down-weighting handles bad actors at consensus time; this is the
+-- hard, auditable removal for confirmed-bad or test/demo atoms.
+
+CREATE OR REPLACE FUNCTION public.retract_projection_event(p_target uuid, p_reason text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE t record; v_retractor uuid; v_new uuid;
+BEGIN
+  SELECT * INTO t FROM projection_event WHERE id = p_target;
+  IF t.id IS NULL THEN RETURN jsonb_build_object('error','target not found'); END IF;
+  IF t.retracted_at IS NOT NULL THEN RETURN jsonb_build_object('error','already retracted','retracted_by',t.retracted_by); END IF;
+
+  INSERT INTO model_registry (slug, provider, caller_kind, base_trust, notes)
+  VALUES ('owner-retraction','owner','platform',0.95,'High-trust retraction actor')
+  ON CONFLICT (slug) DO UPDATE SET last_seen = now() RETURNING id INTO v_retractor;
+  IF v_retractor IS NULL THEN SELECT id INTO v_retractor FROM model_registry WHERE slug='owner-retraction'; END IF;
+
+  INSERT INTO projection_event (request_envelope, result_envelope, result_kind, model_id, model_caller, prompt_sha256, observed_at)
+  VALUES (
+    jsonb_build_object('subject_id', t.request_envelope->>'subject_id', 'attribute', t.request_envelope->>'attribute', 'op','retraction'),
+    jsonb_build_object('label','__retracted__','retracts', p_target, 'reason', p_reason, 'confidence', 1.0),
+    'projection', v_retractor, 'owner:retraction', t.prompt_sha256, now()
+  ) RETURNING id INTO v_new;
+
+  UPDATE projection_event SET retracted_by = v_new, retracted_at = now() WHERE id = p_target;  -- target
+  UPDATE projection_event SET retracted_by = v_new, retracted_at = now() WHERE id = v_new;      -- marker self-retracts
+  RETURN jsonb_build_object('retracted', p_target, 'by_event', v_new, 'reason', p_reason);
+END;
+$$;
+
+COMMENT ON FUNCTION public.retract_projection_event(uuid, text) IS
+  'Reversible retraction: appends a self-retracting marker event (testimony preserved) and points the target''s retracted_at/retracted_by at it. Owner/high-trust only.';

--- a/supabase/migrations/20260615060000_resort_image.sql
+++ b/supabase/migrations/20260615060000_resort_image.sql
@@ -1,0 +1,71 @@
+-- Image re-sorting — the general, unbiased "put the picture where it belongs" primitive.
+--
+-- Misattribution is routine, not radioactive: bulk photo-cascade attributes a whole camera roll
+-- to one vehicle, so frames of OTHER vehicles ride along. Re-homing one is just an operation, and
+-- it's the same operation for every image. Append-only (testimony is never deleted — lineage is
+-- recorded in merged_from_vehicle_id).
+--
+-- This is the APPLY-ARM for the existing detector `check-image-vehicle-match`, which flags strays
+-- (image_vehicle_match_status='mismatch', suggested_vehicle_id=<vehicle>) but has no direct apply.
+-- resort_image consumes that suggestion. Target resolution: explicit id > detector suggestion >
+-- demote to pool (NULL). Demote is a last resort — the cron skips null-vehicle images as
+-- low-signal, so they only get re-identified once the first-attribution drain exists
+-- (attribute_testimony, ISSUES.md). Prefer reattribution.
+--
+-- Re-analysis gate: process-all-images-cron re-appraises images where
+-- `ai_scan_metadata->appraiser->primary_label IS NULL`. Setting ai_processing_status alone does
+-- NOT re-trigger it. So we CLEAR that label here, so the moved image is re-appraised in its new
+-- vehicle's context.
+--
+-- SECURITY DEFINER so the sanctioned function does the write (the god-write hook guards raw agent
+-- UPDATEs to testimony; this is the approved path). Owner/platform only; not on the public MCP.
+
+CREATE OR REPLACE FUNCTION public.resort_image(p_image_id uuid, p_to_vehicle_id uuid, p_reason text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_from uuid; v_suggested uuid; v_target uuid;
+BEGIN
+  SELECT vehicle_id, suggested_vehicle_id INTO v_from, v_suggested FROM vehicle_images WHERE id = p_image_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('error','image not found'); END IF;
+
+  -- Resolve target: explicit > detector suggestion > demote-to-pool.
+  v_target := COALESCE(p_to_vehicle_id, v_suggested);
+
+  UPDATE vehicle_images
+     SET vehicle_id = v_target,
+         merged_from_vehicle_id = COALESCE(merged_from_vehicle_id, v_from),  -- lineage, first move only
+         -- clear the appraiser gate the cron watches → re-appraise in the new context
+         ai_scan_metadata = CASE WHEN ai_scan_metadata IS NULL THEN NULL
+                                 ELSE ai_scan_metadata #- '{appraiser,primary_label}' END,
+         ai_processing_status = 'pending',
+         -- detector reconciliation: a resolved move is confirmed; a pure demote is unrelated.
+         image_vehicle_match_status = CASE WHEN v_target IS NULL THEN 'unrelated' ELSE 'confirmed' END,
+         suggested_vehicle_id = NULL
+   WHERE id = p_image_id;
+
+  RETURN jsonb_build_object(
+    'image_id', p_image_id,
+    'moved_from', v_from,
+    'moved_to', v_target,
+    'used_suggestion', (p_to_vehicle_id IS NULL AND v_suggested IS NOT NULL),
+    'action', CASE WHEN v_target IS NULL THEN 'demoted_to_pool' ELSE 'reattributed' END,
+    'requeued', true,
+    'reason', p_reason
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.retag_image(p_image_id uuid, p_angle text, p_reason text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_old text;
+BEGIN
+  SELECT angle INTO v_old FROM vehicle_images WHERE id = p_image_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('error','image not found'); END IF;
+  UPDATE vehicle_images SET angle = p_angle WHERE id = p_image_id;
+  RETURN jsonb_build_object('image_id', p_image_id, 'angle_was', v_old, 'angle_now', p_angle, 'reason', p_reason);
+END;
+$$;
+
+COMMENT ON FUNCTION public.resort_image(uuid, uuid, text) IS
+  'General image re-sort + apply-arm for check-image-vehicle-match: reattribute to a vehicle (explicit id or the detector''s suggested_vehicle_id) else DEMOTE to pool. Append-only (lineage in merged_from_vehicle_id), clears the appraiser gate to re-appraise, sets image_vehicle_match_status. Sanctioned path; owner/platform only.';
+COMMENT ON FUNCTION public.retag_image(uuid, text, text) IS
+  'Fix a misclassified image angle in place (e.g. a title mistagged exterior_side -> document).';


### PR DESCRIPTION
Closes the external-agent correction loop end-to-end. An outside agent can read a vehicle profile, detect errors, run vision/VIN inference, and submit corrections as **evidence-cited, attributed, append-only claims** — canonical fields are *projected* from the claim set, never overwritten. Deployed to `mcp-connector` + 7 migrations (`20260615000000`–`060000`), proven on the 1966 Mustang `83f6f033`.

## What's in it
- **Phase 0 — unblock + context reads.** `query_vehicle_images` `url`→`image_url` fix (+ a `connector-schema-regression` test that pins every column to live PostgREST), now ships `profile_context` + labeled EXIF so agents analyze in-context. `analyze_image` health-gate/retry/graceful-degrade. OAuth write-tier scopes in `scopeGrammar` (`write:observations` autonomous, `write:canonical` human-gated).
- **Phase 1 — evidence binding.** Every claim cites admissible evidence; a photo can't cite horsepower. `projection_event.evidence_class/_ref` (+ freeze-trigger extended so citations are immutable).
- **Phase 2 — time-varying projection.** Color decomposed into `current`/`original`/`refinish_event`; `project_vehicle_color/_canonical` make canonical a projection of claims (kills the `color_family='Red'` corruption via supersession, not overwrite).
- **Phase 3 — consensus + reputation + abuse resistance.** `project_attribute` weighted consensus (evidence × reputation × recency × corroboration) with conflict surfacing; `recompute_model_reputation`; `flag_suspicious_claims` bad-actor catcher; `retract_projection_event` (append-only reversible).
- **Phase 4 — sourced view.** `vehicle_wiki` + `get_vehicle_wiki`.
- **Image re-sort.** `resort_image`/`retag_image` — the apply-arm for the existing `check-image-vehicle-match` detector (consumes `suggested_vehicle_id`, clears the appraiser gate so re-analysis fires). Proven: a stray Chevy frame auto-moved to its real R3500 record.

## Tests
`scopeGrammar` (29), evidence binding (11), `connector-schema-regression` (1) — all pass.

## Notes
- All 7 migrations are already applied + registered on `qkgaybvrernstplzjaam` (this PR is source-of-truth catch-up).
- `resort_image`'s reattribute arm overlaps the staged `attribute_testimony()` first-attribution primitive — reconcile (delegate) before scaling either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evidence-based claim validation supporting multiple evidence types (photo, VIN decoding, documents, owner claims)
  * Write-tier authorization system (observations vs. canonical levels) for scoped data access
  * Vehicle color history tracking with refinish event records replacing single color attribute
  * Vehicle wiki aggregating cited attribute claims with corroboration counts
  * Work session confirmation tool for recording owner-verified labor
  * Claim retraction system with reversible audit trail
  * Suspicious claim detection flagging contradictions and numeric inflation
  * Image repositioning and angle tagging tools for gallery management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->