### PR TITLE
feat(analysis): per-image "Analyze" — run Claude on a single target

### DIFF
--- a/.github/workflows/byok-analysis-drain.yml
+++ b/.github/workflows/byok-analysis-drain.yml
@@ -35,6 +35,9 @@ on:
       model:
         description: Claude vision model
         default: 'claude-sonnet-4-6'
+      vehicle_id:
+        description: Analyze only this vehicle (blank = whole fleet)
+        default: ''
   schedule:
     - cron: '0 * * * *'   # hourly
 
@@ -91,7 +94,8 @@ jobs:
           bash scripts/daily-receipt/byok-cloud-drain.sh \
             "${{ github.event.inputs.user_id || '0b9f107a-d124-49de-9ded-94698f63c1c4' }}" \
             "${{ github.event.inputs.batch || '12' }}" \
-            "${{ github.event.inputs.minutes || '45' }}"
+            "${{ github.event.inputs.minutes || '45' }}" \
+            "${{ github.event.inputs.vehicle_id || '' }}"
 
       - name: Upload drain log
         if: always()

--- a/nuke_frontend/src/components/image/ImageLightbox.tsx
+++ b/nuke_frontend/src/components/image/ImageLightbox.tsx
@@ -365,6 +365,10 @@ const ImageLightbox: React.FC<ImageLightboxProps> = ({
 
   const [attribution, setAttribution] = useState<any>(null);
   const [imageMetadata, setImageMetadata] = useState<any>(null);
+  // Deep (BYOK) analysis request state — distinct from the legacy ai_processing_status
+  // triage. "Analyzed" here means ai_scan_metadata.byok_deep_analysis exists.
+  const [deepRequesting, setDeepRequesting] = useState(false);
+  const [deepRequested, setDeepRequested] = useState(false);
   const [angleData, setAngleData] = useState<any>(null);
   const [vehicleOwnerId, setVehicleOwnerId] = useState<string | null>(null);
   const [previousOwners, setPreviousOwners] = useState<Set<string>>(new Set());
@@ -1034,6 +1038,31 @@ const ImageLightbox: React.FC<ImageLightboxProps> = ({
     [imageUrl, vehicleId, imageId, session?.user?.id, triggerAIAnalysis, timelineEventId, loadTags, loadImageMetadata]
   );
 
+  // Request deep BYOK analysis for THIS image's vehicle. The drain is the unit
+  // (vehicle day-chunks), so this queues the vehicle; the cloud run reads the frame
+  // and writes ai_scan_metadata.byok_deep_analysis + a provenance-stamped observation.
+  const requestDeepAnalysis = useCallback(async () => {
+    if (!vehicleId || deepRequesting) return;
+    setDeepRequesting(true);
+    try {
+      const { data, error } = await supabase.functions.invoke('trigger-analysis-run', {
+        body: { vehicle_id: vehicleId },
+      });
+      if (error) {
+        // Edge function returns a clear message in the body for known cases (no token, etc.)
+        const msg = (error as any)?.context?.body || error.message || 'Could not start analysis';
+        toast.error(typeof msg === 'string' ? msg : 'Could not start analysis');
+      } else {
+        setDeepRequested(true);
+        toast.success(data?.message || 'Analysis dispatched — runs in the cloud.');
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Could not start analysis');
+    } finally {
+      setDeepRequesting(false);
+    }
+  }, [vehicleId, deepRequesting]);
+
   const submitClaim = useCallback(async () => {
     if (!claimTarget) return;
     setClaimSubmitting(true);
@@ -1507,8 +1536,28 @@ const ImageLightbox: React.FC<ImageLightboxProps> = ({
               />
             );
           })()}
-          
-          <button 
+
+          {/* Deep-analysis trigger — shown only when this image has no BYOK deep verdict
+              yet. Fires a cloud run scoped to this image's vehicle. */}
+          {vehicleId && !imageMetadata?.ai_scan_metadata?.byok_deep_analysis && (
+            <button
+              onClick={requestDeepAnalysis}
+              disabled={deepRequesting || deepRequested}
+              title={deepRequested
+                ? 'Analysis queued for this vehicle'
+                : 'Analyze this image with Claude (runs in the cloud)'}
+              className={`px-3 py-1.5 border-2 text-[9px] font-bold uppercase tracking-wide transition-all duration-150 ${
+                deepRequesting || deepRequested
+                  ? 'bg-[#2a2a2a] text-white/40 border-white/10 cursor-not-allowed'
+                  : 'bg-transparent border-emerald-500/50 text-emerald-300 hover:border-emerald-400 hover:bg-emerald-500/10'
+              }`}
+              style={{ fontFamily: 'Arial, sans-serif' }}
+            >
+              {deepRequesting ? 'Starting…' : deepRequested ? 'Queued' : 'Analyze'}
+            </button>
+          )}
+
+          <button
             onClick={() => setShowSidebar(!showSidebar)}
             className={`px-3 py-1.5 border-2 text-[9px] font-bold uppercase tracking-wide transition-all duration-150 ${
               showSidebar 

--- a/scripts/daily-receipt/byok-cloud-drain.sh
+++ b/scripts/daily-receipt/byok-cloud-drain.sh
@@ -14,14 +14,17 @@
 # API key. Default model is Sonnet, which the batch notes is "fast + accurate enough
 # for the bulk drain" and is easier on subscription rate limits than Opus.
 #
-# Usage: byok-cloud-drain.sh <user-id> [batch_size] [minutes]
+# Usage: byok-cloud-drain.sh <user-id> [batch_size] [minutes] [vehicle_id]
+#   vehicle_id (optional): drain ONLY that one vehicle (the per-image "Analyze" button
+#   in the app targets the image's vehicle). Omitted → drain the whole fleet, most-first.
 set -u
 cd "$(dirname "$0")/../.." || exit 1
 HERE="$(dirname "$0")"
 
-USER_ID="${1:?usage: byok-cloud-drain.sh <user-id> [batch_size] [minutes]}"
+USER_ID="${1:?usage: byok-cloud-drain.sh <user-id> [batch_size] [minutes] [vehicle_id]}"
 BATCH="${2:-12}"
 MINUTES="${3:-45}"
+ONLY_VEHICLE="${4:-}"
 DEADLINE=$(( $(date +%s) + MINUTES * 60 ))
 log(){ echo "$(date -u '+%F %T') | cloud-drain | $*"; }
 
@@ -57,11 +60,17 @@ case "$METHOD" in
     fi ;;
 esac
 
-# Vehicles with approved frames, most-first (cheap; prepare skips drained ones instantly).
+# Build the work list. Single-vehicle when targeted from the app; otherwise the whole
+# fleet, most-first (cheap; prepare skips drained ones instantly).
 VEH=()
-while IFS= read -r line; do
-  [[ "$line" =~ ^[0-9a-f-]{36}$ ]] && VEH+=("$line")
-done < <(dotenvx run -- node scripts/deep-image-analysis-byok.mjs queue --user-id "$USER_ID" 2>&1)
+if [[ "$ONLY_VEHICLE" =~ ^[0-9a-f-]{36}$ ]]; then
+  VEH=("$ONLY_VEHICLE")
+  log "targeted run: single vehicle ${ONLY_VEHICLE:0:8}"
+else
+  while IFS= read -r line; do
+    [[ "$line" =~ ^[0-9a-f-]{36}$ ]] && VEH+=("$line")
+  done < <(dotenvx run -- node scripts/deep-image-analysis-byok.mjs queue --user-id "$USER_ID" 2>&1)
+fi
 
 if [ "${#VEH[@]}" -eq 0 ]; then
   log "vehicle queue empty or query failed — abort (NOT a drain)"; exit 1

--- a/supabase/functions/trigger-analysis-run/index.ts
+++ b/supabase/functions/trigger-analysis-run/index.ts
@@ -5,7 +5,11 @@
  * vehicles with one click instead of opening the GitHub Actions tab.
  *
  * POST /functions/v1/trigger-analysis-run
- *   { minutes?: number, batch?: number }   // model comes from the user's settings
+ *   { minutes?: number, batch?: number, vehicle_id?: uuid }  // model from user settings
+ *
+ * vehicle_id (optional): analyze just that one vehicle — this is what the per-image
+ * "Analyze" button targets. We verify the caller actually has images on that vehicle
+ * before dispatching, so a user can only ever target their own data.
  *
  * The run is ALWAYS scoped to the authenticated user's own id — a caller can never
  * dispatch analysis for someone else's vehicles. It dispatches the existing
@@ -65,8 +69,28 @@ Deno.serve(async (req) => {
 
     // Clamp the budget so a button press can't launch an enormous run.
     const body = await req.json().catch(() => ({}));
-    const minutes = Math.min(Math.max(Number(body.minutes) || 10, 1), 30);
     const batch = Math.min(Math.max(Number(body.batch) || 8, 1), 20);
+
+    // Optional single-vehicle target (the per-image button). Verify ownership: the caller
+    // must actually have images on that vehicle, else they could analyze someone else's.
+    let vehicleId: string | null = null;
+    if (body.vehicle_id) {
+      if (!/^[0-9a-f-]{36}$/i.test(String(body.vehicle_id))) {
+        return json(400, { error: "vehicle_id is not a valid uuid" });
+      }
+      const { count, error: ce } = await supabase
+        .from("vehicle_images")
+        .select("id", { count: "exact", head: true })
+        .eq("vehicle_id", body.vehicle_id)
+        .eq("user_id", user.id);
+      if (ce) return json(500, { error: "ownership check failed: " + ce.message });
+      if (!count) {
+        return json(403, { error: "You don't have any images on that vehicle." });
+      }
+      vehicleId = String(body.vehicle_id);
+    }
+    // A targeted single-vehicle run is short; a fleet run gets the default budget.
+    const minutes = Math.min(Math.max(Number(body.minutes) || (vehicleId ? 8 : 10), 1), 30);
 
     // Respect the user's stored settings: disabled => nothing to do; model passes through
     // the workflow input (the broker still overrides per-row, this is just the default).
@@ -85,6 +109,7 @@ Deno.serve(async (req) => {
       batch: String(batch),
     };
     if (settings?.model) inputs.model = settings.model;
+    if (vehicleId) inputs.vehicle_id = vehicleId;
 
     const res = await fetch(
       `https://api.github.com/repos/${REPO}/actions/workflows/${WORKFLOW}/dispatches`,
@@ -103,7 +128,10 @@ Deno.serve(async (req) => {
     if (res.status === 204) {
       return json(202, {
         ok: true,
-        message: "Analysis run dispatched. It runs in the cloud — check back on your vehicles shortly.",
+        scope: vehicleId ? "vehicle" : "fleet",
+        message: vehicleId
+          ? "Analysis dispatched for this vehicle — it runs in the cloud, check back shortly."
+          : "Analysis run dispatched. It runs in the cloud — check back on your vehicles shortly.",
       });
     }
 


### PR DESCRIPTION
## Why
You asked for an **Analyze** button next to every image that isn't analyzed — the entry point to running Claude directly on a specific target. This is **Layer 1**: the per-target trigger. (Layer 2, the interactive agent on the `image-ai-chat` seed with provenance-stamped writes, comes next.)

## What
- **Lightbox button** — every un-analyzed image shows an **Analyze** button in the toolbar. "Not analyzed" means no `ai_scan_metadata.byok_deep_analysis` (the real deep-verdict key the BYOK engine writes), **not** the legacy `ai_processing_status` triage — so it tells the truth about deep analysis. The button hides once a verdict exists.
- **`trigger-analysis-run`** — now accepts an optional `vehicle_id`, **verifies the caller actually has images on that vehicle** (you can't target someone else's), and dispatches a run scoped to it. Targeted runs get a shorter budget.
- **`byok-cloud-drain.sh` + workflow** — an optional `vehicle_id` drains just that one vehicle; omitted = whole fleet, as before.

## Scope decision (you said "best you figure it out")
The button targets **that image's vehicle**, because the engine's real unit is a vehicle's day-chunks, not a single isolated frame. The cloud run reads the frame and writes `ai_scan_metadata.byok_deep_analysis` plus a provenance-stamped observation. Single-image-in-isolation would bypass the accumulation model and is a much larger engine change — not worth it for the same result.

## Verification
Frontend typecheck clean; drain syntax-checked. Uses `supabase.functions.invoke` (auto-auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VY7vRRmx2gDQhhvELQ5vju

---
_Generated by [Claude Code](https://claude.ai/code/session_01VY7vRRmx2gDQhhvELQ5vju)_