### PR TITLE
Tier 1: BYOK vision resilience

### DIFF
--- a/supabase/functions/_shared/visionFallback.ts
+++ b/supabase/functions/_shared/visionFallback.ts
@@ -1,0 +1,175 @@
+// Cloud vision fallback — BYOK-native. Used ONLY when the free YONO sidecar is unavailable.
+//
+// ECONOMICS (per Skylar, 2026-06-16): Nuke does NOT fund cloud inference. The caller brings the
+// compute — their connected Claude / ChatGPT / Gemini subscription or key (stored in
+// `user_ai_providers`, resolved by getUserApiKey). They pay. Nuke owns the harness (YONO free
+// tier + the consensus engine); the caller owns the inference. A `system` env key is only a
+// temporary bootstrap pool and is reported as such so cost-bearer is always visible; the durable
+// path is: YONO (free) → the USER's connected provider (BYOK). Anthropic is a first-class tier
+// because "connect your Claude subscription" is a primary flow.
+//
+// When neither YONO nor a user key is available, callers should surface
+// "connect your AI subscription to enable analysis" rather than silently spending Nuke's money.
+
+import { callLLM, type LLMConfig } from "./llmProvider.ts";
+import { getUserApiKey } from "./getUserApiKey.ts";
+
+type Provider = "google" | "anthropic" | "openai";
+
+// Cheapest-first provider preference; each resolved BYOK-first via getUserApiKey.
+const PROVIDER_PREFS: Array<{ provider: Provider; model: string; env: string }> = [
+  { provider: "google", model: "gemini-2.0-flash-lite", env: "GOOGLE_AI_API_KEY" },
+  { provider: "anthropic", model: "claude-haiku-4-5-20251001", env: "ANTHROPIC_API_KEY" },
+  { provider: "openai", model: "gpt-4o-mini", env: "OPENAI_API_KEY" },
+];
+
+interface ResolvedTier extends LLMConfig { keySource: "user" | "system"; }
+
+// Resolve usable tiers for this caller. user-source tiers (BYOK — caller pays) rank ahead of any
+// system-pool tier (Nuke's temporary bootstrap). Returns [] if nothing is available.
+async function resolveTiers(supabase: unknown, userId: string | null): Promise<ResolvedTier[]> {
+  const tiers: ResolvedTier[] = [];
+  for (const p of PROVIDER_PREFS) {
+    try {
+      const r = await getUserApiKey(supabase, userId, p.provider, p.env);
+      if (r.apiKey) {
+        tiers.push({ provider: p.provider, model: r.modelName || p.model, apiKey: r.apiKey, source: r.source, keySource: r.source });
+      }
+    } catch {
+      // provider unavailable for this caller; skip
+    }
+  }
+  tiers.sort((a, b) => (a.keySource === "user" ? 0 : 1) - (b.keySource === "user" ? 0 : 1));
+  return tiers;
+}
+
+async function toImagePart(imageUrl: string): Promise<{ type: "image_url"; image_url: { url: string } }> {
+  try {
+    const resp = await fetch(imageUrl, { signal: AbortSignal.timeout(15_000) });
+    if (resp.ok) {
+      const buf = new Uint8Array(await resp.arrayBuffer());
+      let bin = "";
+      for (let i = 0; i < buf.length; i++) bin += String.fromCharCode(buf[i]);
+      const mime = resp.headers.get("content-type") || "image/jpeg";
+      return { type: "image_url", image_url: { url: `data:${mime};base64,${btoa(bin)}` } };
+    }
+  } catch {
+    // fall through to URL pass-through
+  }
+  return { type: "image_url", image_url: { url: imageUrl } };
+}
+
+function parseJson(content: string): unknown | null {
+  if (!content) return null;
+  let s = content;
+  const fence = content.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fence) s = fence[1].trim();
+  else {
+    const obj = content.match(/\{[\s\S]*\}/);
+    if (obj) s = obj[0];
+  }
+  try {
+    return JSON.parse(s);
+  } catch {
+    return null;
+  }
+}
+
+interface VisionResult { data: Record<string, unknown>; provider: string; model: string; keySource: "user" | "system"; ms: number; }
+
+async function runTiers(tiers: ResolvedTier[], messages: unknown[], maxTokens: number): Promise<VisionResult | null> {
+  for (const cfg of tiers) {
+    try {
+      const r = await callLLM(cfg, messages as never[], { temperature: 0.2, maxTokens, vision: true });
+      const data = parseJson(r.content || "");
+      if (data && typeof data === "object") {
+        return { data: data as Record<string, unknown>, provider: cfg.provider, model: cfg.model, keySource: cfg.keySource, ms: r.duration_ms ?? 0 };
+      }
+    } catch (e) {
+      console.warn(`[visionFallback] ${cfg.provider}/${cfg.model} (${cfg.keySource}) failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+  return null;
+}
+
+/** Single-image vision via the caller's BYOK provider. Null if no provider is available. */
+export async function cloudVisionJSON(
+  supabase: unknown,
+  userId: string | null,
+  opts: { systemPrompt?: string; userPrompt: string; imageUrl: string; maxTokens?: number },
+): Promise<VisionResult | null> {
+  const tiers = await resolveTiers(supabase, userId);
+  if (tiers.length === 0) return null;
+  const messages: unknown[] = [];
+  if (opts.systemPrompt) messages.push({ role: "system", content: opts.systemPrompt });
+  messages.push({ role: "user", content: [{ type: "text", text: opts.userPrompt }, await toImagePart(opts.imageUrl)] });
+  return runTiers(tiers, messages, opts.maxTokens ?? 800);
+}
+
+/** Multi-image (interleaved text + images) vision via the caller's BYOK provider. */
+export async function cloudVisionMultiJSON(
+  supabase: unknown,
+  userId: string | null,
+  opts: { systemPrompt?: string; parts: Array<{ text: string } | { imageUrl: string }>; maxTokens?: number },
+): Promise<VisionResult | null> {
+  const tiers = await resolveTiers(supabase, userId);
+  if (tiers.length === 0) return null;
+  const content: unknown[] = [];
+  for (const p of opts.parts) {
+    if ("text" in p) content.push({ type: "text", text: p.text });
+    else content.push(await toImagePart(p.imageUrl));
+  }
+  const messages: unknown[] = [];
+  if (opts.systemPrompt) messages.push({ role: "system", content: opts.systemPrompt });
+  messages.push({ role: "user", content });
+  return runTiers(tiers, messages, opts.maxTokens ?? 600);
+}
+
+export interface CloudAnalyzeResult {
+  make: string | null;
+  is_vehicle: boolean | null;
+  confidence: number;
+  vehicle_zone: string | null;
+  condition_score: number | null;
+  damage_flags: string[];
+  modification_flags: string[];
+  photo_quality: string | null;
+  provider: string;
+  model: string;
+  keySource: "user" | "system";
+  ms: number;
+}
+
+const ANALYZE_PROMPT = `You are a vehicle vision model. Look at the image and respond ONLY with valid JSON (no markdown):
+{
+  "is_vehicle": <true|false>,
+  "make": "<manufacturer or null>",
+  "confidence": <0.0-1.0 that make is correct>,
+  "vehicle_zone": "<one of: ext_front, ext_rear, ext_side, ext_three_quarter, interior_dashboard, interior_seats, engine_bay, undercarriage, wheel, detail, document, other>",
+  "condition_score": <1-5 where 5 is concours, 1 is project; null if not a vehicle>,
+  "damage_flags": [<"rust"|"dent"|"scratch"|"crack"|"missing_part"|... or empty>],
+  "modification_flags": [<"aftermarket_wheels"|"lowered"|"body_kit"|... or empty>],
+  "photo_quality": "<high|medium|low>"
+}`;
+
+/** Analyze an image via the caller's BYOK provider, shaped like the YONO /analyze response. */
+export async function cloudAnalyze(supabase: unknown, userId: string | null, imageUrl: string): Promise<CloudAnalyzeResult | null> {
+  const r = await cloudVisionJSON(supabase, userId, { userPrompt: ANALYZE_PROMPT, imageUrl, maxTokens: 600 });
+  if (!r) return null;
+  const d = r.data;
+  const arr = (v: unknown): string[] => (Array.isArray(v) ? v.map(String) : []);
+  return {
+    make: (d.make as string) ?? null,
+    is_vehicle: typeof d.is_vehicle === "boolean" ? d.is_vehicle : null,
+    confidence: typeof d.confidence === "number" ? d.confidence : 0.5,
+    vehicle_zone: (d.vehicle_zone as string) ?? null,
+    condition_score: typeof d.condition_score === "number" ? d.condition_score : null,
+    damage_flags: arr(d.damage_flags),
+    modification_flags: arr(d.modification_flags),
+    photo_quality: (d.photo_quality as string) ?? null,
+    provider: r.provider,
+    model: r.model,
+    keySource: r.keySource,
+    ms: r.ms,
+  };
+}

--- a/supabase/functions/api-v1-vision/index.ts
+++ b/supabase/functions/api-v1-vision/index.ts
@@ -38,6 +38,7 @@
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.0";
 import { authenticateRequest } from "../_shared/apiKeyAuth.ts";
+import { cloudAnalyze } from "../_shared/visionFallback.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -135,9 +136,9 @@ Deno.serve(async (req) => {
     const body = await req.json().catch(() => ({}));
 
     if (path === "classify") {
-      return await handleClassify(body, t0);
+      return await handleClassify(body, supabase, userId, t0);
     } else if (path === "analyze") {
-      return await handleAnalyze(body, supabase, t0);
+      return await handleAnalyze(body, supabase, userId, t0);
     } else if (path === "batch") {
       return await handleBatch(body, t0);
     } else {
@@ -156,7 +157,7 @@ Deno.serve(async (req) => {
 
 // ── /classify ─────────────────────────────────────────────────────────────
 
-async function handleClassify(body: any, t0: number): Promise<Response> {
+async function handleClassify(body: any, supabase: any, userId: string | null, t0: number): Promise<Response> {
   const { image_url, top_k = 5 } = body;
   if (!image_url) return json({ error: "Missing image_url" }, 400);
 
@@ -177,6 +178,25 @@ async function handleClassify(body: any, t0: number): Promise<Response> {
     });
   }
 
+  // YONO down → BYOK cloud fallback (the caller's connected provider; they pay).
+  const fb = await cloudAnalyze(supabase, userId, image_url);
+  if (fb) {
+    return json({
+      make: fb.make,
+      family: null,
+      family_confidence: null,
+      confidence: fb.confidence,
+      top5: [],
+      is_vehicle: fb.is_vehicle,
+      source: "cloud_fallback",
+      cloud_model: `${fb.provider}/${fb.model}`,
+      cost_bearer: fb.keySource, // 'user' = BYOK (they paid) | 'system' = Nuke bootstrap pool
+      ms: fb.ms,
+      cost_usd: null,
+      elapsed_ms: Date.now() - t0,
+    });
+  }
+
   return json({
     make: null,
     family: null,
@@ -186,7 +206,7 @@ async function handleClassify(body: any, t0: number): Promise<Response> {
     is_vehicle: null,
     source: "unavailable",
     cost_usd: 0,
-    error: "YONO vision service is temporarily unavailable. Retry later.",
+    error: "Vision unavailable: YONO sidecar is down and you have no connected AI provider. Connect your Claude/ChatGPT/Gemini subscription to enable analysis.",
     elapsed_ms: Date.now() - t0,
   }, 503);
 }
@@ -198,6 +218,7 @@ async function handleClassify(body: any, t0: number): Promise<Response> {
 async function handleAnalyze(
   body: any,
   supabase: any,
+  userId: string | null,
   t0: number
 ): Promise<Response> {
   const { image_url, include_comps = false } = body;
@@ -213,6 +234,42 @@ async function handleAnalyze(
   let comps: unknown[] | null = null;
   if (include_comps && classifyResult?.make && classifyResult.is_vehicle) {
     comps = await fetchComps(classifyResult.make, supabase);
+  }
+
+  // Both YONO calls failed → BYOK cloud fallback (the caller's connected provider) before giving up.
+  if (!classifyResult && !analyzeResult) {
+    const fb = await cloudAnalyze(supabase, userId, image_url);
+    if (fb) {
+      let fbComps: unknown[] | null = null;
+      if (include_comps && fb.make && fb.is_vehicle) fbComps = await fetchComps(fb.make, supabase);
+      return json({
+        make: fb.make,
+        family: null,
+        family_confidence: null,
+        confidence: fb.confidence,
+        top5: [],
+        is_vehicle: fb.is_vehicle,
+        vehicle_zone: fb.vehicle_zone,
+        zone_confidence: null,
+        zone_source: "cloud_fallback",
+        condition_score: fb.condition_score,
+        damage_flags: fb.damage_flags,
+        modification_flags: fb.modification_flags,
+        interior_quality: null,
+        photo_quality: fb.photo_quality,
+        photo_type: null,
+        comps: fbComps,
+        source: "cloud_fallback",
+        cost_bearer: fb.keySource, // 'user' = BYOK | 'system' = Nuke bootstrap pool
+        classify_model: `${fb.provider}/${fb.model}`,
+        analyze_model: `${fb.provider}/${fb.model}`,
+        classify_ms: fb.ms,
+        analyze_ms: fb.ms,
+        cost_usd: null,
+        elapsed_ms: Date.now() - t0,
+        image_url,
+      });
+    }
   }
 
   // Merge classify + analyze results into unified response

--- a/supabase/functions/check-image-vehicle-match/index.ts
+++ b/supabase/functions/check-image-vehicle-match/index.ts
@@ -1,6 +1,7 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { corsHeaders } from "../_shared/cors.ts";
+import { cloudVisionJSON, cloudVisionMultiJSON } from "../_shared/visionFallback.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -78,37 +79,17 @@ function isUnfetchableUrl(url: string): boolean {
 // ---------------------------------------------------------------------------
 
 async function buildVehicleSignature(
+  supabase: any,
+  userId: string | null,
   imageUrls: string[],
   vehicleDesc: string,
-  anthropicKey: string,
 ): Promise<VehicleSignature["signature"]> {
-  const imageContent = imageUrls
-    .filter((u) => !isNoiseUrl(u) && !isUnfetchableUrl(u))
-    .slice(0, 4)
-    .map((url) => ({
-      type: "image" as const,
-      source: { type: "url" as const, url },
-    }));
+  const usable = imageUrls.filter((u) => !isNoiseUrl(u) && !isUnfetchableUrl(u)).slice(0, 4);
+  if (usable.length === 0) return null;
 
-  if (imageContent.length === 0) return null;
-
-  const resp = await fetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers: {
-      "x-api-key": anthropicKey,
-      "anthropic-version": "2023-06-01",
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({
-      model: "claude-haiku-4-5-20251001",
-      max_tokens: 500,
-      messages: [{
-        role: "user",
-        content: [
-          ...imageContent,
-          {
-            type: "text",
-            text: `These photos are of: ${vehicleDesc}
+  const parts: Array<{ text: string } | { imageUrl: string }> = usable.map((imageUrl) => ({ imageUrl }));
+  parts.push({
+    text: `These photos are of: ${vehicleDesc}
 
 Describe this SPECIFIC vehicle's distinguishing visual features so it can be told apart from similar vehicles of the same make. Return ONLY valid JSON:
 {
@@ -120,22 +101,11 @@ Describe this SPECIFIC vehicle's distinguishing visual features so it can be tol
 }
 
 Be SPECIFIC about colors (not just "red" but "dark red/maroon metallic"). Focus on features that distinguish THIS vehicle from others of the same make/model/era.`,
-          },
-        ],
-      }],
-    }),
   });
 
-  if (!resp.ok) {
-    const errText = await resp.text();
-    throw new Error(`Signature API ${resp.status}: ${errText}`);
-  }
-
-  const data = await resp.json();
-  const text = data.content?.[0]?.text || "";
-  const jsonMatch = text.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) throw new Error(`No JSON in signature response: ${text.slice(0, 200)}`);
-  return JSON.parse(jsonMatch[0]);
+  const r = await cloudVisionMultiJSON(supabase, userId, { parts, maxTokens: 500 });
+  if (!r) throw new Error("vision unavailable: connect an AI provider (no user key; YONO sidecar down)");
+  return r.data as VehicleSignature["signature"];
 }
 
 // ---------------------------------------------------------------------------
@@ -143,9 +113,10 @@ Be SPECIFIC about colors (not just "red" but "dark red/maroon metallic"). Focus 
 // ---------------------------------------------------------------------------
 
 async function disambiguateImage(
+  supabase: any,
+  userId: string | null,
   imageUrl: string,
   candidates: VehicleSignature[],
-  anthropicKey: string,
 ): Promise<{
   assigned_label: string;
   vehicle_id: string;
@@ -155,7 +126,7 @@ async function disambiguateImage(
   reason: string;
 }> {
   // Build the context: reference images + text descriptions for each candidate
-  const content: any[] = [];
+  const parts: Array<{ text: string } | { imageUrl: string }> = [];
 
   // First, add reference images for each candidate (if available)
   const candidateDescriptions: string[] = [];
@@ -163,24 +134,18 @@ async function disambiguateImage(
     const desc = [c.year, c.make, c.model, c.trim].filter(Boolean).join(" ");
     let sigDesc = "";
     if (c.signature) {
-      const parts: string[] = [];
-      if (c.signature.paint_colors?.length) parts.push(`Paint: ${c.signature.paint_colors.join("/")}`);
-      if (c.signature.body_style) parts.push(`Body: ${c.signature.body_style}`);
-      if (c.signature.modifications?.length) parts.push(`Mods: ${c.signature.modifications.join(", ")}`);
-      if (c.signature.unique_features?.length) parts.push(`Unique: ${c.signature.unique_features.join(", ")}`);
-      sigDesc = parts.join(". ");
+      const sp: string[] = [];
+      if (c.signature.paint_colors?.length) sp.push(`Paint: ${c.signature.paint_colors.join("/")}`);
+      if (c.signature.body_style) sp.push(`Body: ${c.signature.body_style}`);
+      if (c.signature.modifications?.length) sp.push(`Mods: ${c.signature.modifications.join(", ")}`);
+      if (c.signature.unique_features?.length) sp.push(`Unique: ${c.signature.unique_features.join(", ")}`);
+      sigDesc = sp.join(". ");
     }
 
     // Add reference image if available
     if (c.reference_image_url && !isNoiseUrl(c.reference_image_url) && !isUnfetchableUrl(c.reference_image_url)) {
-      content.push({
-        type: "text",
-        text: `--- Reference photo for Vehicle ${c.label} (${desc}): ---`,
-      });
-      content.push({
-        type: "image",
-        source: { type: "url", url: c.reference_image_url },
-      });
+      parts.push({ text: `--- Reference photo for Vehicle ${c.label} (${desc}): ---` });
+      parts.push({ imageUrl: c.reference_image_url });
     }
 
     candidateDescriptions.push(
@@ -189,18 +154,11 @@ async function disambiguateImage(
   }
 
   // Add the image to classify
-  content.push({
-    type: "text",
-    text: "--- Image to classify: ---",
-  });
-  content.push({
-    type: "image",
-    source: { type: "url", url: imageUrl },
-  });
+  parts.push({ text: "--- Image to classify: ---" });
+  parts.push({ imageUrl });
 
   // The disambiguation prompt
-  content.push({
-    type: "text",
+  parts.push({
     text: `The owner of these vehicles needs help sorting photos into the correct vehicle profiles.
 
 CANDIDATE VEHICLES:
@@ -231,31 +189,11 @@ Return ONLY valid JSON:
 If you genuinely cannot tell which vehicle it is (e.g. extreme close-up of a generic part), use confidence < 0.3 and assign to the vehicle it's currently on.`,
   });
 
-  const resp = await fetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers: {
-      "x-api-key": anthropicKey,
-      "anthropic-version": "2023-06-01",
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({
-      model: "claude-haiku-4-5-20251001",
-      max_tokens: 400,
-      messages: [{ role: "user", content }],
-    }),
-  });
-
-  if (!resp.ok) {
-    const errText = await resp.text();
-    throw new Error(`Disambiguate API ${resp.status}: ${errText}`);
-  }
-
-  const data = await resp.json();
-  const text = data.content?.[0]?.text || "";
-  const jsonMatch = text.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) throw new Error(`No JSON in disambiguate response: ${text.slice(0, 200)}`);
-
-  const result = JSON.parse(jsonMatch[0]);
+  const r = await cloudVisionMultiJSON(supabase, userId, { parts, maxTokens: 400 });
+  if (!r) throw new Error("vision unavailable: connect an AI provider (no user key; YONO sidecar down)");
+  const result = r.data as {
+    assigned_label: string; confidence: number; distinguishing_features: string[]; image_type: string; reason: string;
+  };
 
   // Resolve label to vehicle_id
   const matched = candidates.find((c) => c.label === result.assigned_label);
@@ -270,9 +208,10 @@ If you genuinely cannot tell which vehicle it is (e.g. extreme close-up of a gen
 // ---------------------------------------------------------------------------
 
 async function classifyImage(
+  supabase: any,
+  userId: string | null,
   imageUrl: string,
   expectedVehicle: string,
-  anthropicKey: string,
 ): Promise<{
   is_vehicle: boolean;
   matches_expected: boolean;
@@ -281,23 +220,10 @@ async function classifyImage(
   confidence: number;
   reason: string;
 }> {
-  const resp = await fetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers: {
-      "x-api-key": anthropicKey,
-      "anthropic-version": "2023-06-01",
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({
-      model: "claude-haiku-4-5-20251001",
-      max_tokens: 300,
-      messages: [{
-        role: "user",
-        content: [
-          { type: "image", source: { type: "url", url: imageUrl } },
-          {
-            type: "text",
-            text: `Expected vehicle: ${expectedVehicle}
+  const r = await cloudVisionJSON(supabase, userId, {
+    imageUrl,
+    maxTokens: 300,
+    userPrompt: `Expected vehicle: ${expectedVehicle}
 
 Classify this image. Return ONLY valid JSON:
 {
@@ -314,22 +240,17 @@ Rules:
 - matches_expected: true ONLY if it matches the expected vehicle above (same make, model, similar year)
 - detected_vehicle: what vehicle is actually shown (null if not a vehicle)
 - Be strict: a Ford is not a BMW, a sedan is not an SUV`,
-          },
-        ],
-      }],
-    }),
   });
-
-  if (!resp.ok) {
-    const errText = await resp.text();
-    throw new Error(`Anthropic API ${resp.status}: ${errText}`);
-  }
-
-  const data = await resp.json();
-  const text = data.content?.[0]?.text || "";
-  const jsonMatch = text.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) throw new Error(`No JSON in response: ${text.slice(0, 200)}`);
-  return JSON.parse(jsonMatch[0]);
+  if (!r) throw new Error("vision unavailable: no cloud provider key (YONO sidecar also down)");
+  const d = r.data;
+  return {
+    is_vehicle: !!d.is_vehicle,
+    matches_expected: !!d.matches_expected,
+    detected_vehicle: (d.detected_vehicle as string) ?? null,
+    image_type: (d.image_type as string) ?? "unrelated",
+    confidence: typeof d.confidence === "number" ? d.confidence : 0.5,
+    reason: (d.reason as string) ?? "",
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -344,11 +265,12 @@ Deno.serve(async (req: Request) => {
   try {
     const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
     const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-    const anthropicKey = Deno.env.get("ANTHROPIC_API_KEY");
-    if (!anthropicKey) throw new Error("ANTHROPIC_API_KEY not configured");
 
     const supabase = createClient(supabaseUrl, serviceKey);
     const body: CheckRequest = await req.json();
+    // BYOK: vision runs on the vehicle owner's connected provider (they pay). Falls to the
+    // system bootstrap pool only if no user key. user_id is the owner whose photos we're sorting.
+    const userId = body.user_id ?? null;
     const mode = body.mode || "check";
     const batchSize = Math.min(body.batch_size || 10, 50);
     const dryRun = body.dry_run ?? false;
@@ -408,7 +330,7 @@ Deno.serve(async (req: Request) => {
         const imageUrls = sigImages.map((i: any) => i.image_url).filter(Boolean);
 
         try {
-          const signature = await buildVehicleSignature(imageUrls, desc, anthropicKey);
+          const signature = await buildVehicleSignature(supabase, userId, imageUrls, desc);
 
           if (!dryRun && signature) {
             await supabase
@@ -567,7 +489,7 @@ Deno.serve(async (req: Request) => {
 
       for (const img of imagesToCheck) {
         try {
-          const ai = await disambiguateImage(img.image_url, candidates, anthropicKey);
+          const ai = await disambiguateImage(supabase, userId, img.image_url, candidates);
 
           const isCurrentVehicle = ai.vehicle_id === body.vehicle_id;
           let status: MatchResult["status"];
@@ -795,7 +717,7 @@ Deno.serve(async (req: Request) => {
       const expectedVehicle = [vehicle.year, vehicle.make, vehicle.model].filter(Boolean).join(" ");
 
       try {
-        const ai = await classifyImage(url, expectedVehicle, anthropicKey);
+        const ai = await classifyImage(supabase, userId, url, expectedVehicle);
 
         let status: MatchResult["status"];
         if (!ai.is_vehicle) {


### PR DESCRIPTION
Unblocks the image-analysis loop. The vision layer was dead (YONO sidecar down, `check-image-vehicle-match` hardcoded to a depleted Anthropic key, `api-v1-vision` returning 503 with no fallback).

**BYOK-native by design** (per the economics: Nuke does not fund cloud inference — the caller brings the compute):
- `_shared/visionFallback.ts` resolves the **caller's** connected provider key via `getUserApiKey` (`user_ai_providers`). The user pays; a system env key is only a labeled bootstrap pool, and `cost_bearer` is reported on every response. Claude / ChatGPT / Gemini are all first-class connectable providers.
- `api-v1-vision` classify+analyze fall back to the caller's BYOK provider when YONO is down; surfaces "connect your AI subscription" when neither is available.
- `check-image-vehicle-match` (classify/disambiguate/build_signatures) rewired off the hardcoded Anthropic call onto the BYOK helper.

**GATE 1 passed:** with YONO down, `analyze` returns `make:Ford`/zone via `cloud_fallback`; check mode processes 3/3 with 0 errors (was 40/40 credit errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)