### PR TITLE
Image-analysis pipeline for the test user: date/EXIF fix, free-data structuring, grouping, attribution, session linkage

### DIFF
--- a/nuke_frontend/src/components/ProImageViewer.tsx
+++ b/nuke_frontend/src/components/ProImageViewer.tsx
@@ -202,7 +202,9 @@ const ProImageViewer: React.FC<ProImageViewerProps> = ({
         .not('is_superseded', 'is', true)
         .or('vision_gate_status.is.null,vision_gate_status.not.in.("rejected_personal","rejected_misattributed")');
 
-      const { data, error } = await query.order('created_at', { ascending: false });
+      const { data, error } = await query
+        .order('taken_at', { ascending: false, nullsFirst: false })
+        .order('created_at', { ascending: false });
 
       if (error) {
         console.error('ProImageViewer: Database error:', error);

--- a/nuke_frontend/src/components/image-viewer/useImageViewerState.ts
+++ b/nuke_frontend/src/components/image-viewer/useImageViewerState.ts
@@ -81,13 +81,23 @@ export const useImageViewerState = (vehicleId: string) => {
     if (filters.area) query = query.ilike('area', `%${filters.area}%`);
     if (filters.part) query = query.ilike('part', `%${filters.part}%`);
 
-    // Apply ordering based on sortMode
+    // Apply ordering based on sortMode. Order by CAPTURE time (taken_at), not
+    // ingestion time (created_at) — backfilled/synced photos get created_at=now,
+    // so a created_at sort interleaves old and new photos. created_at is the
+    // fallback only for the minority with no taken_at.
     if (sortMode === 'primary_newest') {
-      query = query.order('is_primary', { ascending: false }).order('created_at', { ascending: false });
+      query = query
+        .order('is_primary', { ascending: false })
+        .order('taken_at', { ascending: false, nullsFirst: false })
+        .order('created_at', { ascending: false });
     } else if (sortMode === 'newest') {
-      query = query.order('created_at', { ascending: false });
+      query = query
+        .order('taken_at', { ascending: false, nullsFirst: false })
+        .order('created_at', { ascending: false });
     } else if (sortMode === 'oldest') {
-      query = query.order('created_at', { ascending: true });
+      query = query
+        .order('taken_at', { ascending: true, nullsFirst: false })
+        .order('created_at', { ascending: true });
     }
 
     try {

--- a/nuke_frontend/src/components/image/MobileImageGallery.tsx
+++ b/nuke_frontend/src/components/image/MobileImageGallery.tsx
@@ -42,6 +42,8 @@ const MobileImageGallery: React.FC<MobileImageGalleryProps> = ({ leadImageUrl, o
       .select('id, image_url, large_url, caption, angle_tag, created_at')
       .eq('vehicle_id', vehicleId)
       .order('is_primary', { ascending: false })
+      // Capture time, not ingestion time — backfilled photos get created_at=now.
+      .order('taken_at', { ascending: false, nullsFirst: false })
       .order('created_at', { ascending: false });
 
     if (!error && data) {

--- a/nuke_frontend/src/components/images/ImageGallery.tsx
+++ b/nuke_frontend/src/components/images/ImageGallery.tsx
@@ -1236,8 +1236,8 @@ const ImageGallery = ({
         const posB = (typeof b?.position === 'number' && Number.isFinite(b.position)) ? b.position : Number.POSITIVE_INFINITY;
         if (posA !== posB) return posA - posB;
 
-        const ca = typeof a?.created_at === 'string' ? new Date(a.created_at).getTime() : 0;
-        const cb = typeof b?.created_at === 'string' ? new Date(b.created_at).getTime() : 0;
+        const ca = new Date(a?.taken_at || a?.created_at || 0).getTime();
+        const cb = new Date(b?.taken_at || b?.created_at || 0).getTime();
         if (ca !== cb) return ca - cb;
 
         return String(a?.id || '').localeCompare(String(b?.id || ''));

--- a/nuke_frontend/src/components/profile/PublicImageGallery.tsx
+++ b/nuke_frontend/src/components/profile/PublicImageGallery.tsx
@@ -144,6 +144,8 @@ const PublicImageGallery: React.FC<PublicImageGalleryProps> = ({ userId, isOwnPr
         .from('vehicle_images')
         .select(IMAGE_SELECT)
         .eq('user_id', userId)
+        // Capture time, not ingestion time — backfilled photos get created_at=now.
+        .order('taken_at', { ascending: false, nullsFirst: false })
         .order('created_at', { ascending: false })
         .limit(200);
 

--- a/nuke_frontend/src/services/profileService.ts
+++ b/nuke_frontend/src/services/profileService.ts
@@ -200,9 +200,39 @@ export class ProfileService {
       console.log('ProfileService: Built contributions sample:', realContributions.slice(0, 3));
       console.log('ProfileService: Contribution dates:', realContributions.map(c => c.contribution_date).slice(0, 10));
 
-      // ALWAYS use the real contribution data from timeline events, NEVER the fake user_contributions table
-      // The user_contributions table has inaccurate/fake data that should be ignored
-      const finalContributions = realContributions;
+      // Heatmap counts come from the uncapped server-side aggregate
+      // (get_user_contribution_days), NOT the three wide selects above — those are
+      // silently capped to 1000 rows by PostgREST db-max-rows, so for a >1000-image
+      // user the heatmap rendered an arbitrary recent slice (346 of 1,626 capture-days
+      // for user 0, nothing before 2017, while real history reaches further back). The
+      // RPC groups by COALESCE(taken_at, created_at) over ALL rows and floors bogus
+      // pre-2000 EXIF. Falls back to the capped client-built map if the RPC is
+      // unavailable; business events (not covered by the RPC) are preserved.
+      let finalContributions = realContributions;
+      try {
+        const days = await ProfileService.getContributionDays(userId);
+        if (days && days.length) {
+          const kindToType: Record<string, UserContribution['contribution_type']> = {
+            photo: 'image_upload', event: 'vehicle_data', work: 'vehicle_data',
+          };
+          const rpcContribs: UserContribution[] = days.map((d) => ({
+            id: `${userId}-${d.day}-${d.kind}`,
+            user_id: userId,
+            contribution_date: d.day,
+            contribution_type: kindToType[d.kind] || 'vehicle_data',
+            contribution_count: d.n,
+            metadata: {},
+            related_vehicle_id: null,
+            created_at: d.day,
+          }));
+          const businessContribs = realContributions.filter(
+            (c) => c.contribution_type === 'business_event',
+          );
+          finalContributions = [...rpcContribs, ...businessContribs];
+        }
+      } catch (e) {
+        console.warn('[ProfileService] get_user_contribution_days failed, using capped fallback:', e);
+      }
       
       console.log('ProfileService: Using REAL timeline-built contributions data');
       console.log('ProfileService: Real contributions from timeline events:', realContributions.length);

--- a/scripts/backfill-exif-free-data.mjs
+++ b/scripts/backfill-exif-free-data.mjs
@@ -1,0 +1,115 @@
+/**
+ * Backfill FREE image metadata from exif_data → structured columns.
+ *
+ * Step one of the analysis pipeline: copy the already-available data sitting in
+ * the heterogeneous vehicle_images.exif_data JSON blob into the typed columns the
+ * downstream cheap analysis + grouping read. Zero inference, zero token cost.
+ *
+ * Promotes (null-only, idempotent — never overwrites an existing value):
+ *   - latitude/longitude  ← exif_data.location{lat,lon} | flat exif_data.latitude/longitude
+ *   - apple_ml_labels[]   ← exif_data.labels (Apple on-device Vision subject tags)
+ *
+ * NOT promoted (no clean column home / ambiguous): camera_make/model, dimensions,
+ * full technical EXIF (iso/aperture/shutter), orientation→rotation, the Apple
+ * aesthetic `score` object. Those stay in the blob until a column exists for them.
+ *
+ * Why batched + paced: vehicle_images has a per-row AFTER UPDATE trigger
+ * (trg_recompute_value_on_images) that recomputes vehicle valuation on EVERY
+ * update, and trg_auto_tag_org_from_gps runs an org-stats cascade on lat/lon
+ * updates. A single bulk UPDATE blows the statement timeout. GPS batches must stay
+ * small (~150-300); label batches tolerate ~1500-2000.
+ *
+ * Usage:
+ *   SUPABASE_SERVICE_ROLE_KEY=... node scripts/backfill-exif-free-data.mjs \
+ *     --user-id <uuid> [--labels-batch 1500] [--gps-batch 200] [--sleep-ms 250]
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error('Missing VITE_SUPABASE_URL/SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+const sb = createClient(SUPABASE_URL, SERVICE_KEY);
+
+const args = process.argv.slice(2);
+const arg = (n, d) => { const i = args.indexOf(n); return i >= 0 ? args[i + 1] : d; };
+const USER_ID = arg('--user-id');
+const LABELS_BATCH = parseInt(arg('--labels-batch', '1500'));
+const GPS_BATCH = parseInt(arg('--gps-batch', '200'));
+const SLEEP_MS = parseInt(arg('--sleep-ms', '250'));
+if (!USER_ID) { console.error('--user-id <uuid> required'); process.exit(1); }
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const NUM = /^-?[0-9]+(\.[0-9]+)?$/;
+
+function gpsFrom(exif) {
+  const loc = exif?.location;
+  const cands = [
+    [loc?.latitude, loc?.longitude],
+    [exif?.latitude, exif?.longitude],
+  ];
+  for (const [la, lo] of cands) {
+    const las = la == null ? '' : String(la);
+    const los = lo == null ? '' : String(lo);
+    if (NUM.test(las) && NUM.test(los)) return { lat: Number(las), lon: Number(los) };
+  }
+  return null;
+}
+
+async function backfillLabels() {
+  let total = 0;
+  for (;;) {
+    const { data, error } = await sb
+      .from('vehicle_images')
+      .select('id, exif_data')
+      .eq('user_id', USER_ID)
+      .is('apple_ml_labels', null)
+      .limit(LABELS_BATCH);
+    if (error) { console.error('labels select:', error.message); break; }
+    const rows = (data || []).filter((r) => Array.isArray(r.exif_data?.labels) && r.exif_data.labels.length);
+    if (!rows.length) break;
+    for (const r of rows) {
+      const { error: e } = await sb.from('vehicle_images')
+        .update({ apple_ml_labels: r.exif_data.labels.map(String) })
+        .eq('id', r.id);
+      if (e) console.error(`  labels ${r.id}: ${e.message}`); else total++;
+    }
+    console.log(`labels: +${rows.length} (total ${total})`);
+    await sleep(SLEEP_MS);
+    if (rows.length < LABELS_BATCH) break;
+  }
+  return total;
+}
+
+async function backfillGps() {
+  let total = 0;
+  for (;;) {
+    const { data, error } = await sb
+      .from('vehicle_images')
+      .select('id, exif_data')
+      .eq('user_id', USER_ID)
+      .is('latitude', null)
+      .limit(GPS_BATCH);
+    if (error) { console.error('gps select:', error.message); break; }
+    const rows = (data || []).map((r) => ({ id: r.id, g: gpsFrom(r.exif_data) })).filter((r) => r.g);
+    if (!rows.length) break;
+    for (const r of rows) {
+      const { error: e } = await sb.from('vehicle_images')
+        .update({ latitude: r.g.lat, longitude: r.g.lon })
+        .eq('id', r.id);
+      if (e) console.error(`  gps ${r.id}: ${e.message}`); else total++;
+    }
+    console.log(`gps: +${rows.length} (total ${total})`);
+    await sleep(SLEEP_MS);
+    if ((data || []).length < GPS_BATCH) break;
+  }
+  return total;
+}
+
+console.log(`backfill-exif-free-data: user ${USER_ID}`);
+const labels = await backfillLabels();
+const gps = await backfillGps();
+console.log(`done: ${labels} labels, ${gps} gps promoted`);

--- a/scripts/capture-sessions.mjs
+++ b/scripts/capture-sessions.mjs
@@ -68,14 +68,14 @@ function sessionize(frames) {
     const gpsJump = cur && cur.lastLat != null && f.latitude != null &&
       (Math.abs(f.latitude - cur.lastLat) > GPS_JUMP || Math.abs(f.longitude - cur.lastLon) > GPS_JUMP);
     if (!cur || (t - cur.lastT) > GAP_MS || gpsJump) {
-      cur = { frames: [], lastT: t, lastLat: f.latitude, lastLon: f.longitude,
+      cur = { frames: [], unassignedIds: [], lastT: t, lastLat: f.latitude, lastLon: f.longitude,
               vehicles: new Set(), unassigned: 0, labels: new Map(), startT: t };
       sessions.push(cur);
     }
     cur.frames.push(f.id);
     cur.lastT = t;
     if (f.latitude != null) { cur.lastLat = f.latitude; cur.lastLon = f.longitude; }
-    if (f.vehicle_id) cur.vehicles.add(f.vehicle_id); else cur.unassigned++;
+    if (f.vehicle_id) cur.vehicles.add(f.vehicle_id); else { cur.unassigned++; cur.unassignedIds.push(f.id); }
     for (const l of (f.apple_ml_labels || [])) cur.labels.set(l, (cur.labels.get(l) || 0) + 1);
   }
   return sessions;
@@ -101,4 +101,27 @@ console.log('\ntop bursts:');
 for (const s of [...sessions].sort((a, b) => b.frames.length - a.frames.length).slice(0, 15)) {
   console.log(`  ${new Date(s.startT).toISOString().slice(0,10)}  shots=${s.frames.length}  span=${spanMin(s)}m  ` +
     `vehicles=${s.vehicles.size}  unassigned=${s.unassigned}  subject=${topLabel(s)}`);
+}
+
+// --apply: propagate the burst's vehicle to its unassigned frames as a SUGGESTION
+// (never a hard assignment — suggest-only per the misattribution scar tissue). Only
+// single-subject bursts; only frames with no existing suggestion. Batched + paced
+// because each update fires the per-row valuation-recompute trigger.
+if (args.includes('--apply')) {
+  let suggested = 0;
+  for (const s of attribution) {
+    const veh = [...s.vehicles][0];
+    for (let i = 0; i < s.unassignedIds.length; i += 200) {
+      const batch = s.unassignedIds.slice(i, i + 200);
+      const { error } = await sb.from('vehicle_images')
+        .update({ suggested_vehicle_id: veh, image_vehicle_match_status: 'ambiguous' })
+        .in('id', batch)
+        .is('suggested_vehicle_id', null)
+        .is('vehicle_id', null);
+      if (error) console.error(`  suggest burst ${new Date(s.startT).toISOString().slice(0,10)}: ${error.message}`);
+      else suggested += batch.length;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  }
+  console.log(`\napplied: ${suggested} suggested_vehicle_id propagations (suggest-only)`);
 }

--- a/scripts/capture-sessions.mjs
+++ b/scripts/capture-sessions.mjs
@@ -1,0 +1,104 @@
+/**
+ * Capture-session detection (step 4: "shot a lot, consistently → likely same subject").
+ *
+ * Derives photo BURSTS from the cheap free signals alone — taken_at gaps + GPS
+ * jumps — with zero inference. A burst (many frames, tight time, one location) is
+ * the programmatic expression of a focused shoot, which is overwhelmingly a single
+ * subject (validated 2026-06-21: 72% of 5+-shot bursts map to ≤1 vehicle).
+ *
+ * READ-ONLY. Outputs:
+ *   - session summary (count, span, GPS cluster, dominant Apple-ML subject, vehicles)
+ *   - attribution candidates: single-subject bursts holding UNASSIGNED frames whose
+ *     vehicle can be propagated from their burst-mates (addresses the ~38% of images
+ *     with no vehicle_id). It only REPORTS these — assignment stays suggest-only per
+ *     the repo's misattribution scar tissue ("102 frames on one truck", resolveVehicle).
+ *   - review list: multi-vehicle bursts (likely pollution / genuinely multi-subject).
+ *
+ * Depends on taken_at being trustworthy — see the exifOf fix in
+ * scripts/deep-image-analysis-byok.mjs (taken_at is authoritative, not exif_data).
+ *
+ * Usage:
+ *   SUPABASE_SERVICE_ROLE_KEY=... node scripts/capture-sessions.mjs \
+ *     --user-id <uuid> [--gap-min 90] [--gps-jump 0.02] [--min-shots 5]
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error('Missing VITE_SUPABASE_URL/SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+const sb = createClient(SUPABASE_URL, SERVICE_KEY);
+
+const args = process.argv.slice(2);
+const arg = (n, d) => { const i = args.indexOf(n); return i >= 0 ? args[i + 1] : d; };
+const USER_ID = arg('--user-id');
+const GAP_MS = parseInt(arg('--gap-min', '90')) * 60 * 1000;
+const GPS_JUMP = parseFloat(arg('--gps-jump', '0.02'));
+const MIN_SHOTS = parseInt(arg('--min-shots', '5'));
+if (!USER_ID) { console.error('--user-id <uuid> required'); process.exit(1); }
+
+// Pull all of the user's dated frames (paginated past the 1000-row cap), ordered by capture time.
+async function loadFrames() {
+  const out = [];
+  const PAGE = 1000;
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await sb
+      .from('vehicle_images')
+      .select('id, vehicle_id, taken_at, latitude, longitude, apple_ml_labels')
+      .eq('user_id', USER_ID)
+      .not('taken_at', 'is', null)
+      .order('taken_at', { ascending: true })
+      .range(from, from + PAGE - 1);
+    if (error) { console.error('load:', error.message); process.exit(1); }
+    if (!data || data.length === 0) break;
+    out.push(...data);
+    if (data.length < PAGE) break;
+  }
+  return out;
+}
+
+function sessionize(frames) {
+  const sessions = [];
+  let cur = null;
+  for (const f of frames) {
+    const t = new Date(f.taken_at).getTime();
+    const gpsJump = cur && cur.lastLat != null && f.latitude != null &&
+      (Math.abs(f.latitude - cur.lastLat) > GPS_JUMP || Math.abs(f.longitude - cur.lastLon) > GPS_JUMP);
+    if (!cur || (t - cur.lastT) > GAP_MS || gpsJump) {
+      cur = { frames: [], lastT: t, lastLat: f.latitude, lastLon: f.longitude,
+              vehicles: new Set(), unassigned: 0, labels: new Map(), startT: t };
+      sessions.push(cur);
+    }
+    cur.frames.push(f.id);
+    cur.lastT = t;
+    if (f.latitude != null) { cur.lastLat = f.latitude; cur.lastLon = f.longitude; }
+    if (f.vehicle_id) cur.vehicles.add(f.vehicle_id); else cur.unassigned++;
+    for (const l of (f.apple_ml_labels || [])) cur.labels.set(l, (cur.labels.get(l) || 0) + 1);
+  }
+  return sessions;
+}
+
+const frames = await loadFrames();
+const sessions = sessionize(frames).filter((s) => s.frames.length >= MIN_SHOTS);
+
+const attribution = sessions.filter((s) => s.vehicles.size === 1 && s.unassigned > 0);
+const orphanBursts = sessions.filter((s) => s.vehicles.size === 0 && s.unassigned > 0);
+const review = sessions.filter((s) => s.vehicles.size > 1);
+
+const topLabel = (s) => [...s.labels.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] || '—';
+const spanMin = (s) => Math.round((s.lastT - s.startT) / 60000);
+
+console.log(`frames=${frames.length}  sessions(>=${MIN_SHOTS})=${sessions.length}`);
+console.log(`single-subject bursts with unassigned frames (propagatable): ${attribution.length} ` +
+  `(${attribution.reduce((n, s) => n + s.unassigned, 0)} frames)`);
+console.log(`orphan bursts (0 vehicles, all unassigned): ${orphanBursts.length} ` +
+  `(${orphanBursts.reduce((n, s) => n + s.unassigned, 0)} frames)`);
+console.log(`multi-vehicle bursts to review (likely pollution): ${review.length}`);
+console.log('\ntop bursts:');
+for (const s of [...sessions].sort((a, b) => b.frames.length - a.frames.length).slice(0, 15)) {
+  console.log(`  ${new Date(s.startT).toISOString().slice(0,10)}  shots=${s.frames.length}  span=${spanMin(s)}m  ` +
+    `vehicles=${s.vehicles.size}  unassigned=${s.unassigned}  subject=${topLabel(s)}`);
+}

--- a/scripts/com.nuke.byok-image-analysis.plist
+++ b/scripts/com.nuke.byok-image-analysis.plist
@@ -6,14 +6,17 @@
     <string>com.nuke.byok-image-analysis</string>
 
     <!-- Runs in the login shell (NOT inside Claude Code's Bash sandbox), so the
-         network steps reach Supabase normally. One bounded batch per fire. -->
+         network steps reach Supabase normally. One bounded batch per fire.
+         byok-image-drain.sh SELF-DRIVES across ALL the user's vehicles via a
+         persistent cursor (was pinned to one hardcoded vehicle, leaving the rest
+         un-analyzed); a network blip never advances the cursor or marks the fleet drained. -->
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
-        <string>/Users/skylar/nuke/scripts/daily-receipt/byok-image-batch.sh</string>
-        <!-- vehicle-id (1977 K5 Blazer) ; change to process a different vehicle -->
-        <string>e08bf694-970f-4cbe-8a74-8715158a0f2e</string>
-        <!-- batch size per fire (4 keeps an Opus-4.8 vision fire inside the 15-min window) -->
+        <string>/Users/skylar/nuke/scripts/daily-receipt/byok-image-drain.sh</string>
+        <!-- user-id (the owner whose vehicles get drained) -->
+        <string>0b9f107a-d124-49de-9ded-94698f63c1c4</string>
+        <!-- batch size per fire (15 keeps an Opus-4.8 vision fire inside the 15-min window) -->
         <string>15</string>
     </array>
 

--- a/scripts/daily-receipt/build-day.mjs
+++ b/scripts/daily-receipt/build-day.mjs
@@ -132,6 +132,11 @@ const sessionRow = {
   total_labor_cost: Number(laborCost.toFixed(2)),
   total_job_cost: Number((laborCost + parts_value).toFixed(2)),
   image_count: photos.length,
+  // Session↔image linkage. Without these the session stores only a count and is
+  // unnavigable to its photos (the confirmation loop / COGS / timeline all need
+  // to reach the day's frames). photos is ordered by taken_at ascending.
+  start_image_id: photos[0].id,
+  end_image_id: photos[photos.length - 1].id,
 };
 
 // Check if exists
@@ -154,6 +159,20 @@ if (existing && existing.length > 0) {
   sessionId = ins.data.id;
   console.log(`[insert] work_session ${sessionId} for ${DATE}`);
 }
+
+// Write the back-link onto the day's photos so the session is navigable both ways.
+// Idempotent; only this day's gated photos. (Batched to stay gentle on the per-row
+// valuation-recompute trigger on vehicle_images.)
+const photoIds = photos.map(p => p.id);
+for (let i = 0; i < photoIds.length; i += 200) {
+  const batch = photoIds.slice(i, i + 200);
+  const { error: linkErr } = await supabase
+    .from('vehicle_images')
+    .update({ work_session_id: sessionId })
+    .in('id', batch);
+  if (linkErr) console.error('link photos→session:', linkErr.message);
+}
+console.log(`[link] ${photoIds.length} photos → work_session ${sessionId}`);
 
 // 5. Call get_daily_work_receipt to verify the receipt now materializes
 const rpcResp = await fetch(`${SUPABASE_URL}/rest/v1/rpc/get_daily_work_receipt`, {

--- a/scripts/daily-receipt/byok-image-drain.sh
+++ b/scripts/daily-receipt/byok-image-drain.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# byok-image-drain.sh — self-driving BYOK analysis drain (one bounded batch per fire).
+#
+# This is the launchd cron's body. The old plist hardcoded ONE vehicle (the K5 Blazer),
+# so the always-on trickle only ever analyzed one car while the rest sat 'completed'
+# but un-analyzed. This walks a persistent cursor across ALL of the user's vehicles
+# (most-approved-frames first), runs ONE bounded byok-image-batch for the current
+# vehicle each fire, and persists the cursor — so the 15-min trickle covers the whole
+# fleet and RESUMES where it left off after the laptop sleeps.
+#
+# Network-blip safe (the 2026-06-02 lesson, where one blip silently skipped the fleet):
+#   - a transient batch failure (exit 1) NEVER advances the cursor or marks drained;
+#   - a failed vehicle-list refresh keeps the cached list rather than wiping it;
+#   - only a genuine drain (byok-image-batch exit 3) advances the cursor.
+# It self-drives across vehicles but never silently declares the fleet done on an error.
+#
+# Coexists with byok-burn-all.sh: that script unloads this cron before its relentless
+# parallel run and re-arms it after, so the two never fight.
+#
+# Usage (and launchd ProgramArguments): byok-image-drain.sh <user-id> [batch_size]
+set -u
+cd "$(dirname "$0")/../.." || exit 1
+HERE="$(dirname "$0")"
+export PATH="/Users/skylar/.local/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH"
+
+USER_ID="${1:?usage: byok-image-drain.sh <user-id> [batch_size]}"
+BATCH="${2:-15}"
+REFRESH_AGE=3600        # re-query the vehicle list at least hourly (picks up new vehicles/uploads)
+
+STATE_DIR="/Users/skylar/nuke/state"
+TAG="${USER_ID:0:8}"
+VLIST="$STATE_DIR/byok-drain-$TAG-vehicles.txt"
+CURSOR="$STATE_DIR/byok-drain-$TAG-cursor.txt"
+LOG="/Users/skylar/nuke/logs/byok-image-batch.log"
+LOCK="/tmp/byok-image-drain-$TAG.lock"
+mkdir -p "$STATE_DIR" "$(dirname "$LOG")"
+log(){ echo "$(date '+%F %T') | drain | $*" | tee -a "$LOG"; }
+
+# One fire at a time — don't overlap a slow prior fire or a manual burn-all.
+if [ -f "$LOCK" ]; then
+  pid=$(cat "$LOCK" 2>/dev/null)
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then log "already running (PID $pid) — skip"; exit 0; fi
+fi
+echo $$ > "$LOCK"; trap 'rm -f "$LOCK"' EXIT
+
+# Refresh the vehicle list if missing or stale. A FAILED refresh must not wipe a good
+# list or claim drained — keep the cache; abort only if there is nothing cached.
+need_refresh=0
+if [ ! -s "$VLIST" ]; then
+  need_refresh=1
+else
+  age=$(( $(date +%s) - $(stat -f %m "$VLIST" 2>/dev/null || echo 0) ))
+  [ "$age" -gt "$REFRESH_AGE" ] && need_refresh=1
+fi
+if [ "$need_refresh" -eq 1 ]; then
+  TMP="$VLIST.tmp.$$"
+  if dotenvx run -- node scripts/deep-image-analysis-byok.mjs queue --user-id "$USER_ID" 2>>"$LOG" \
+       | grep -E '^[0-9a-f-]{36}$' > "$TMP" && [ -s "$TMP" ]; then
+    mv "$TMP" "$VLIST"; echo 0 > "$CURSOR"
+    log "refreshed vehicle list: $(wc -l < "$VLIST" | tr -d ' ') vehicles"
+  else
+    rm -f "$TMP"
+    if [ ! -s "$VLIST" ]; then log "vehicle-list refresh failed and nothing cached — abort (NOT draining)"; exit 1; fi
+    log "vehicle-list refresh failed (network?) — using existing cached list"
+  fi
+fi
+
+# Load the list (bash 3.2: no mapfile/readarray).
+VEH=(); while IFS= read -r line; do [ -n "$line" ] && VEH+=("$line"); done < "$VLIST"
+TOTAL=${#VEH[@]}
+[ "$TOTAL" -eq 0 ] && { log "empty vehicle list — abort"; exit 1; }
+
+IDX=$(cat "$CURSOR" 2>/dev/null || echo 0); case "$IDX" in ''|*[!0-9]*) IDX=0;; esac
+if [ "$IDX" -ge "$TOTAL" ]; then
+  log "fleet fully drained ($TOTAL vehicles) — idle until next hourly refresh"
+  exit 0
+fi
+
+# Walk forward, skipping already-drained vehicles, until we do ONE real batch.
+checked=0
+while [ "$IDX" -lt "$TOTAL" ] && [ "$checked" -lt "$TOTAL" ]; do
+  vid="${VEH[$IDX]}"
+  bash "$HERE/byok-image-batch.sh" "$vid" "$BATCH"; rc=$?
+  checked=$((checked+1))
+  case "$rc" in
+    3) IDX=$((IDX+1)); echo "$IDX" > "$CURSOR"; log "drained $vid — cursor $IDX/$TOTAL"; continue;;
+    1) echo "$IDX" > "$CURSOR"; log "transient on $vid (network?) — hold cursor $IDX, retry next fire"; exit 1;;
+    *) echo "$IDX" > "$CURSOR"; log "batch ran on $vid (rc=$rc) — hold cursor, more frames next fire"; exit 0;;
+  esac
+done
+
+echo "$TOTAL" > "$CURSOR"
+log "reached end of fleet this fire — idle until next hourly refresh"
+exit 0

--- a/scripts/deep-image-analysis-byok.mjs
+++ b/scripts/deep-image-analysis-byok.mjs
@@ -573,13 +573,41 @@ async function buildContext() {
   console.log(`context: wrote briefing → ${OUT} (dossier=${dossier ? 'yes' : 'THIN'}, timeline=${dossier?.timeline?.length || 0} days)`);
 }
 
+// queue — print this user's vehicle_ids that have approved frames, most-first.
+// Used by byok-image-drain.sh to self-drive the steady launchd cron across ALL
+// vehicles instead of one hardcoded car. Cheap (scoped to approved frames);
+// prepare skips already-analyzed frames, so a fully-drained vehicle returns
+// instantly and the drain's cursor advances past it.
+async function queue() {
+  const VEHICLE_USER = arg('--user-id');
+  if (!VEHICLE_USER) { console.error('queue: --user-id required'); process.exit(1); }
+  const counts = new Map();
+  const PAGE = 1000;
+  for (let offset = 0; ; offset += PAGE) {
+    const { data, error } = await sb
+      .from('vehicle_images')
+      .select('vehicle_id')
+      .eq('user_id', VEHICLE_USER)
+      .eq('vision_gate_status', 'approved')
+      .not('vehicle_id', 'is', null)
+      .order('vehicle_id', { ascending: true })
+      .range(offset, offset + PAGE - 1);
+    if (error) { console.error(`queue: ${error.message}`); process.exit(1); }
+    if (!data || data.length === 0) break;
+    for (const r of data) counts.set(r.vehicle_id, (counts.get(r.vehicle_id) || 0) + 1);
+    if (data.length < PAGE) break;
+  }
+  for (const [vid] of [...counts.entries()].sort((a, b) => b[1] - a[1])) console.log(vid);
+}
+
 const isMain = process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url);
 if (isMain) {
-  if (!['prepare', 'ingest', 'context'].includes(mode)) {
-    console.error('mode must be "prepare", "ingest", or "context"');
+  if (!['prepare', 'ingest', 'context', 'queue'].includes(mode)) {
+    console.error('mode must be "prepare", "ingest", "context", or "queue"');
     process.exit(1);
   }
   if (mode === 'prepare') await prepare();
   else if (mode === 'context') await buildContext();
+  else if (mode === 'queue') await queue();
   else await ingest();
 }

--- a/scripts/deep-image-analysis-byok.mjs
+++ b/scripts/deep-image-analysis-byok.mjs
@@ -195,15 +195,30 @@ async function prepare() {
   mkdirSync(dirname(WORKLIST), { recursive: true });
   // EXIF is invisible in the (Supabase-stripped) pixels the agent reads — extract it
   // from the row and hand it over: true capture time, GPS, resolved location, camera.
+  //
+  // CRITICAL: the authoritative capture date is the `taken_at` COLUMN (the iOS capture
+  // relay writes asset.creationDate there; see apps/nuke-capture-ios SupabaseService.swift),
+  // NOT exif_data. The relay's exif_data carries no date field and stores the camera as
+  // flat `camera_make`/`camera_model` keys — so the previous code, which read shot_at
+  // from exif_data date fields and the camera from a nested `e.camera.make` object,
+  // returned shot_at=null + camera=null for the ENTIRE iOS-synced library. With no
+  // temporal anchor the detective inferred a date from image content (a 2017 build photo
+  // could land on a 2026 frame). taken_at is primary; exif_data is fallback for
+  // exiftool-backfilled storage images only.
   const exifOf = (r) => {
     const e = r.exif_data || {};
-    const cam = e.camera && typeof e.camera === 'object' ? `${e.camera.make || ''} ${e.camera.model || ''}`.trim()
-      : (typeof e.camera === 'string' ? e.camera : null);
-    const shotAt = e.dateTaken || e.dateTime || e.DateTimeOriginal || e.technical?.dateTaken || null;
+    const shotAt = r.taken_at
+      || e.dateTaken || e.dateTime || e.DateTimeOriginal || e.technical?.dateTaken || e.CreateDate || null;
+    const camMake = e.camera_make || e.Make || (e.camera && typeof e.camera === 'object' ? e.camera.make : null) || null;
+    const camModel = e.camera_model || e.Model || (e.camera && typeof e.camera === 'object' ? e.camera.model : null) || null;
+    const cam = [camMake, camModel].filter(Boolean).join(' ').trim()
+      || (typeof e.camera === 'string' ? e.camera : null) || null;
     const lat = r.latitude ?? e.gps?.latitude ?? e.location?.latitude ?? null;
     const lon = r.longitude ?? e.gps?.longitude ?? e.location?.longitude ?? null;
     return {
-      shot_at: shotAt, camera: cam || null,
+      shot_at: shotAt,
+      shot_at_source: r.taken_at ? 'taken_at' : (shotAt ? 'exif_data' : null),
+      camera: cam,
       gps: (lat != null && lon != null) ? { lat: Number(lat), lon: Number(lon) } : null,
       location_name: r.location_name || null,
       exif_present: !!(cam || shotAt || (lat != null)),

--- a/supabase/migrations/20260621000000_work_session_day_intent_and_confirm.sql
+++ b/supabase/migrations/20260621000000_work_session_day_intent_and_confirm.sql
@@ -1,0 +1,97 @@
+-- work_sessions: day-level intent + drift-repair of owner confirmation columns
+-- ============================================================================
+-- Closes the owner intent-confirmation loop's SCHEMA gap (the top crack in
+-- docs/features/image-processing/GOALS.md). Grounded against the LIVE DB on
+-- 2026-06-21, NOT against the (stale) goals doc:
+--
+--   * owner_confirmed_at / owner_confirmed_by ALREADY EXIST in prod but live in
+--     NO migration and are referenced by NO code — applied directly via SQL in a
+--     past session and orphaned (2 of 778 sessions confirmed; 66 unconfirmed
+--     labor days). GOALS.md asked for differently-named confirmed_at/confirmed_by;
+--     following the doc would have created DUPLICATE columns. This migration
+--     instead repairs the drift: it puts the real columns into version control
+--     (IF NOT EXISTS = no-op in prod, correct on a fresh DB).
+--   * The genuinely-missing piece is day-level INTENT — what a work day was FOR
+--     (the $410-text-to-dad gate). The BYOK detective already produces frame-level
+--     intent (scripts/deep-image-analysis-byok.mjs); this is its day-level rollup
+--     home so a labor day can be owner-confirmed and feed the compounding loop.
+--
+-- Mutable rollup row, not testimony: the immutable record stays in the append-only
+-- vehicle_observations chain. intent_source tracks whether the current value is an
+-- AI guess or owner truth, mirroring the repo's existing *_source provenance idiom
+-- (zone_source, angle_source, vehicle_source). Safe + idempotent.
+
+-- 1. Drift repair — bring the orphaned confirmation columns under version control.
+ALTER TABLE work_sessions
+  ADD COLUMN IF NOT EXISTS owner_confirmed_at  timestamptz,
+  ADD COLUMN IF NOT EXISTS owner_confirmed_by  uuid REFERENCES auth.users(id);
+
+-- 2. Day-level intent (the missing piece). text + CHECK (not a pg enum — enums are
+--    painful to alter) using the BYOK verdict's intent vocabulary so frame→day
+--    rollup is consistent. NULL allowed (CHECK passes on NULL) for not-yet-inferred days.
+ALTER TABLE work_sessions
+  ADD COLUMN IF NOT EXISTS intent             text,
+  ADD COLUMN IF NOT EXISTS intent_confidence  numeric(4,3),
+  ADD COLUMN IF NOT EXISTS intent_source      text NOT NULL DEFAULT 'ai_inferred';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'work_sessions_intent_check') THEN
+    ALTER TABLE work_sessions ADD CONSTRAINT work_sessions_intent_check
+      CHECK (intent IS NULL OR intent IN
+        ('labor','inspection','parts_sourcing','communication','acquisition','documentation','unknown'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'work_sessions_intent_source_check') THEN
+    ALTER TABLE work_sessions ADD CONSTRAINT work_sessions_intent_source_check
+      CHECK (intent_source IN ('ai_inferred','owner_confirmed'));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'work_sessions_intent_confidence_range') THEN
+    ALTER TABLE work_sessions ADD CONSTRAINT work_sessions_intent_confidence_range
+      CHECK (intent_confidence IS NULL OR (intent_confidence >= 0 AND intent_confidence <= 1));
+  END IF;
+END $$;
+
+-- 3. Triage index — "labor days awaiting owner confirmation" is the candidate set
+--    the confirmation surface selects. Partial index keeps it cheap on a growing table.
+CREATE INDEX IF NOT EXISTS idx_work_sessions_unconfirmed
+  ON work_sessions (vehicle_id, session_date DESC)
+  WHERE owner_confirmed_at IS NULL;
+
+-- 4. Column documentation.
+COMMENT ON COLUMN work_sessions.owner_confirmed_at IS
+  'When the owner confirmed this day actually happened as inferred (testimony, owner-trust tier). NULL = awaiting confirmation → surfaces in triage.';
+COMMENT ON COLUMN work_sessions.owner_confirmed_by IS
+  'auth.users id of the owner who confirmed the day.';
+COMMENT ON COLUMN work_sessions.intent IS
+  'Day-level intent: what the work day was FOR. Enum mirrors the BYOK frame-level intent (labor|inspection|parts_sourcing|communication|acquisition|documentation|unknown). Only confirmed labor accrues billable value (the $410 gate).';
+COMMENT ON COLUMN work_sessions.intent_confidence IS
+  '0.0-1.0 AI confidence in the inferred intent. Low confidence + a labor claim = high triage priority.';
+COMMENT ON COLUMN work_sessions.intent_source IS
+  'Provenance of intent: ai_inferred (detective guess) or owner_confirmed (owner testimony, set alongside owner_confirmed_at). Owner truth supersedes the AI guess.';
+
+-- 5. Pipeline registry — record ownership so the next agent does not re-discover this.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'pipeline_registry') THEN
+    INSERT INTO pipeline_registry
+      (table_name, column_name, owned_by, description, valid_values, do_not_write_directly, write_via)
+    VALUES
+      ('work_sessions', 'owner_confirmed_at', 'owner-confirmation',
+       'Owner testimony that a work day happened. Set only via the confirmation write path, never auto.',
+       NULL, true, 'owner confirmation flow (see GOALS.md "THE NEXT MOVE")'),
+      ('work_sessions', 'owner_confirmed_by', 'owner-confirmation',
+       'Owner who confirmed the day.', NULL, true, 'owner confirmation flow'),
+      ('work_sessions', 'intent', 'work-session-rollup',
+       'Day-level intent. AI-inferred by the BYOK detective rollup; owner-correctable via confirmation.',
+       ARRAY['labor','inspection','parts_sourcing','communication','acquisition','documentation','unknown'],
+       false, NULL),
+      ('work_sessions', 'intent_confidence', 'work-session-rollup',
+       'AI confidence 0-1 in inferred intent.', NULL, false, NULL),
+      ('work_sessions', 'intent_source', 'work-session-rollup',
+       'ai_inferred or owner_confirmed.', ARRAY['ai_inferred','owner_confirmed'], false, NULL)
+    ON CONFLICT (table_name, column_name) DO UPDATE
+      SET owned_by = EXCLUDED.owned_by, description = EXCLUDED.description,
+          valid_values = EXCLUDED.valid_values, write_via = EXCLUDED.write_via,
+          do_not_write_directly = EXCLUDED.do_not_write_directly, updated_at = now();
+  END IF;
+END $$;

--- a/supabase/migrations/20260621010000_scope_recompute_value_trigger.sql
+++ b/supabase/migrations/20260621010000_scope_recompute_value_trigger.sql
@@ -1,0 +1,24 @@
+-- Scope the vehicle-value recompute trigger to columns that actually affect value
+-- ============================================================================
+-- trg_recompute_value_on_images fired recompute_value_from_images() on EVERY
+-- INSERT/DELETE/UPDATE of vehicle_images with no column list. recompute calls
+-- compute_vehicle_value(), whose only inputs FROM vehicle_images are:
+--   count(*)                                  -- membership (vehicle_id) + insert/delete
+--   count(*) filter (where coalesce(is_approved, true))   -- is_approved
+-- Nothing else on the row affects value. So every metadata write — work_session_id,
+-- apple_ml_labels, latitude/longitude, suggested_vehicle_id, condition_score,
+-- vehicle_zone, … — was triggering a full per-vehicle revaluation (count over the
+-- vehicle's entire image set + a vehicles UPDATE) for no reason. On a 38.9M-row
+-- table that is a large, constant, wasted prod load, and it forced every backfill
+-- into tiny batches (statement timeouts, measured 2026-06-21).
+--
+-- Fix: fire only on the value-relevant changes. Same function, scoped events.
+-- Value semantics are unchanged (the dropped events never changed the computed value).
+
+DROP TRIGGER IF EXISTS trg_recompute_value_on_images ON public.vehicle_images;
+
+CREATE TRIGGER trg_recompute_value_on_images
+  AFTER INSERT OR DELETE OR UPDATE OF vehicle_id, is_approved
+  ON public.vehicle_images
+  FOR EACH ROW
+  EXECUTE FUNCTION recompute_value_from_images();

--- a/supabase/migrations/20260621020000_fix_orphan_primary_images.sql
+++ b/supabase/migrations/20260621020000_fix_orphan_primary_images.sql
@@ -1,0 +1,70 @@
+-- Stop flagging orphan (vehicle_id IS NULL) images as is_primary
+-- ============================================================================
+-- auto_set_primary_image() (BEFORE INSERT on vehicle_images) decides "first image
+-- for the vehicle → primary" with NOT EXISTS (... WHERE vehicle_id = NEW.vehicle_id).
+-- When NEW.vehicle_id IS NULL, "vehicle_id = NULL" matches no rows, so the guard is
+-- always true and EVERY orphan upload is flagged is_primary=true. Measured 2026-06-21:
+-- user 0 had 7,374 orphan images flagged primary (vs 124 correct per-vehicle primaries
+-- across 131 vehicles).
+--
+-- These are wrong (an unattached image is primary of nothing) AND landmines: the
+-- unique index vehicle_images_one_primary_per_vehicle_idx only covers
+-- vehicle_id IS NOT NULL, so assigning such an image to a vehicle that already has a
+-- primary violates the index and the assignment fails.
+--
+-- Fix: short-circuit the trigger when there is no vehicle. (The AFTER INSERT
+-- primary-setters set_first_image_as_primary_if_none / set_vehicle_primary_image are
+-- already null-safe — their subqueries no-op on vehicle_id = NULL.)
+
+CREATE OR REPLACE FUNCTION public.auto_set_primary_image()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+  -- Orphans cannot be a vehicle's primary; leave is_primary as-is (default false).
+  IF NEW.vehicle_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- If this is the first image for the vehicle, make it primary
+  IF NOT EXISTS (
+    SELECT 1 FROM vehicle_images
+    WHERE vehicle_id = NEW.vehicle_id
+    AND id != NEW.id
+  ) THEN
+    NEW.is_primary = true;
+  END IF;
+
+  -- If no primary exists and this isn't already set as primary, make it primary
+  IF NEW.is_primary IS NOT true AND NOT EXISTS (
+    SELECT 1 FROM vehicle_images
+    WHERE vehicle_id = NEW.vehicle_id
+    AND is_primary = true
+    AND id != NEW.id
+  ) THEN
+    NEW.is_primary = true;
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+-- Data cleanup: clear the bogus orphan primaries. is_primary on a vehicle_id-NULL row
+-- affects no vehicle value or hero selection, so this is non-destructive. Done in a
+-- DO loop in capped batches to stay gentle on the per-row image triggers.
+DO $$
+DECLARE
+  touched int;
+BEGIN
+  LOOP
+    UPDATE vehicle_images
+    SET is_primary = false
+    WHERE id IN (
+      SELECT id FROM vehicle_images
+      WHERE vehicle_id IS NULL AND is_primary = true
+      LIMIT 2000
+    );
+    GET DIAGNOSTICS touched = ROW_COUNT;
+    EXIT WHEN touched = 0;
+  END LOOP;
+END $$;


### PR DESCRIPTION
All changes grounded against the **live code + live DB** for the one test user (`shkylar`, 26,199 images), not the stale docs. 9 commits. Everything here is **substrate/intake-layer** — the prerequisites the real analysis (the BYOK detective) reads from. None require an iOS release (all web / Postgres / scripts).

### Intake correctness
1. **Detective blind to capture date+camera** (`deep-image-analysis-byok.mjs`) — `exifOf` read date/camera from `exif_data`, but the iOS relay writes them to the `taken_at` column + flat `camera_make/model`. Whole iOS library got `shot_at:null` → agent inferred dates from content (2017 on a 2026 frame). Now reads `taken_at` first.
2. **Timeline ordering** (5 web components) — galleries ordered by `created_at` (ingestion), so backfilled old photos surfaced as new. Now order by `taken_at`.
3. **Heatmap truncation** (`profileService`) — built from `.limit(5000)` selects (PostgREST caps to 1000); showed 346 of 1,626 capture-days. Now uses the uncapped `get_user_contribution_days` RPC.

### Structuring (free data → typed columns)
4. **EXIF → columns** — GPS → 21,412 images, Apple ML labels → 8,413 (zero inference).
5. **Capture-session/burst detection** — `taken_at` gaps + GPS jumps → 4,700 sessions, 72% single-subject.
6. **Burst attribution (suggest-only)** — ~601 high-confidence `suggested_vehicle_id` on the unassigned backlog.

### Schema / data-integrity repairs
7. **`work_sessions` day-intent + confirmation drift-repair** — version-controls the orphaned `owner_confirmed_*` columns; adds day-level `intent` (the confirmation-loop foundation).
8. **Session↔image linkage + value-trigger scope** — `build-day.mjs` now writes `start/end_image_id` + `work_session_id` (linkage 381→3,381); scoped `recompute_value_from_images` to `UPDATE OF vehicle_id, is_approved` (was firing on every write).
9. **Orphan-primary fix** — `auto_set_primary_image` flagged every `vehicle_id NULL` upload primary (7,374 for user 0, also unique-index landmines). Guarded + cleaned to 0.

### Known-open (not in this PR)
Analysis drain is laptop-bound and pinned to one vehicle; YONO vision sidecar down; ~314+ byte-identical relay re-sync duplicates in the orphan pool (iOS root cause); session coverage 776/1,623 days; `detect_work_sessions` is dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VY7vRRmx2gDQhhvELQ5vju

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Images now sort by capture time rather than upload time across galleries, improving chronological organization.
  * Work sessions can now be marked with owner confirmation and intent status.
  * Contribution heatmaps now display uncapped aggregated data.

* **Bug Fixes**
  * Fixed orphan images being incorrectly flagged as primary, preventing constraint conflicts.
  * Optimized database triggers to process updates only when relevant data changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->