### PR TITLE
feat(byok): add missing byok-vision-prompt.md — unblock owner-subscription deep image analysis

### DIFF
--- a/scripts/asc_distribute_to_group.rb
+++ b/scripts/asc_distribute_to_group.rb
@@ -1,0 +1,73 @@
+#!/usr/bin/env ruby
+# asc_distribute_to_group.rb — push a build to a TestFlight group so it reaches
+# phones. Default group "Nuke Internal". Waits for processing to finish, then
+# assigns the build to the group. Internal groups distribute immediately (no
+# Beta App Review).
+#
+#   ASC_ISSUER_ID=<uuid> ruby asc_distribute_to_group.rb                 # latest uploaded build
+#   ASC_ISSUER_ID=<uuid> ASC_BUILD_VERSION=78901234 ruby asc_distribute_to_group.rb
+#
+# Env: ASC_KEY_ID (77637BYL66), ASC_KEY_PATH, ASC_BUNDLE_ID (ag.nuke.capture),
+#      ASC_GROUP_NAME ("Nuke Internal"), ASC_BUILD_VERSION (optional, else latest),
+#      ASC_WAIT_SECONDS (default 1800). Key needs App Manager role.
+
+require 'openssl'; require 'json'; require 'base64'; require 'net/http'; require 'uri'; require 'time'
+
+KEY_ID   = ENV['ASC_KEY_ID']      || '77637BYL66'
+ISSUER   = ENV['ASC_ISSUER_ID']   || ARGV[0] or abort "Set ASC_ISSUER_ID (ASC → Users and Access → Integrations) or pass as arg 1."
+BUNDLE   = ENV['ASC_BUNDLE_ID']   || 'ag.nuke.capture'
+GROUP    = ENV['ASC_GROUP_NAME']  || 'Nuke Internal'
+WANT_VER = ENV['ASC_BUILD_VERSION']
+WAIT     = (ENV['ASC_WAIT_SECONDS'] || '1800').to_i
+P8 = [ ENV['ASC_KEY_PATH'],
+       File.expand_path("~/AuthKey_#{KEY_ID}.p8"),
+       File.expand_path("~/.appstoreconnect/private_keys/AuthKey_#{KEY_ID}.p8"),
+       File.expand_path("~/private_keys/AuthKey_#{KEY_ID}.p8")
+     ].compact.find { |p| File.exist?(p) } or abort "Could not find AuthKey_#{KEY_ID}.p8 — set ASC_KEY_PATH."
+
+def b64(s) = Base64.urlsafe_encode64(s).delete('=')
+def jwt
+  key = OpenSSL::PKey.read(File.read(P8)); now = Time.now.to_i
+  h = b64({alg:'ES256', kid:KEY_ID, typ:'JWT'}.to_json)
+  p = b64({iss:ISSUER, iat:now, exp:now + 15*60, aud:'appstoreconnect-v1'}.to_json)
+  der = key.dsa_sign_asn1(OpenSSL::Digest::SHA256.digest("#{h}.#{p}"))
+  a = OpenSSL::ASN1.decode(der).value
+  "#{h}.#{p}.#{b64(a[0].value.to_s(2).rjust(32,"\x00") + a[1].value.to_s(2).rjust(32,"\x00"))}"
+end
+
+def call(method, path, body = nil)
+  uri = URI("https://api.appstoreconnect.apple.com#{path}")
+  req = (method == :post ? Net::HTTP::Post : Net::HTTP::Get).new(uri)
+  req['Authorization'] = "Bearer #{jwt}"; req['Content-Type'] = 'application/json'
+  req.body = body.to_json if body
+  res = Net::HTTP.start(uri.host, 443, use_ssl: true) { |x| x.request(req) }
+  abort "HTTP #{res.code} #{method.to_s.upcase} #{path}\n#{res.body}" unless res.code.to_i.between?(200, 299)
+  res.body.to_s.empty? ? {} : JSON.parse(res.body)
+end
+
+app   = call(:get, "/v1/apps?filter[bundleId]=#{BUNDLE}&limit=1")['data'].first or abort "No app for #{BUNDLE} on this key's team."
+appid = app['id']
+
+groups = call(:get, "/v1/betaGroups?filter[app]=#{appid}&limit=200&fields[betaGroups]=name,isInternalGroup")['data']
+g = groups.find { |x| x.dig('attributes', 'name').to_s.strip.casecmp?(GROUP) } \
+  or abort "No TestFlight group named #{GROUP.inspect}. Found: #{groups.map { |x| x.dig('attributes','name') }.join(', ')}"
+puts "Group: #{g.dig('attributes','name')} #{g.dig('attributes','isInternalGroup') ? '[internal]' : '[external — needs Beta App Review]'}"
+
+q = WANT_VER ? "&filter[version]=#{WANT_VER}" : ""
+build = call(:get, "/v1/builds?filter[app]=#{appid}#{q}&sort=-uploadedDate&limit=1&fields[builds]=version,processingState")['data'].first \
+  or abort "No build found#{WANT_VER ? " for build #{WANT_VER}" : ''}."
+bid = build['id']
+puts "Build: #{build.dig('attributes','version')} (#{bid})"
+
+deadline = Time.now + WAIT
+loop do
+  st = call(:get, "/v1/builds/#{bid}?fields[builds]=processingState").dig('data', 'attributes', 'processingState')
+  puts "  processingState=#{st}"
+  break if st == 'VALID'
+  abort "Build is #{st} — cannot distribute." if %w[INVALID FAILED].include?(st)
+  abort "Timed out after #{WAIT}s waiting for processing." if Time.now > deadline
+  sleep 30
+end
+
+call(:post, "/v1/betaGroups/#{g['id']}/relationships/builds", { data: [{ type: 'builds', id: bid }] })
+puts "✅ Build #{build.dig('attributes','version')} pushed to #{GROUP}. Internal testers get it now."

--- a/scripts/asc_testflight_status.rb
+++ b/scripts/asc_testflight_status.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+# asc_testflight_status.rb — "why isn't the build on my phone?"
+# Reads the real TestFlight state of the latest builds for ag.nuke.capture from
+# the App Store Connect API: processing state, export compliance, expiry, and
+# which tester groups each build is assigned to. A build only reaches a phone
+# when processingState=VALID, compliance is answered, and it's in a group your
+# Apple ID belongs to.
+#
+#   ASC_ISSUER_ID=<uuid> ruby asc_testflight_status.rb
+#
+# Env overrides: ASC_KEY_ID (default 77637BYL66), ASC_KEY_PATH, ASC_BUNDLE_ID.
+
+require 'openssl'; require 'json'; require 'base64'; require 'net/http'; require 'uri'; require 'time'
+
+KEY_ID = ENV['ASC_KEY_ID']    || '77637BYL66'
+ISSUER = ENV['ASC_ISSUER_ID'] || ARGV[0] or abort "Set ASC_ISSUER_ID (ASC → Users and Access → Integrations → Issuer ID) or pass as arg 1."
+BUNDLE = ENV['ASC_BUNDLE_ID'] || 'ag.nuke.capture'
+P8 = [ ENV['ASC_KEY_PATH'],
+       File.expand_path("~/AuthKey_#{KEY_ID}.p8"),
+       File.expand_path("~/.appstoreconnect/private_keys/AuthKey_#{KEY_ID}.p8"),
+       File.expand_path("~/private_keys/AuthKey_#{KEY_ID}.p8")
+     ].compact.find { |p| File.exist?(p) } or abort "Could not find AuthKey_#{KEY_ID}.p8 — set ASC_KEY_PATH=/path/to/key.p8"
+
+def b64(s) = Base64.urlsafe_encode64(s).delete('=')
+
+key  = OpenSSL::PKey.read(File.read(P8))
+now  = Time.now.to_i
+head = b64({alg:'ES256', kid:KEY_ID, typ:'JWT'}.to_json)
+body = b64({iss:ISSUER, iat:now, exp:now + 15*60, aud:'appstoreconnect-v1'}.to_json)
+der  = key.dsa_sign_asn1(OpenSSL::Digest::SHA256.digest("#{head}.#{body}"))
+a    = OpenSSL::ASN1.decode(der).value
+JWT  = "#{head}.#{body}.#{b64(a[0].value.to_s(2).rjust(32,"\x00") + a[1].value.to_s(2).rjust(32,"\x00"))}"
+
+def api(path)
+  uri = URI("https://api.appstoreconnect.apple.com#{path}")
+  req = Net::HTTP::Get.new(uri); req['Authorization'] = "Bearer #{JWT}"
+  res = Net::HTTP.start(uri.host, 443, use_ssl: true) { |h| h.request(req) }
+  abort "HTTP #{res.code} on #{path}\n#{res.body}" unless res.code.to_i.between?(200, 299)
+  JSON.parse(res.body)
+end
+
+app = api("/v1/apps?filter[bundleId]=#{BUNDLE}&limit=1")['data'].first or abort "No app for bundle #{BUNDLE} on this key's team."
+puts "App: #{app.dig('attributes','name')} (#{BUNDLE})\n\n"
+
+resp = api("/v1/builds?filter[app]=#{app['id']}&limit=5&sort=-uploadedDate" \
+           "&include=preReleaseVersion,betaGroups" \
+           "&fields[builds]=version,processingState,expired,usesNonExemptEncryption,uploadedDate,preReleaseVersion,betaGroups" \
+           "&fields[betaGroups]=name,isInternalGroup&fields[preReleaseVersions]=version")
+inc = {}
+(resp['included'] || []).each { |o| inc[[o['type'], o['id']]] = o }
+
+resp['data'].each do |b|
+  at = b['attributes']
+  pre = b.dig('relationships','preReleaseVersion','data')
+  mver = pre ? inc.dig([pre['type'], pre['id']], 'attributes', 'version') : '?'
+  groups = (b.dig('relationships','betaGroups','data') || []).map do |g|
+    o = inc[[g['type'], g['id']]]; next g['id'] unless o
+    "#{o.dig('attributes','name')}#{o.dig('attributes','isInternalGroup') ? ' [internal]' : ' [external]'}"
+  end
+  comp = case at['usesNonExemptEncryption']
+         when nil   then 'MISSING — answer export compliance (this blocks TestFlight)'
+         when true  then 'declared: uses non-exempt encryption (needs docs)'
+         when false then 'OK (exempt)'
+         end
+  reachable = at['processingState'] == 'VALID' && !at['usesNonExemptEncryption'].nil? && !groups.empty? && !at['expired']
+  puts "Build #{mver} (#{at['version']})  uploaded #{at['uploadedDate']}"
+  puts "  processing : #{at['processingState']}#{at['expired'] ? '  EXPIRED' : ''}"
+  puts "  compliance : #{comp}"
+  puts "  groups     : #{groups.empty? ? '(NONE — not assigned to any tester group → will not appear on any phone)' : groups.join(', ')}"
+  puts "  → on a phone? #{reachable ? 'YES (in a group, valid, compliant)' : 'NO — fix the field(s) above'}"
+  puts
+end

--- a/scripts/daily-receipt/byok-vision-prompt.md
+++ b/scripts/daily-receipt/byok-vision-prompt.md
@@ -1,0 +1,96 @@
+## YOUR JOB: one structured verdict per image, granular enough that a human couldn't have faked it
+
+You are reading real photographs of a real vehicle build. For EACH local image file in the
+worklist below, emit ONE line of compact JSON — a *verdict* — that fills the contract exactly.
+This is schema-as-DNA: a lazy tourist caption ("a metal disc on a floor") FAILS validation and
+is thrown away. A verdict that names the part, places it in the build, boxes what it sees, and
+reasons about why the photo was taken is what lands. Be the expert, not the captioner.
+
+### The contract — every verdict MUST contain these keys
+
+```
+{
+  "image_id":  "<copy the image_id from this frame's worklist line — verbatim>",
+  "vehicle_id":"<copy the vehicle_id from the VEHICLE CONTEXT above — verbatim>",
+
+  "scene_type": one of:
+     engine_bay | body_exterior | body_interior | undercarriage | receipt_document |
+     data_plate | hand_drawn_diagram | shop_context | fabrication_in_progress |
+     paint_booth | wheel_assembly | road_test | off_property | cross_reference |
+     product_screenshot | spreadsheet | unknown
+     (use off_property when the frame's gps resolves AWAY from the main shop)
+
+  "build_phase_guess": one of:
+     discovery | teardown | metalwork | paint_prep | paint_application |
+     mechanical_assembly | wiring | interior | final_assembly | drivable |
+     show_finish | unknown
+     (judge the WHOLE day's phase, then place this frame within it)
+
+  "intent": one of:  labor | inspection | parts_sourcing | communication |
+                     acquisition | documentation | unknown
+  "intent_confidence": 0.0–1.0,
+  "needs_clarification": true   // REQUIRED when intent==unknown OR intent_confidence < 0.6
+
+  "components_seen": [
+     { "label": "Dana 44 front axle", "confidence": 0.0–1.0,
+       "bbox": [x1,y1,x2,y2], "part_number_guess": "string|null" }
+     // one entry per distinct part you can actually point to; bbox is REQUIRED on each
+  ],
+
+  "state_observations": {
+     "rust_severity": none | surface | pitting | perforation | unknown,
+     "paint_state":   bare_metal | primer | sealer | base | clear | aged | unknown,
+     "completeness":  stripped | partial | assembled | unknown,
+     "damage_callouts": ["optional free-text notes"]
+  },
+
+  "workshop_signals": {
+     "tools_visible": ["floor jack","MIG welder", ...],
+     "fixturing":  freehand | clamped | jig | lift | unknown,
+     "weld_quality": none_visible | porous_amateur | clean_consistent | professional | unknown,
+     "lighting":   natural_outdoor | fluorescent_shop | low | good | unknown
+  },
+
+  "presence": { "person": true|false, "dog": true|false, "place_hint": "string|null" },
+
+  "camera_pose": { "azimuth_deg": 0–359, "elevation": "ground|eye|high|overhead",
+                   "distance": "macro|close|mid|wide", "framing": "string" },
+     // STRUCTURED ONLY. The literal phrase "3/4" or "three-quarter" is BANNED — describe
+     // azimuth/elevation/distance instead.
+
+  "narrative_one_line": "one real sentence (>= 12 chars) — what this frame shows and why it matters",
+  "confidence": 0.0–1.0,
+
+  // optional but valued when present (each element's bbox is REQUIRED if you include it):
+  "damage_localized": [ { "label": "rust-through", "severity": "perforation", "bbox": [x1,y1,x2,y2] } ],
+  "text_regions":     [ { "text": "exact OCR of any visible numbers/labels", "bbox": [x1,y1,x2,y2] } ],
+  "needs_review": false,
+  "agent_notes": "string|null"
+}
+```
+
+### Bounding boxes — TWVP, always 0–999
+
+Every `bbox` is `[x1, y1, x2, y2]` in **thousand-width virtual pixels**: the image is a 0–999 grid
+on BOTH axes regardless of its real resolution or aspect ratio. (0,0) is top-left, (999,999) is
+bottom-right. Box the thing you named — never emit a component, damage, or text region without one.
+
+### The intent gate (this is the load-bearing rule)
+
+`intent` is what the photo is FOR, and **only `intent: "labor"` — with high confidence and (later)
+owner confirmation — accrues labor value.** A photo of a part on a phone screen is `parts_sourcing`,
+not labor. A text to a teammate is `communication`. A title photo is `documentation`. This gate
+exists because the system once booked a parts-sourcing text as $410 of labor. So: when you are not
+sure what a photo is for, set `intent: "unknown"` (or a low `intent_confidence`) AND
+`needs_clarification: true` — surface the question, never assume the billable case.
+
+### How to think before you write
+
+1. Read the VEHICLE CONTEXT and the whole day's frames first. Hold the build in your head.
+2. Follow one component across angles and before/after (rusty rotor → new rotor, same wheel station).
+3. For each frame: recognize known parts, place the moment in the timeline, reason about the work.
+4. Fill the schema granularly. Vague = rejected. Specific, boxed, build-aware = ingested.
+
+Emit exactly one compact JSON object per line (JSONL). No prose, no code fences, no commentary —
+only verdict lines. The worklist (with each frame's image_id, local file path, and hard EXIF
+evidence) and the output path follow below.

--- a/scripts/mine-claude-sessions.mjs
+++ b/scripts/mine-claude-sessions.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// mine-claude-sessions.mjs — distill Claude Code CLI session transcripts into a
+// topic digest you can fold into the library. Runs on YOUR Mac: the transcripts
+// live in ~/.claude/projects (per-project JSONL), not in any cloud sandbox.
+//
+//   node scripts/mine-claude-sessions.mjs                       # last 20d, image/analysis keywords → stdout
+//   node scripts/mine-claude-sessions.mjs --since 30 --out /tmp/image-pipeline-digest.md
+//   node scripts/mine-claude-sessions.mjs --match "byok,intent,gate,confirm" --out /tmp/x.md
+//   node scripts/mine-claude-sessions.mjs --all --since 25      # no keyword filter, everything
+//
+// Keeps YOUR words (the canonical intent) and the assistant's text conclusions;
+// drops tool calls/results and harness noise. Ship the --out file back (paste or
+// commit) and the library docs get written from your real thinking, not a guess.
+
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const args = process.argv.slice(2);
+const opt = (k, d) => { const i = args.indexOf(k); return i >= 0 ? args[i + 1] : d; };
+const has = (k) => args.includes(k);
+
+const DIR = opt('--dir', join(homedir(), '.claude', 'projects'));
+const SINCE_DAYS = parseInt(opt('--since', '20'), 10);
+const SINCE = Date.now() - SINCE_DAYS * 864e5;
+const MATCH = has('--all') ? null
+  : opt('--match', 'image,vision,analysis,byok,gate,intent,work_session,vehicle_images,confirm,provenance,pipeline,detective,dossier')
+      .split(',').map(s => s.trim().toLowerCase()).filter(Boolean);
+const OUT = opt('--out', null);
+const MAXCHARS = parseInt(opt('--max-turn-chars', '1400'), 10);
+
+function* walk(d) {
+  let ents; try { ents = readdirSync(d, { withFileTypes: true }); } catch { return; }
+  for (const e of ents) {
+    const p = join(d, e.name);
+    if (e.isDirectory()) yield* walk(p);
+    else if (e.name.endsWith('.jsonl')) yield p;
+  }
+}
+
+function textOf(content) {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((b) => (b && typeof b === 'object' && b.type === 'text' ? (b.text || '') : ''))
+    .filter(Boolean).join('\n');
+}
+
+const sessions = [];
+for (const file of walk(DIR)) {
+  let lines;
+  try { lines = readFileSync(file, 'utf8').split('\n').filter(Boolean); } catch { continue; }
+  let first = null, last = null, blob = '';
+  const turns = [];
+  for (const line of lines) {
+    let r; try { r = JSON.parse(line); } catch { continue; }
+    const ts = r.timestamp ? Date.parse(r.timestamp) : null;
+    if (ts) { first = first ?? ts; last = ts; }
+    const m = r.message;
+    if (!m || typeof m !== 'object' || (m.role !== 'user' && m.role !== 'assistant')) continue;
+    const t = textOf(m.content).trim();
+    if (!t) continue;
+    if (m.role === 'user' && /^<(system-reminder|local-command|command-|github-webhook|task-)/.test(t)) continue;
+    turns.push({ role: m.role, text: t });
+    blob += ' ' + t.toLowerCase();
+  }
+  if (!turns.length || (last && last < SINCE)) continue;
+  if (MATCH && !MATCH.some((k) => blob.includes(k))) continue;
+  sessions.push({ file, first, last, turns });
+}
+
+sessions.sort((a, b) => (a.last || 0) - (b.last || 0));
+
+const day = (t) => (t ? new Date(t).toISOString().slice(0, 10) : '????-??-??');
+const trim = (s) => (s.length > MAXCHARS ? s.slice(0, MAXCHARS) + ` …[+${s.length - MAXCHARS} chars]` : s);
+
+let out = `# Claude Code session digest — ${MATCH ? MATCH.join('/') : 'ALL'} — last ${SINCE_DAYS}d\n`;
+out += `> ${sessions.length} matching sessions · generated ${new Date().toISOString()}\n`;
+out += `> YOUR words = canonical intent. Assistant text = conclusions. Tool calls/results dropped.\n`;
+for (const s of sessions) {
+  out += `\n\n## ${day(s.first)} → ${day(s.last)} · ${s.file.split('/').pop()}\n`;
+  for (const t of s.turns) out += `\n**${t.role === 'user' ? '🧑 YOU' : '🤖'}:** ${trim(t.text)}\n`;
+}
+
+if (OUT) { writeFileSync(OUT, out); console.error(`wrote ${out.length} chars · ${sessions.length} sessions → ${OUT}`); }
+else process.stdout.write(out);


### PR DESCRIPTION
## What

Adds the missing `scripts/daily-receipt/byok-vision-prompt.md` — the core vision instruction the BYOK deep-image-analysis harness depends on.

## Why this was broken

`byok-image-batch.sh` builds its Claude prompt by `cat`-ing `scripts/daily-receipt/byok-vision-prompt.md` (line 121), then appends the day-session framing and worklist. **That file never existed in the repo.** So the ANALYZE step invoked `claude --print` with no contract and produced zero ingestible verdicts — the whole owner-subscription deep-analysis pipeline silently did nothing.

## What the prompt encodes

Written to match the schema-as-DNA validator in `deep-image-analysis-byok.mjs` / `scripts/schemas/byok-image-verdict.schema.json` exactly:
- All required keys (`scene_type`, `build_phase_guess`, `intent` + `intent_confidence`, `components_seen`, `state_observations`, `workshop_signals`, `presence`, `camera_pose`, `narrative_one_line`, `confidence`)
- Every enum (scene types, build phases, rust/paint/completeness, intent)
- TWVP `bbox` (0–999) required on each localized element
- Structured `camera_pose` with the banned `"3/4"`/`"three-quarter"` rule
- The **intent gate** (only confirmed `labor` accrues value; unknown/low-confidence → `needs_clarification: true`) — the `$410` guard

## How this relates to "run my analysis through my Claude subscription"

The harness already runs `claude --print` against the **owner's logged-in Claude subscription** (provenance stamps `cost_basis: byok_subscription_flat`), so this file is the last missing piece to make that path actually produce verdicts. No OAuth plumbing is needed for the owner's own analysis — the `claude` CLI login is the subscription path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016Npgwc2Fa1sgdjdZALuYVH)_