### PR TITLE
feat(analysis): "Analyze Now" — fire the drain from the app UI

### DIFF
--- a/nuke_frontend/src/pages/settings/AnalysisSettingsPage.tsx
+++ b/nuke_frontend/src/pages/settings/AnalysisSettingsPage.tsx
@@ -19,7 +19,7 @@
 
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { supabase } from '../../lib/supabase';
+import { supabase, getSupabaseFunctionsUrl } from '../../lib/supabase';
 import { useAuth } from '../../hooks/useAuth';
 
 type Method = 'nuke_hosted' | 'byo_api_key' | 'byo_subscription';
@@ -82,6 +82,7 @@ export default function AnalysisSettingsPage() {
   const [provider, setProvider] = useState<Provider>('anthropic');
   const [model, setModel] = useState('');
   const [secret, setSecret] = useState('');
+  const [running, setRunning] = useState(false);
 
   useEffect(() => {
     if (authLoading) return;
@@ -171,6 +172,35 @@ export default function AnalysisSettingsPage() {
       setError(err instanceof Error ? err.message : 'Failed to save');
     } finally {
       setSaving(false);
+    }
+  };
+
+  // Fire a one-off cloud run for just this user's vehicles, right now.
+  const runNow = async () => {
+    setRunning(true);
+    setError('');
+    setNotice('');
+    try {
+      const accessToken = session?.access_token;
+      if (!accessToken) {
+        navigate('/login');
+        return;
+      }
+      const res = await fetch(`${getSupabaseFunctionsUrl()}/trigger-analysis-run`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ minutes: 10, batch: 8 }),
+      });
+      const result = await res.json().catch(() => ({}));
+      if (res.ok) {
+        setNotice(result.message || 'Analysis run dispatched — it runs in the cloud.');
+      } else {
+        setError(result.error || `Could not start analysis (${res.status}).`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not start analysis');
+    } finally {
+      setRunning(false);
     }
   };
 
@@ -361,24 +391,56 @@ export default function AnalysisSettingsPage() {
         </div>
       )}
 
-      <button
-        onClick={save}
-        disabled={saving}
-        style={{
-          background: 'var(--accent)',
-          color: 'var(--bg)',
-          border: 'none',
-          padding: '12px 20px',
-          fontSize: '12px',
-          cursor: saving ? 'default' : 'pointer',
-          opacity: saving ? 0.5 : 1,
-          textTransform: 'uppercase',
-          letterSpacing: '0.06em',
-          fontWeight: 700,
-        }}
-      >
-        {saving ? 'Saving…' : 'Save Analysis Settings'}
-      </button>
+      <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
+        <button
+          onClick={save}
+          disabled={saving}
+          style={{
+            background: 'var(--accent)',
+            color: 'var(--bg)',
+            border: 'none',
+            padding: '12px 20px',
+            fontSize: '12px',
+            cursor: saving ? 'default' : 'pointer',
+            opacity: saving ? 0.5 : 1,
+            textTransform: 'uppercase',
+            letterSpacing: '0.06em',
+            fontWeight: 700,
+          }}
+        >
+          {saving ? 'Saving…' : 'Save Analysis Settings'}
+        </button>
+
+        {/* On-demand run — no GitHub tab needed. Disabled until a method is saved. */}
+        <button
+          onClick={runNow}
+          disabled={running || !settings || settings.enabled === false}
+          title={
+            !settings
+              ? 'Save your analysis settings first'
+              : settings.enabled === false
+              ? 'Analysis is turned off'
+              : 'Analyze your vehicles now (runs in the cloud)'
+          }
+          style={{
+            background: 'transparent',
+            color: 'var(--text)',
+            border: '2px solid var(--accent)',
+            padding: '12px 20px',
+            fontSize: '12px',
+            cursor: running || !settings || settings.enabled === false ? 'default' : 'pointer',
+            opacity: running || !settings || settings.enabled === false ? 0.5 : 1,
+            textTransform: 'uppercase',
+            letterSpacing: '0.06em',
+            fontWeight: 700,
+          }}
+        >
+          {running ? 'Starting…' : 'Analyze Now'}
+        </button>
+      </div>
+      <p style={{ fontSize: '10px', color: 'var(--text-muted)', marginTop: '8px' }}>
+        "Analyze Now" runs a short cloud burst over your vehicles. The hourly schedule keeps going on its own.
+      </p>
     </div>
   );
 }

--- a/supabase/functions/trigger-analysis-run/index.ts
+++ b/supabase/functions/trigger-analysis-run/index.ts
@@ -1,0 +1,119 @@
+/**
+ * Trigger Analysis Run
+ *
+ * Fires the BYOK analysis drain from the app UI — so a user analyzes their own
+ * vehicles with one click instead of opening the GitHub Actions tab.
+ *
+ * POST /functions/v1/trigger-analysis-run
+ *   { minutes?: number, batch?: number }   // model comes from the user's settings
+ *
+ * The run is ALWAYS scoped to the authenticated user's own id — a caller can never
+ * dispatch analysis for someone else's vehicles. It dispatches the existing
+ * `byok-analysis-drain.yml` workflow via GitHub's workflow_dispatch API; that
+ * workflow then resolves THIS user's chosen compute (nuke_hosted / subscription /
+ * api key) through the broker, exactly like the scheduled run.
+ *
+ * SECRET REQUIRED: GITHUB_DISPATCH_TOKEN — a fine-grained PAT (or GitHub App token)
+ * with `actions: write` on sss97133/nuke. Without it the function returns a clear
+ * 503 instead of silently doing nothing.
+ */
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+const REPO = "sss97133/nuke";
+const WORKFLOW = "byok-analysis-drain.yml";
+const REF = "main";
+
+function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+  if (req.method !== "POST") return json(405, { error: "POST only" });
+
+  try {
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    );
+
+    // Authenticate — the run is scoped to THIS user only.
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) return json(401, { error: "Authentication required" });
+    const token = authHeader.replace("Bearer ", "");
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !user) return json(401, { error: "Invalid authentication" });
+
+    const ghToken = Deno.env.get("GITHUB_DISPATCH_TOKEN");
+    if (!ghToken) {
+      return json(503, {
+        error:
+          "On-demand analysis isn't wired up yet: set the GITHUB_DISPATCH_TOKEN secret " +
+          "(a PAT with actions:write on " + REPO + "). The hourly schedule still runs without it.",
+      });
+    }
+
+    // Clamp the budget so a button press can't launch an enormous run.
+    const body = await req.json().catch(() => ({}));
+    const minutes = Math.min(Math.max(Number(body.minutes) || 10, 1), 30);
+    const batch = Math.min(Math.max(Number(body.batch) || 8, 1), 20);
+
+    // Respect the user's stored settings: disabled => nothing to do; model passes through
+    // the workflow input (the broker still overrides per-row, this is just the default).
+    const { data: settings } = await supabase
+      .from("user_analysis_settings")
+      .select("enabled, model")
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (settings && settings.enabled === false) {
+      return json(409, { error: "Analysis is turned off in your settings. Enable it first." });
+    }
+
+    const inputs: Record<string, string> = {
+      user_id: user.id,
+      minutes: String(minutes),
+      batch: String(batch),
+    };
+    if (settings?.model) inputs.model = settings.model;
+
+    const res = await fetch(
+      `https://api.github.com/repos/${REPO}/actions/workflows/${WORKFLOW}/dispatches`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${ghToken}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ ref: REF, inputs }),
+      },
+    );
+
+    if (res.status === 204) {
+      return json(202, {
+        ok: true,
+        message: "Analysis run dispatched. It runs in the cloud — check back on your vehicles shortly.",
+      });
+    }
+
+    const detail = await res.text().catch(() => "");
+    return json(502, {
+      error: "GitHub rejected the dispatch",
+      status: res.status,
+      detail: detail.slice(0, 400),
+    });
+  } catch (err) {
+    return json(500, { error: err instanceof Error ? err.message : "unexpected error" });
+  }
+});


### PR DESCRIPTION
## Why
After #295 a user could pick their analysis compute in Settings, but the only way to *run* it on demand was the GitHub Actions tab. That's not a product. This adds a one-click **Analyze Now** in the app.

## What
- **Edge function `trigger-analysis-run`** — authenticates the user and dispatches the existing `byok-analysis-drain.yml` workflow, **scoped to their own `user_id`** (a caller can never analyze someone else's vehicles). It honors the user's `enabled` flag, passes their chosen model through, and clamps `minutes`/`batch` so a button press can't launch an enormous run. If the `GITHUB_DISPATCH_TOKEN` secret isn't set it returns a clear **503** rather than a silent no-op.
- **Settings UI** — an **Analyze Now** button beside Save (`/settings/analysis`), disabled until settings are saved or when analysis is turned off. The hourly schedule keeps running regardless.

## How the run still picks the right compute
The dispatched workflow runs the same broker (`deep-image-analysis-byok.mjs resolve`) it does on a schedule, so the on-demand run uses whatever the user chose — hosted / subscription / API key.

## Action required
On-demand needs one **new Supabase function secret**: `GITHUB_DISPATCH_TOKEN` — a fine-grained PAT (or GitHub App token) with `actions: write` on `sss97133/nuke`. Set it via `supabase secrets set` or the dashboard. **The hourly schedule needs none of this** and keeps working without the token.

## Deploy
The edge function deploys automatically via `supabase-deploy.yml` (changed-function detection) on merge to `main` — no hand-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VY7vRRmx2gDQhhvELQ5vju

---
_Generated by [Claude Code](https://claude.ai/code/session_01VY7vRRmx2gDQhhvELQ5vju)_