### PR TITLE
fix(images): deterministic primary-image rule + Layer 2 vehicle-agent (WIP)

### DIFF
--- a/docs/library/technical/engineering-manual/16-image-attribution-harness.md
+++ b/docs/library/technical/engineering-manual/16-image-attribution-harness.md
@@ -75,15 +75,35 @@ substitute for that context.**
   never re-reading the pixels — so it is nearly free.
 
 - **Context folder (work session).** The strongest prior of all, because it encodes
-  *intent*: the vehicle the technician is actually working on. A dash-teardown
-  close-up that names no marque ("an older vehicle") is not ambiguous if the work
-  session says "today is the 1989 R3500" — the whole session is the R3500 by
-  **declaration**, and inheritance is unnecessary. The rail exists
-  (`vehicle_images.work_session_id`) but is currently null; capturing it at upload —
-  the technician declaring/confirming the active build — is the highest-leverage
-  attribution fix in the system, because it converts a guess into ground truth at
-  the source. For the backlog, the folder is reconstructed (time+GPS) and the subject
-  is confirmed by the owner in review.
+  *intent* — but it is **evidenced, never declared.** The technician does not tell
+  the system what they are working on; **they already testified by shooting.** The
+  photo declares the intent (a teardown shot *is* the teardown), the sequence
+  declares the session, and the **device signature** signs who testified. A
+  dash-teardown close-up that names no marque is not ambiguous, not because anyone
+  declared the subject, but because it is signed by the same device, within the same
+  time/place run, inside a progression that is visibly the 1989 R3500. **Soliciting a
+  declaration is friction for evidence the system already holds.** The rail
+  `vehicle_images.work_session_id` is null — but so is the declaration's premise: the
+  fix is not a "what are you working on?" prompt, it is to *read the testimony that is
+  already on every frame* (see Device signature, Gap as proof of work). For the
+  backlog the folder is reconstructed from that evidence; the owner only adjudicates
+  genuine ambiguity in review.
+
+- **Device signature.** The phone/account identity in EXIF — the technician's
+  signature on the testimony. Present on 100% of the test frames
+  (`exif_data.camera_make/camera_model/synced_by` = "Apple / iPhone 15 Pro /
+  capture-relay-ios"), yet **never extracted** into the queryable
+  `device_fingerprint` / `documented_by_device` columns (both null). Extracting it is
+  the real "context folder" rail: same-device + time + place binds a run of frames
+  into one work session without asking anyone anything.
+
+- **Gap as proof of work.** A work session is self-proving through *change*. When the
+  sequence goes broken → fixed on the same component, the gap between the states
+  **is** the work — and the same part progressing **is** the same vehicle, which
+  confirms subject continuity for the whole run, including the close-ups that name
+  nothing. State-change is therefore both the proof that a session is real and the
+  glue that holds its subject together. (This is the image-as-testimony spine of the
+  platform applied to attribution: the tech already testified; we read it.)
 
 - **Knowledge-base re-pass.** Once a frame's subject is fixed (by anchor, inheritance,
   or context folder), the read can be sharpened by re-running it *with the correct
@@ -186,6 +206,11 @@ image), so flagging a frame removes it from the wrong profile *before* the move.
   exactly the unnameable close-ups — which the work session resolves (the technician
   knows that teardown is the 1989 R3500 Cheyenne, `b1edd5c1`, confirmed in the
   garage).
+- **The testimony is already signed.** All 122 frames of that sweep are stamped in
+  EXIF by one device — Apple iPhone 15 Pro via capture-relay-ios — across one work
+  day (01:10–21:55). The technician signed every frame; the system simply never
+  extracted the signature (`device_fingerprint` null on 100%). Attribution does not
+  need a declaration; it needs to *read what is already there*.
 - **Subject identity cannot be done in SQL.** Token-overlap against the kin garage
   trades false positives (a pseudo-vehicle "Unassigned Vehicle **Photos**" matching
   any narrative with "photos"/"vehicle"; "Intake Quarantine" matching engine
@@ -201,11 +226,14 @@ image), so flagging a frame removes it from the wrong profile *before* the move.
 - `byok-vision-prompt.md` is referenced by `byok-image-batch.sh` but **missing from
   the repo** — the cloud drain `cat`s a file that isn't there, degrading the prompt.
   Recreate before relying on the forward-fix.
-- `upload_batch_id` **and** `work_session_id` are **null** across `vehicle_images` —
-  both the batch rail and the context-folder rail exist but are unpopulated. Sessions
-  must be reconstructed from time+GPS until these are stamped at intake. Stamping
-  `work_session_id` at capture (technician declares the active build) is the
-  single highest-leverage fix and should be prioritized over backlog reconstruction.
+- `upload_batch_id`, `work_session_id`, `device_fingerprint`, and
+  `documented_by_device` are all **null** across `vehicle_images` — the rails exist,
+  unpopulated. But the underlying evidence is **not** missing: `exif_data` is present
+  on 100% of frames and already carries the device signature
+  (`camera_make/camera_model/synced_by`). The highest-leverage fix is therefore to
+  **extract the signature from EXIF and derive the work session from evidence**
+  (device + time + place + state-change), not to add a declaration UI — the testimony
+  is already on the image.
 - One-off cleanup scripts exist (`fix-mixed-vehicle-data.js`,
   `cleanup_vehicle_contamination.js`) — prior attempts that did not stick because
   they never fixed the DNA (no structured subject, no harness). This chapter is the

--- a/docs/library/technical/engineering-manual/16-image-attribution-harness.md
+++ b/docs/library/technical/engineering-manual/16-image-attribution-harness.md
@@ -105,19 +105,21 @@ substitute for that context.**
   glue that holds its subject together. (This is the image-as-testimony spine of the
   platform applied to attribution: the tech already testified; we read it.)
 
-- **Album context.** The uploaded set is a **gappy subset** of the real album, and
-  correct sessionization needs the whole. Proof (test user, 2026-06-20): the day's
-  frames are filenames IMG_1373–1507 — a 135-frame span in the album, of which only
-  **122 uploaded; 13 neighbors exist locally and the cloud never sees them.** The
-  relay also synced `source_type:"user_library"` (the whole camera roll) rather than
-  the vehicle's **folder** — so the owner's own organization (e.g. the 84 K20 folder)
-  never reached the cloud. Two consequences: (1) the contiguous `original_filename`
-  run is a *cleaner* session key than time/GPS bucketing (one IMG_ run = one shoot);
-  (2) the strongest attribution signal of all — the local album folder — is only
-  visible to **local processing**. This is why the architecture is local+cloud: local
-  reads the folder + the full album index (count, this frame's position, neighbors,
-  what's still pending) and hands it up; the cloud does the heavy read. Without it the
-  cloud is attributing from a sequence with holes.
+- **Album context (sequence, not folders).** The uploaded set is a **gappy subset**
+  of the real album, and correct sessionization needs to know the whole — but *not*
+  by trusting albums. Proof (test user, 2026-06-20): the day's frames are filenames
+  IMG_1373–1507 — a 135-frame span, of which only **122 uploaded; 13 neighbors exist
+  locally and the cloud never sees them.** The dependable local signal is the
+  **chronological sequence and its completeness** — how many frames bracket this one,
+  which exist locally but haven't uploaded, which are still coming — so the cloud
+  stops sessionizing from a sequence with holes. **Albums/folders are NOT dependable
+  and must never key attribution**: a user may treat an album as a random bag (the
+  relay even synced `source_type:"user_library"`, the whole roll). The contiguous
+  `original_filename`/time run is a useful *session* signal (one IMG_ run ≈ one
+  shoot); but the *subject* of those frames always comes from **content** (signatures
+  + the harness), never from which album they sit in. This is the real local+cloud
+  split: local supplies full-sequence awareness (count, position, neighbors,
+  pending); the cloud does the content read.
 
 - **Knowledge-base re-pass.** Once a frame's subject is fixed (by anchor, inheritance,
   or context folder), the read can be sharpened by re-running it *with the correct

--- a/docs/library/technical/engineering-manual/16-image-attribution-harness.md
+++ b/docs/library/technical/engineering-manual/16-image-attribution-harness.md
@@ -105,6 +105,20 @@ substitute for that context.**
   glue that holds its subject together. (This is the image-as-testimony spine of the
   platform applied to attribution: the tech already testified; we read it.)
 
+- **Album context.** The uploaded set is a **gappy subset** of the real album, and
+  correct sessionization needs the whole. Proof (test user, 2026-06-20): the day's
+  frames are filenames IMG_1373–1507 — a 135-frame span in the album, of which only
+  **122 uploaded; 13 neighbors exist locally and the cloud never sees them.** The
+  relay also synced `source_type:"user_library"` (the whole camera roll) rather than
+  the vehicle's **folder** — so the owner's own organization (e.g. the 84 K20 folder)
+  never reached the cloud. Two consequences: (1) the contiguous `original_filename`
+  run is a *cleaner* session key than time/GPS bucketing (one IMG_ run = one shoot);
+  (2) the strongest attribution signal of all — the local album folder — is only
+  visible to **local processing**. This is why the architecture is local+cloud: local
+  reads the folder + the full album index (count, this frame's position, neighbors,
+  what's still pending) and hands it up; the cloud does the heavy read. Without it the
+  cloud is attributing from a sequence with holes.
+
 - **Knowledge-base re-pass.** Once a frame's subject is fixed (by anchor, inheritance,
   or context folder), the read can be sharpened by re-running it *with the correct
   vehicle's dossier as context* — its receipts, parts, prior verdicts. This is not a

--- a/docs/library/technical/engineering-manual/16-image-attribution-harness.md
+++ b/docs/library/technical/engineering-manual/16-image-attribution-harness.md
@@ -1,0 +1,180 @@
+# Chapter 16: The Image Attribution Harness
+
+## Why this chapter exists
+
+Deep image analysis can be excellent and still produce a worthless vehicle profile.
+On a real garage (test user, 2026-06-21) the analysis read a data plate down to the
+serial — "International Harvester Scout 80 4x4, serial FC 26799A" — and correctly
+flagged the frame off-subject. Yet that frame, and ~40 others, were attached to a
+**1966 Mustang**. The analysis was right; the *attribution* was wrong. Only 45% of
+the Mustang's analyzed photos actually depicted a Mustang.
+
+The lesson that organizes this chapter: **a count of "images analyzed" is a vanity
+metric. The unit of correctness is whether each verdict is bound to the right
+vehicle.** A fast wrong attribution is negative value — it pollutes a profile you
+then pay to clean. Accuracy, not throughput, is what compute is spent on.
+
+This chapter defines the vocabulary and the architecture for getting the binding
+right, especially for the hard case: the close-up and the non-obvious frame.
+
+---
+
+## The thesis: model the expert glance
+
+An expert can look at almost any vehicle photo and be reliably close. Naming *why*
+gives us the architecture, because the machine must be handed deliberately what the
+expert carries for free.
+
+1. **Gestalt over priors.** The expert matches the whole-image signature against a
+   vast library of examples and resolves the **genus** instantly (square-body Chevy,
+   early Bronco, a '66 Mustang). Fast, holistic, sub-second.
+2. **Convergence, not single cues.** No one cue decides. Valve-cover color, bolt
+   pattern, casting roughness, patina, fastener style — each is weak, but they
+   **converge**. Confidence is *agreement among independent cues*, not a single
+   score. This is why the genus is reliably right: it is over-determined.
+3. **Context as a silent prior.** The expert knows whose shop this is and what was
+   just in frame. A carburetor close-up is not ambiguous to them because *they know
+   they are standing at the Scout.* This is Bayesian context the machine throws away
+   when it judges a frame in isolation.
+4. **Calibrated humility.** "Almost always close" ≠ "certain." The expert nails the
+   genus and holds the **species** (exact trim, casting date, build history) as an
+   open question. The system must likewise be confident about the genus and explicit
+   about the unresolved species.
+
+A frame analyzed alone will always underperform the expert, because the expert's
+edge is the context the frame doesn't contain. **The harness is the machine's
+substitute for that context.**
+
+---
+
+## Definitions (the new vocabulary)
+
+- **Subject identity.** What vehicle a frame actually depicts: `{depicted_make,
+  depicted_model, confidence, identity_evidence}`. Distinct from `vehicle_id`, which
+  is the vehicle the frame is *attributed to*. Mis-attribution = subject identity ≠
+  attributed vehicle.
+
+- **Anchor.** A frame whose subject identity is self-evident from its own pixels — a
+  full-vehicle shot, a badge, and most authoritatively a **data plate / VIN /
+  casting number**. Anchors carry identity for everything around them.
+
+- **Detail (non-obvious) frame.** A close-up — carburetor, weld, bolt, bracket —
+  that cannot self-identify. It must **inherit**, never be guessed from its pixels.
+
+- **Capture session.** The unit of attribution, *not* the image. A continuous
+  shooting run, reconstructed from `taken_at` proximity + GPS + (when populated)
+  `upload_batch_id`. You shoot a vehicle wide, then zoom into details; the details
+  are temporally bracketed by the anchors. A **sweep** is a session containing more
+  than one subject (a lot/facility walk) — it must be segmented by subject, not
+  moved wholesale.
+
+- **Inheritance.** A detail frame takes the subject of the nearest anchor within its
+  session. This is the formal answer to "how do you attribute a close-up": *you
+  don't analyze it, you inherit from its session.*
+
+- **Component DNA.** Marque-level cues the analysis already extracts
+  (`components_seen`, `state_observations`) — an IH slant-4 is not a Ford V8 is not a
+  Chevy small-block. Used to *cross-check* an inherited subject (agree → confidence
+  up; contradict → flag), never as the primary signal for a detail frame.
+
+- **Kin network.** The set of a user's other vehicles (and discovered/comp
+  vehicles). The home-resolution space: a mis-attributed segment is re-homed to the
+  kin vehicle it actually depicts (the Scout frames → the 1961 Scout 80), not
+  orphaned. Owned vehicles vs discovered/comp vehicles are different kin tiers and
+  must not pool their data (see Chapter 9, Discovery System).
+
+- **Authority / resolution ladder.** Where the system "turns" when gestalt
+  confidence is low — descended only as far as needed, never skipped to a guess:
+  1. the object's own marks (data plate, VIN, casting numbers, date codes),
+  2. the paper (title, build sheet, receipts, original listing),
+  3. the reference corpus (marque registry, casting-number books, decoders),
+  4. the kin and comps (compare to known examples),
+  5. the human of last resort (marque club, the person who knows).
+
+- **Two-speed engine.** The analysis as a whole: **fast gestalt** for coverage and
+  calibrated confidence, **slow authority-resolution** for the details that matter.
+  Low confidence escalates down the ladder; it does not emit a coin-flip dressed as
+  a verdict.
+
+---
+
+## Architecture
+
+### Stage 0 — Deep analysis (existing)
+`scripts/deep-image-analysis-byok.mjs` writes per-frame verdicts to
+`vehicle_images.ai_scan_metadata.byok_deep_analysis` against the contract in
+`scripts/schemas/byok-image-verdict.schema.json` (schema-as-DNA: a tourist-caption
+verdict cannot land). Rich today: scene_type, components_seen, state_observations,
+camera_pose, GPS place_hint, narrative_one_line.
+
+**The gap:** the verdict schema has no structured `subject`. The model identifies the
+vehicle in prose ("International Harvester Scout 80") but never asserts it as data,
+and never states whether it matches the attributed vehicle. So a Scout verdict
+validates fine on a Mustang. The early-stage fix (forward): add a required `subject`
+block —
+```
+subject: { matches_target: yes | no | detail_inherits | uncertain,
+           depicted_make, depicted_model, match_confidence, identity_evidence }
+```
+`detail_inherits` is the close-up declaring it must be resolved by the harness, not
+by itself.
+
+### Stage 1 — Subject extraction
+For the **backlog** (verdicts already written), extract structured subject from the
+existing prose with a **text-only LLM pass** — no re-vision, cheap compute. This is
+the load-bearing step: it was proven empirically that SQL token-matching *cannot* do
+it (see Empirical Findings). The output is normalized `{depicted_make,
+depicted_model, confidence}` that matches cleanly against the kin garage.
+
+### Stage 2 — Sessionize → anchor → inherit
+Group a vehicle's frames into capture sessions (`taken_at` 30-min bucket + GPS, until
+`upload_batch_id` is backfilled). Within each session: anchors set the subject; detail
+frames inherit the session's dominant anchor; component DNA cross-checks. A session
+with **no anchor** resolves to nothing and goes to review — it is not guessed.
+
+### Stage 3 — Reconcile and re-home (reversible)
+Each frame whose resolved subject ≠ its attributed vehicle is a **proposal**, written
+to `image_attribution_review` (status `proposed`) with its evidence, resolution
+(`anchor` | `inherit` | `review`), session key, and proposed kin home. Applying a
+proposal sets `image_vehicle_match_status` and (on confirmation) moves `vehicle_id`,
+recording provenance so it is reversible. **Nothing moves until applied.** The
+primary-image chooser already excludes `mismatch`/`unrelated` (Chapter, primary
+image), so flagging a frame removes it from the wrong profile *before* the move.
+
+### Tables / functions
+- `image_attribution_review` — reversible staging of proposals.
+- `reconcile_vehicle_attribution(vehicle_id)` — runs Stages 2–3, writes proposals.
+- `image_vehicle_match_status` — the early-stage mismatch signal (exists; was dead —
+  null on the Scout frames — because nothing fed it).
+
+---
+
+## Empirical findings (2026-06-21, test user)
+
+- Deep analysis quality is high: it reads data plates and identifies marque/model.
+- Attribution is the failure: 168 analyzed frames are explicitly self-flagged
+  off-subject; the Mustang held a full Scout shoot.
+- The session + inheritance mechanics **work**: they cleanly split 30 Scout frames
+  (anchors + inherited close-ups) from 209 Mustang frames and parked 24 un-anchorable
+  frames in review — no pixel-guessing of close-ups.
+- **Subject identity cannot be done in SQL.** Token-overlap against the kin garage
+  trades false positives (a pseudo-vehicle "Unassigned Vehicle **Photos**" matching
+  any narrative with "photos"/"vehicle"; "Intake Quarantine" matching engine
+  "intake") for false negatives (excluding craigslist-source kin to kill garbage
+  tokens also drops the real Scout, which is a *discovered* vehicle). An LLM
+  disambiguates "international harvester scout" from "intake" trivially; SQL cannot.
+  Hence Stage 1 must be an LLM pass.
+
+---
+
+## Drift notes (verify against prod before trusting)
+
+- `byok-vision-prompt.md` is referenced by `byok-image-batch.sh` but **missing from
+  the repo** — the cloud drain `cat`s a file that isn't there, degrading the prompt.
+  Recreate before relying on the forward-fix.
+- `upload_batch_id` is **null** across `vehicle_images` — sessions must be
+  reconstructed from time+GPS until it is backfilled at intake.
+- One-off cleanup scripts exist (`fix-mixed-vehicle-data.js`,
+  `cleanup_vehicle_contamination.js`) — prior attempts that did not stick because
+  they never fixed the DNA (no structured subject, no harness). This chapter is the
+  durable replacement.

--- a/docs/library/technical/engineering-manual/16-image-attribution-harness.md
+++ b/docs/library/technical/engineering-manual/16-image-attribution-harness.md
@@ -221,6 +221,36 @@ image), so flagging a frame removes it from the wrong profile *before* the move.
 
 ---
 
+## The schema already encodes this theory (the gap is wiring, not design)
+
+Investigating the live DB, every concept above already exists as schema — the system
+was designed for the testimony model and then left unwired at the joins:
+
+- **Device signature**: `generate_device_fingerprint()` →
+  `get_or_create_ghost_user()` → `device_attributions` + `ghost_users`, plus the
+  denormalized `vehicle_images.device_fingerprint`. *Was* dead on iOS photos because
+  it read only standard EXIF keys; **fixed** 2026-06-21 to read the relay's
+  `camera_make/camera_model/synced_by`, and backfilled (14,944 frames signed, 59
+  devices). This is the one fix that was a true bug, not a missing build.
+- **Work session (context folder)**: the `work_sessions` table is fully modeled —
+  `technician_phone_link_id` (device link), `place_id`, `start/end_image_id`,
+  `zones_touched`, `stages_observed`, `stage_transitions` (the broken→fixed
+  progression — *gap as proof of work*, schematized), `intent`/`intent_source`,
+  `evidence`, and `owner_confirmed_at/by`. 789 sessions already exist for the test
+  user, but the per-frame back-link `vehicle_images.work_session_id` is null — the
+  sessions float, unlinked. **Crucially it requires `vehicle_id NOT NULL`**: a work
+  session is bound to one vehicle, so a multi-subject sweep cannot be bound until the
+  subject is resolved.
+- **Mismatch signal**: `image_vehicle_match_status` exists and the primary chooser
+  already respects it — but it is null/unfed (see above).
+
+The dependency chain is therefore: **device signature (now wired) → subject identity
+(the one missing capability) → work-session binding → attribution reconciliation.**
+Every downstream rail waits on the same thing — structured subject extraction — which
+is why that LLM-over-prose pass (Stage 1) is the keystone, not an optional nicety.
+
+---
+
 ## Drift notes (verify against prod before trusting)
 
 - `byok-vision-prompt.md` is referenced by `byok-image-batch.sh` but **missing from

--- a/docs/library/technical/engineering-manual/16-image-attribution-harness.md
+++ b/docs/library/technical/engineering-manual/16-image-attribution-harness.md
@@ -70,7 +70,28 @@ substitute for that context.**
 
 - **Inheritance.** A detail frame takes the subject of the nearest anchor within its
   session. This is the formal answer to "how do you attribute a close-up": *you
-  don't analyze it, you inherit from its session.*
+  don't analyze it, you inherit from its session.* Inheritance is computed by
+  comparing the **narratives** of temporally adjacent frames — text against text,
+  never re-reading the pixels — so it is nearly free.
+
+- **Context folder (work session).** The strongest prior of all, because it encodes
+  *intent*: the vehicle the technician is actually working on. A dash-teardown
+  close-up that names no marque ("an older vehicle") is not ambiguous if the work
+  session says "today is the 1989 R3500" — the whole session is the R3500 by
+  **declaration**, and inheritance is unnecessary. The rail exists
+  (`vehicle_images.work_session_id`) but is currently null; capturing it at upload —
+  the technician declaring/confirming the active build — is the highest-leverage
+  attribution fix in the system, because it converts a guess into ground truth at
+  the source. For the backlog, the folder is reconstructed (time+GPS) and the subject
+  is confirmed by the owner in review.
+
+- **Knowledge-base re-pass.** Once a frame's subject is fixed (by anchor, inheritance,
+  or context folder), the read can be sharpened by re-running it *with the correct
+  vehicle's dossier as context* — its receipts, parts, prior verdicts. This is not a
+  blind vision re-run; it is a cheap, knowledge-informed second look (text over the
+  existing verdict + the dossier), and it embodies the DB-as-memory thesis: hand the
+  read the right memory and it improves for free. Vision pixels are re-touched only on
+  the rare residual the dossier still can't resolve (top rung of the ladder).
 
 - **Component DNA.** Marque-level cues the analysis already extracts
   (`components_seen`, `state_observations`) — an IH slant-4 is not a Ford V8 is not a
@@ -157,6 +178,14 @@ image), so flagging a frame removes it from the wrong profile *before* the move.
 - The session + inheritance mechanics **work**: they cleanly split 30 Scout frames
   (anchors + inherited close-ups) from 209 Mustang frames and parked 24 un-anchorable
   frames in review — no pixel-guessing of close-ups.
+- A single capture sweep is **many-subject**, not two. One 2026-06-20 sweep on the
+  Mustang held: a Scout, a square-body Suburban/Blazer, a crew-cab pickup, a *second*
+  (later) Mustang, a Honda CB motorcycle, dash-teardown close-ups that name no
+  vehicle, and shop-context frames. Text extraction over the existing narratives
+  recovered every self-identifying subject for ~zero compute; the residual was
+  exactly the unnameable close-ups — which the work session resolves (the technician
+  knows that teardown is the 1989 R3500 Cheyenne, `b1edd5c1`, confirmed in the
+  garage).
 - **Subject identity cannot be done in SQL.** Token-overlap against the kin garage
   trades false positives (a pseudo-vehicle "Unassigned Vehicle **Photos**" matching
   any narrative with "photos"/"vehicle"; "Intake Quarantine" matching engine
@@ -172,8 +201,11 @@ image), so flagging a frame removes it from the wrong profile *before* the move.
 - `byok-vision-prompt.md` is referenced by `byok-image-batch.sh` but **missing from
   the repo** — the cloud drain `cat`s a file that isn't there, degrading the prompt.
   Recreate before relying on the forward-fix.
-- `upload_batch_id` is **null** across `vehicle_images` — sessions must be
-  reconstructed from time+GPS until it is backfilled at intake.
+- `upload_batch_id` **and** `work_session_id` are **null** across `vehicle_images` —
+  both the batch rail and the context-folder rail exist but are unpopulated. Sessions
+  must be reconstructed from time+GPS until these are stamped at intake. Stamping
+  `work_session_id` at capture (technician declares the active build) is the
+  single highest-leverage fix and should be prioritized over backlog reconstruction.
 - One-off cleanup scripts exist (`fix-mixed-vehicle-data.js`,
   `cleanup_vehicle_contamination.js`) — prior attempts that did not stick because
   they never fixed the DNA (no structured subject, no harness). This chapter is the

--- a/docs/library/technical/engineering-manual/README.md
+++ b/docs/library/technical/engineering-manual/README.md
@@ -50,6 +50,11 @@ How to deploy edge functions, run migrations, manage cron jobs. The Supabase CLI
 
 How each data source is scraped. Bring a Trailer (direct fetch with HTML parsing), Facebook Marketplace (logged-out GraphQL with `doc_id`, no tokens, residential IP required), Craigslist, PCarMarket (API), Cars and Bids (Firecrawl for JS rendering), and generic sources (Firecrawl fallback). Access methods, rate limits, and data quality per source.
 
+### Chapter 16: The Image Attribution Harness
+`16-image-attribution-harness.md`
+
+Why a good per-frame analysis can still produce a wrong vehicle profile, and how to fix it. Models the expert glance (gestalt over priors, confidence by convergence, context as prior, calibrated humility) and defines the vocabulary — subject identity, anchors, detail frames, capture sessions, inheritance, component DNA, the kin network, the authority/resolution ladder, the two-speed engine. The architecture for binding each verdict to the right vehicle: structured subject extraction, sessionize → anchor → inherit, reversible re-homing via `image_attribution_review` and `reconcile_vehicle_attribution`. Includes the empirical proof that subject identity cannot be done in SQL.
+
 ---
 
 ## How to Read This Manual

--- a/nuke_frontend/src/pages/vehicle-profile/VehicleAgentChat.tsx
+++ b/nuke_frontend/src/pages/vehicle-profile/VehicleAgentChat.tsx
@@ -1,0 +1,129 @@
+/**
+ * Vehicle Agent Chat
+ *
+ * Interactive Claude scoped to ONE vehicle. You message it; the vehicle's own data
+ * (observations + deep-analyzed images) is the harness it reasons over, loaded
+ * server-side by the `vehicle-agent` edge function. When the exchange establishes a
+ * durable new fact, the agent records it as a provenance-stamped observation on your
+ * behalf (rank 'normal', fully backtrackable) — surfaced here as a "recorded" note.
+ *
+ * Compute follows the user's analysis settings (their API key, else the platform key).
+ */
+
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { supabase } from '../../lib/supabase';
+import { CollapsibleWidget } from '../../components/ui/CollapsibleWidget';
+
+interface Turn {
+  role: 'user' | 'assistant';
+  content: string;
+  wrote?: Array<{ id: string; kind: string; content_text: string | null }>;
+}
+
+const VehicleAgentChat: React.FC<{ vehicleId: string }> = ({ vehicleId }) => {
+  const [turns, setTurns] = useState<Turn[]>([]);
+  const [input, setInput] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [allowWrites, setAllowWrites] = useState(true);
+  const [error, setError] = useState('');
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => { endRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [turns, busy]);
+
+  const send = useCallback(async () => {
+    const message = input.trim();
+    if (!message || busy) return;
+    setError('');
+    setBusy(true);
+    const history = turns.map((t) => ({ role: t.role, content: t.content }));
+    setTurns((t) => [...t, { role: 'user', content: message }]);
+    setInput('');
+    try {
+      const { data, error: e } = await supabase.functions.invoke('vehicle-agent', {
+        body: { vehicle_id: vehicleId, message, history, allow_writes: allowWrites },
+      });
+      if (e) {
+        const msg = (e as any)?.context?.body || e.message || 'Agent error';
+        setError(typeof msg === 'string' ? msg : 'Agent error');
+        setTurns((t) => [...t, { role: 'assistant', content: '(failed)' }]);
+      } else {
+        setTurns((t) => [...t, { role: 'assistant', content: data?.reply || '(no response)', wrote: data?.wrote }]);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Agent error');
+    } finally {
+      setBusy(false);
+    }
+  }, [input, busy, turns, vehicleId, allowWrites]);
+
+  const onKey = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); }
+  };
+
+  return (
+    <CollapsibleWidget variant="profile" title="Ask the Vehicle Agent" defaultCollapsed={true}>
+      <div style={{ fontFamily: 'Arial, sans-serif' }}>
+        <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 8 }}>
+          Claude with this vehicle's data as context. It can record durable new facts as
+          observations on your behalf — tracked and reversible.
+        </div>
+
+        {turns.length > 0 && (
+          <div style={{ border: '2px solid var(--border)', maxHeight: 320, overflowY: 'auto', padding: 8, marginBottom: 8 }}>
+            {turns.map((t, i) => (
+              <div key={i} style={{ marginBottom: 10 }}>
+                <div style={{ fontSize: 9, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--text-muted)', marginBottom: 2 }}>
+                  {t.role === 'user' ? 'You' : 'Agent'}
+                </div>
+                <div style={{ fontSize: 12, whiteSpace: 'pre-wrap', color: 'var(--text)' }}>{t.content}</div>
+                {t.wrote && t.wrote.length > 0 && (
+                  <div style={{ marginTop: 4, fontSize: 10, color: 'var(--success, #4caf50)' }}>
+                    ✓ recorded {t.wrote.length} observation{t.wrote.length > 1 ? 's' : ''}:{' '}
+                    {t.wrote.map((w) => w.kind).join(', ')}
+                  </div>
+                )}
+              </div>
+            ))}
+            {busy && <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Thinking…</div>}
+            <div ref={endRef} />
+          </div>
+        )}
+
+        {error && (
+          <div style={{ fontSize: 11, color: 'var(--error, #f44336)', marginBottom: 8 }}>{error}</div>
+        )}
+
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={onKey}
+          placeholder="Ask about this vehicle… (Enter to send)"
+          rows={2}
+          style={{
+            width: '100%', padding: 8, fontSize: 12, fontFamily: 'Arial, sans-serif',
+            background: 'var(--bg-secondary)', border: '2px solid var(--border)', color: 'var(--text)', resize: 'vertical',
+          }}
+        />
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 6 }}>
+          <label style={{ fontSize: 10, color: 'var(--text-muted)', display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}>
+            <input type="checkbox" checked={allowWrites} onChange={(e) => setAllowWrites(e.target.checked)} />
+            Let it record observations
+          </label>
+          <button
+            onClick={send}
+            disabled={busy || !input.trim()}
+            style={{
+              background: 'var(--accent)', color: 'var(--bg)', border: 'none', padding: '8px 16px',
+              fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em',
+              cursor: busy || !input.trim() ? 'default' : 'pointer', opacity: busy || !input.trim() ? 0.5 : 1,
+            }}
+          >
+            {busy ? 'Sending…' : 'Send'}
+          </button>
+        </div>
+      </div>
+    </CollapsibleWidget>
+  );
+};
+
+export default VehicleAgentChat;

--- a/nuke_frontend/src/pages/vehicle-profile/WorkspaceContent.tsx
+++ b/nuke_frontend/src/pages/vehicle-profile/WorkspaceContent.tsx
@@ -31,6 +31,7 @@ const VehicleListingDetailsCard = React.lazy(() => import('../../components/vehi
 const SimilarSalesSection = React.lazy(() => import('../../components/vehicle/SimilarSalesSection').then(m => ({ default: m.SimilarSalesSection })));
 const PriceHistoryChart = React.lazy(() => import('../../components/vehicle/PriceHistoryChart'));
 const ObservationTimeline = React.lazy(() => import('./ObservationTimeline'));
+const VehicleAgentChat = React.lazy(() => import('./VehicleAgentChat'));
 const InventoryWidgetLink = React.lazy(() => import('./InventoryWidgetLink'));
 // BuildLog removed — work sessions now surface via BarcodeTimeline Day Card popups
 
@@ -171,6 +172,14 @@ const WorkspaceContent: React.FC<WorkspaceContentProps> = ({
           {(isRowOwner || isVerifiedOwner || hasContributorAccess) && (
             <React.Suspense fallback={null}>
               <WorkMemorySection vehicleId={vehicle.id} permissions={permissions} />
+            </React.Suspense>
+          )}
+
+          {/* Vehicle Agent — interactive Claude over this vehicle's data; can record
+              observations on the owner's behalf (provenance-stamped, reversible). */}
+          {(isRowOwner || isVerifiedOwner || hasContributorAccess) && (
+            <React.Suspense fallback={null}>
+              <VehicleAgentChat vehicleId={vehicle.id} />
             </React.Suspense>
           )}
 

--- a/supabase/functions/check-image-vehicle-match/index.ts
+++ b/supabase/functions/check-image-vehicle-match/index.ts
@@ -374,13 +374,14 @@ Deno.serve(async (req: Request) => {
         p_user_id: body.user_id,
       });
 
+      // Memory bound: build the TARGET's signature per invocation, not every sibling.
+      // Building all of a user's vehicles (300+) in one edge call fetched images +
+      // ran a vision call per vehicle and hit WORKER_RESOURCE_LIMIT. Callers build
+      // each vehicle's signature with its own call; siblings already carrying a
+      // signature are used as-is by disambiguate.
+      void siblings;
       const allVehicles = [
         { ...target, vehicle_id: target.id },
-        ...(siblings || []).map((s: any) => ({
-          id: s.vehicle_id, year: s.v_year, make: s.v_make, model: s.v_model,
-          trim: s.v_trim, vin: s.v_vin, visual_signature: s.visual_signature,
-          primary_image_url: s.primary_image_url,
-        })),
       ];
 
       const results: { vehicle_id: string; desc: string; signature: any; skipped?: string }[] = [];
@@ -474,14 +475,22 @@ Deno.serve(async (req: Request) => {
           signature: target.visual_signature,
           reference_image_url: target.primary_image_url,
         },
-        ...(siblings || []).map((s: any, i: number) => ({
-          vehicle_id: s.vehicle_id,
-          label: labels[i + 1] || `V${i + 2}`,
-          year: s.v_year, make: s.v_make, model: s.v_model,
-          trim: s.v_trim, vin: s.v_vin,
-          signature: s.visual_signature,
-          reference_image_url: s.primary_image_url,
-        })),
+        // Memory/prompt bound: cap candidates. Sending 300+ reference images into one
+        // vision call hit WORKER_RESOURCE_LIMIT. Prefer siblings that already have a
+        // built signature (cheap, no image fetch); cap the rest. (The candidate set
+        // should also be scoped to OWNED vehicles upstream in get_sibling_vehicles so
+        // discovery comps can't become a re-home target — see Ch.16.)
+        ...[...(siblings || [])]
+          .sort((a: any, b: any) => (b.visual_signature ? 1 : 0) - (a.visual_signature ? 1 : 0))
+          .slice(0, 12)
+          .map((s: any, i: number) => ({
+            vehicle_id: s.vehicle_id,
+            label: labels[i + 1] || `V${i + 2}`,
+            year: s.v_year, make: s.v_make, model: s.v_model,
+            trim: s.v_trim, vin: s.v_vin,
+            signature: s.visual_signature,
+            reference_image_url: s.primary_image_url,
+          })),
       ];
 
       // Get images to check

--- a/supabase/functions/vehicle-agent/index.ts
+++ b/supabase/functions/vehicle-agent/index.ts
@@ -1,0 +1,206 @@
+/**
+ * Vehicle Agent — interactive Claude, with a single vehicle's data as the harness.
+ *
+ * This is the per-vehicle agent: you message it about ONE target, and the vehicle's
+ * own long-term memory (vehicle_observations) + its deep-analyzed images
+ * (ai_scan_metadata.byok_deep_analysis) are loaded as the context it reasons over.
+ * The DB is the memory; this function is the ephemeral reconstitution of it.
+ *
+ * POST /functions/v1/vehicle-agent
+ *   { vehicle_id: uuid, message: string,
+ *     history?: [{role:'user'|'assistant', content:string}], allow_writes?: boolean }
+ *
+ * WRITES (on behalf of the user, fully backtrackable): when the agent establishes a
+ * durable new fact and writes are allowed, it appends provenance-stamped rows to
+ * vehicle_observations — rank='normal' (never outranks verified/human/source data),
+ * submitted_by_user_id = the caller, agent_model + extracted_by='vehicle-agent'. The
+ * append-only superseding model means these are additive and reversible: a wrong call
+ * can be superseded, never silently overwrites a profile.
+ *
+ * COMPUTE: routes through the user's settings. byo_api_key+anthropic uses their own key
+ * (decrypted server-side); otherwise the platform key. (A Claude *subscription* OAuth
+ * token isn't a Messages-API credential, so byo_subscription uses the platform key for
+ * synchronous chat — the async drain is where the subscription is spent.)
+ */
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.0";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+// The agent may only emit these kinds, and only at rank 'normal'. Keeps it from minting
+// listings/sales/bids (source-of-record kinds) or outranking verified data.
+const ALLOWED_KINDS = new Set([
+  "condition", "specification", "valuation", "provenance",
+  "expert_opinion", "work_record", "ownership", "activity", "sighting",
+]);
+const CONFIDENCE = new Set(["verified", "high", "medium", "low", "inferred"]);
+
+function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+  if (req.method !== "POST") return json(405, { error: "POST only" });
+
+  try {
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    );
+
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) return json(401, { error: "Authentication required" });
+    const { data: { user }, error: authError } = await supabase.auth.getUser(
+      authHeader.replace("Bearer ", ""),
+    );
+    if (authError || !user) return json(401, { error: "Invalid authentication" });
+
+    const body = await req.json().catch(() => ({}));
+    const vehicleId = String(body.vehicle_id || "");
+    const message = String(body.message || "").trim();
+    const history: Array<{ role: string; content: string }> = Array.isArray(body.history)
+      ? body.history.slice(-12)
+      : [];
+    const allowWrites = body.allow_writes !== false; // default on; the user chose "it can write"
+    if (!/^[0-9a-f-]{36}$/i.test(vehicleId)) return json(400, { error: "vehicle_id must be a uuid" });
+    if (!message) return json(400, { error: "message is required" });
+
+    // Access check: the caller must have images on this vehicle (their data).
+    const { count: owns, error: oe } = await supabase
+      .from("vehicle_images").select("id", { count: "exact", head: true })
+      .eq("vehicle_id", vehicleId).eq("user_id", user.id);
+    if (oe) return json(500, { error: "access check failed: " + oe.message });
+    if (!owns) return json(403, { error: "You don't have access to that vehicle." });
+
+    // ── Harness: load the vehicle's memory ───────────────────────────────────
+    const { data: veh } = await supabase
+      .from("vehicles").select("year, make, model, trim, vin, color").eq("id", vehicleId).maybeSingle();
+
+    const { data: obs } = await supabase
+      .from("vehicle_observations")
+      .select("kind, observed_at, content_text, structured_data, confidence")
+      .eq("vehicle_id", vehicleId)
+      .or("is_superseded.is.null,is_superseded.eq.false")
+      .order("observed_at", { ascending: false })
+      .limit(60);
+
+    const { data: imgs } = await supabase
+      .from("vehicle_images")
+      .select("id, taken_at, ai_scan_metadata")
+      .eq("vehicle_id", vehicleId)
+      .not("ai_scan_metadata->byok_deep_analysis", "is", null)
+      .order("taken_at", { ascending: false })
+      .limit(20);
+
+    const imageSummaries = (imgs || []).map((r: any) => {
+      const d = r.ai_scan_metadata?.byok_deep_analysis ?? {};
+      return { taken_at: r.taken_at, summary: d.summary ?? d.condition_summary ?? null, observations: d.observations ?? d.structured ?? null };
+    }).filter((x: any) => x.summary || x.observations);
+
+    const vehName = veh ? `${veh.year ?? ""} ${veh.make ?? ""} ${veh.model ?? ""}${veh.trim ? " " + veh.trim : ""}`.trim() : "this vehicle";
+
+    // ── Compute: which key + model (the settings toggle) ─────────────────────
+    const { data: settings } = await supabase
+      .from("user_analysis_settings").select("method, provider, model").eq("user_id", user.id).maybeSingle();
+    const model = (settings?.model && /^claude-/.test(settings.model)) ? settings.model : "claude-sonnet-4-6";
+    let apiKey = Deno.env.get("ANTHROPIC_API_KEY") || "";
+    let computeNote = "platform";
+    if (settings?.method === "byo_api_key" && settings.provider === "anthropic") {
+      const { data: cred } = await supabase.rpc("get_analysis_credential", { p_user_id: user.id });
+      if (cred) { apiKey = String(cred); computeNote = "your_api_key"; }
+    }
+    if (!apiKey) return json(503, { error: "No Anthropic key available for chat. Set one in Settings or configure the platform key." });
+
+    const system =
+      `You are the persistent agent assigned to ONE vehicle: ${vehName}` +
+      (veh?.vin ? ` (VIN ${veh.vin})` : "") + `.\n` +
+      `You reason ONLY from this vehicle's own data, provided below as your memory. Do not invent facts. ` +
+      `If the data doesn't say, say so. Be concrete and concise.\n\n` +
+      `=== OBSERVATIONS (most recent first) ===\n${JSON.stringify(obs ?? [], null, 0).slice(0, 12000)}\n\n` +
+      `=== DEEP-ANALYZED IMAGES ===\n${JSON.stringify(imageSummaries, null, 0).slice(0, 8000)}\n\n` +
+      (allowWrites
+        ? `If — and only if — this exchange establishes a DURABLE new fact about the vehicle that isn't ` +
+          `already in the observations, you may record it. To do so, end your reply with a fenced json block:\n` +
+          "```json\n{\"observations\":[{\"kind\":\"condition|specification|valuation|provenance|expert_opinion|work_record|ownership|activity|sighting\",\"summary\":\"...\",\"fields\":{},\"confidence\":\"high|medium|low|inferred\"}]}\n```\n" +
+          `Only record things you are confident about and that the user's message or the data supports. Most replies need NO json block.`
+        : `Writing is disabled for this conversation; answer only.`);
+
+    const messages = [
+      ...history.filter((m) => m.role === "user" || m.role === "assistant").map((m) => ({ role: m.role, content: String(m.content || "") })),
+      { role: "user", content: message },
+    ];
+
+    const t0 = Date.now();
+    const aiRes = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: { "x-api-key": apiKey, "anthropic-version": "2023-06-01", "content-type": "application/json" },
+      body: JSON.stringify({ model, max_tokens: 1500, system, messages }),
+      signal: AbortSignal.timeout(90_000),
+    });
+    if (!aiRes.ok) {
+      const detail = await aiRes.text().catch(() => "");
+      return json(502, { error: "Claude error", status: aiRes.status, detail: detail.slice(0, 300) });
+    }
+    const aiData = await aiRes.json();
+    const raw = (aiData.content || []).map((b: any) => b.text || "").join("").trim();
+    const durationMs = Date.now() - t0;
+
+    // Split prose from an optional trailing json block of observations to record.
+    let reply = raw;
+    let proposed: any[] = [];
+    const m = raw.match(/```json\s*([\s\S]*?)```\s*$/);
+    if (m) {
+      reply = raw.slice(0, m.index).trim();
+      try { proposed = JSON.parse(m[1]).observations || []; } catch { /* ignore malformed */ }
+    }
+
+    // ── Provenance-stamped writes (rank normal, on behalf of the user) ───────
+    const wrote: any[] = [];
+    if (allowWrites && Array.isArray(proposed) && proposed.length) {
+      const now = new Date().toISOString();
+      const rows = proposed
+        .filter((o) => o && ALLOWED_KINDS.has(o.kind))
+        .slice(0, 5)
+        .map((o) => ({
+          vehicle_id: vehicleId,
+          subject_type: "vehicle",
+          observed_at: now,
+          kind: o.kind,
+          rank: "normal",
+          structured_data: o.fields && typeof o.fields === "object" ? o.fields : {},
+          content_text: typeof o.summary === "string" ? o.summary : null,
+          confidence: CONFIDENCE.has(o.confidence) ? o.confidence : "low",
+          submitted_by_user_id: user.id,
+          agent_model: model,
+          agent_tier: "interactive",
+          extraction_method: "interactive_agent",
+          extracted_by: "vehicle-agent",
+          agent_duration_ms: durationMs,
+          processing_metadata: { surface: "vehicle-agent", on_behalf_of: user.id },
+        }));
+      if (rows.length) {
+        const { data: ins, error: ie } = await supabase
+          .from("vehicle_observations").insert(rows).select("id, kind, content_text");
+        if (ie) reply += `\n\n_(Note: I couldn't save the observation: ${ie.message})_`;
+        else wrote.push(...(ins || []));
+      }
+    }
+
+    return json(200, {
+      reply: reply || "(no response)",
+      wrote,
+      compute: { model, source: computeNote },
+      context: { observations: (obs ?? []).length, analyzed_images: imageSummaries.length },
+    });
+  } catch (err) {
+    return json(500, { error: err instanceof Error ? err.message : "unexpected error" });
+  }
+});

--- a/supabase/migrations/20260621120000_consolidate_primary_image_triggers.sql
+++ b/supabase/migrations/20260621120000_consolidate_primary_image_triggers.sql
@@ -1,0 +1,126 @@
+-- Consolidate primary-image selection on vehicle_images.
+--
+-- PROBLEM (measured 2026-06-21): FIVE competing triggers set the primary image with
+-- contradictory rules — auto_set_primary_image (arbitrary first row),
+-- sync_vehicle_primary_image (oldest-first, created_at ASC),
+-- set_first_image_as_primary_if_none (newest-first, taken_at DESC),
+-- set_vehicle_primary_image_from_vehicle_images (only-if-missing). They raced on every
+-- write, producing "random" lead-image promotion and a garage/profile mismatch: the
+-- garage reads vehicles.primary_image_url (set oldest-first) while the profile reads the
+-- is_primary row (set newest-first), so they disagreed. recompute_vehicle_primary_image
+-- (the only correct chooser) was an RPC that nothing called automatically, and it gated
+-- on analysis completion, so a brand-new photo couldn't become primary until analyzed.
+--
+-- FIX: one deterministic rule. The primary is the latest APPROVED OWNER photo (prefer a
+-- recent exterior), gated on ATTRIBUTION (vision_gate approved), NOT on analysis. We
+-- swap function bodies only (no CREATE/DROP TRIGGER) because vehicle_images is a large
+-- hot table where acquiring ACCESS EXCLUSIVE for DDL times out; the existing
+-- trg_sync_vehicle_primary_image (AFTER INSERT/UPDATE/DELETE) is repurposed as the sole
+-- maintainer, and the other three choosers are neutered to no-ops. trigger_ensure_single
+-- _primary_image is kept (harmless single-primary guard). Applied live + backfilled the
+-- test user's 97 vehicles: garage≠profile 3→0, zero_primary 2→0, idempotent (0 still
+-- changing).
+
+CREATE OR REPLACE FUNCTION public.recompute_vehicle_primary_image(p_vehicle_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $function$
+DECLARE
+  v_old text; v_latest timestamptz;
+  v_id uuid; v_url text; v_taken timestamptz; v_zone text;
+  c_owner text[] := ARRAY['iphoto','user_upload','capture_relay','capture_relay_ios','daily_receipt',
+                          'photo_auto_sync','drop-folder','owner_import','user-submission','owner_submission'];
+BEGIN
+  SELECT primary_image_url INTO v_old FROM vehicles WHERE id = p_vehicle_id;
+
+  -- Latest eligible OWNER photo. Gated on ATTRIBUTION (vision_gate approved), NOT on
+  -- analysis completion — a brand-new approved photo is the primary immediately.
+  SELECT COALESCE(taken_at, created_at) INTO v_latest
+  FROM vehicle_images
+  WHERE vehicle_id = p_vehicle_id AND source = ANY(c_owner)
+    AND COALESCE(vision_gate_status,'approved') = 'approved'
+    AND COALESCE(is_superseded,false)=false AND COALESCE(is_duplicate,false)=false
+    AND COALESCE(image_vehicle_match_status,'pending') NOT IN ('mismatch','unrelated')
+    AND image_url IS NOT NULL AND image_url <> ''
+  ORDER BY COALESCE(taken_at, created_at) DESC LIMIT 1;
+
+  IF v_latest IS NULL THEN
+    -- No owner photo (e.g. scraped-only comp): fall back to any approved non-dup image.
+    SELECT id,image_url,COALESCE(taken_at,created_at),vehicle_zone INTO v_id,v_url,v_taken,v_zone
+    FROM vehicle_images
+    WHERE vehicle_id = p_vehicle_id
+      AND COALESCE(is_superseded,false)=false AND COALESCE(is_duplicate,false)=false
+      AND COALESCE(image_vehicle_match_status,'pending') NOT IN ('mismatch','unrelated')
+      AND image_url IS NOT NULL AND image_url <> ''
+    ORDER BY COALESCE(is_primary,false) DESC, COALESCE(taken_at,created_at) DESC LIMIT 1;
+    IF v_id IS NULL THEN
+      RETURN jsonb_build_object('vehicle_id',p_vehicle_id,'changed',false,'reason','no_candidate','primary',v_old);
+    END IF;
+  ELSE
+    -- Prefer the latest EXTERIOR within 120d of the latest owner photo; else the latest owner photo.
+    SELECT id,image_url,COALESCE(taken_at,created_at),vehicle_zone INTO v_id,v_url,v_taken,v_zone
+    FROM vehicle_images
+    WHERE vehicle_id = p_vehicle_id AND source = ANY(c_owner)
+      AND COALESCE(vision_gate_status,'approved') = 'approved'
+      AND COALESCE(is_superseded,false)=false AND COALESCE(is_duplicate,false)=false
+      AND COALESCE(image_vehicle_match_status,'pending') NOT IN ('mismatch','unrelated')
+      AND image_url IS NOT NULL AND image_url <> '' AND vehicle_zone ILIKE 'ext%'
+      AND COALESCE(taken_at,created_at) >= v_latest - interval '120 days'
+    ORDER BY COALESCE(taken_at,created_at) DESC LIMIT 1;
+
+    IF v_id IS NULL THEN
+      SELECT id,image_url,COALESCE(taken_at,created_at),vehicle_zone INTO v_id,v_url,v_taken,v_zone
+      FROM vehicle_images
+      WHERE vehicle_id = p_vehicle_id AND source = ANY(c_owner)
+        AND COALESCE(vision_gate_status,'approved') = 'approved'
+        AND COALESCE(is_superseded,false)=false AND COALESCE(is_duplicate,false)=false
+        AND COALESCE(image_vehicle_match_status,'pending') NOT IN ('mismatch','unrelated')
+        AND image_url IS NOT NULL AND image_url <> ''
+      ORDER BY COALESCE(taken_at,created_at) DESC LIMIT 1;
+    END IF;
+  END IF;
+
+  UPDATE vehicle_images SET is_primary=false WHERE vehicle_id=p_vehicle_id AND is_primary=true AND id<>v_id;
+  UPDATE vehicle_images SET is_primary=true  WHERE id=v_id AND COALESCE(is_primary,false)=false;
+  UPDATE vehicles SET primary_image_url=v_url WHERE id=p_vehicle_id AND primary_image_url IS DISTINCT FROM v_url;
+
+  RETURN jsonb_build_object('vehicle_id',p_vehicle_id,'changed',(v_old IS DISTINCT FROM v_url),
+    'chosen_image_id',v_id,'taken_at',v_taken,'zone',v_zone,'was',left(v_old,40),'now',left(v_url,40));
+END $function$;
+
+-- Sole maintainer (repurposes the existing AFTER INSERT/UPDATE/DELETE trigger function).
+CREATE OR REPLACE FUNCTION public.sync_vehicle_primary_image()
+RETURNS trigger LANGUAGE plpgsql AS $function$
+DECLARE v_vehicle uuid;
+BEGIN
+  IF pg_trigger_depth() > 1 THEN RETURN COALESCE(NEW, OLD); END IF;   -- stop self-recursion
+  v_vehicle := COALESCE(NEW.vehicle_id, OLD.vehicle_id);
+  IF v_vehicle IS NULL THEN RETURN COALESCE(NEW, OLD); END IF;
+
+  -- On UPDATE, skip unless a field that affects selection changed.
+  IF TG_OP = 'UPDATE'
+     AND NEW.vehicle_id IS NOT DISTINCT FROM OLD.vehicle_id
+     AND NEW.is_primary IS NOT DISTINCT FROM OLD.is_primary
+     AND NEW.vision_gate_status IS NOT DISTINCT FROM OLD.vision_gate_status
+     AND NEW.is_duplicate IS NOT DISTINCT FROM OLD.is_duplicate
+     AND NEW.is_superseded IS NOT DISTINCT FROM OLD.is_superseded
+     AND NEW.image_vehicle_match_status IS NOT DISTINCT FROM OLD.image_vehicle_match_status
+     AND NEW.image_url IS NOT DISTINCT FROM OLD.image_url
+     AND NEW.taken_at IS NOT DISTINCT FROM OLD.taken_at THEN
+    RETURN NEW;
+  END IF;
+
+  PERFORM recompute_vehicle_primary_image(v_vehicle);
+  IF TG_OP = 'UPDATE' AND OLD.vehicle_id IS DISTINCT FROM NEW.vehicle_id AND OLD.vehicle_id IS NOT NULL THEN
+    PERFORM recompute_vehicle_primary_image(OLD.vehicle_id);
+  END IF;
+  RETURN COALESCE(NEW, OLD);
+END $function$;
+
+-- Neuter the three conflicting choosers (their triggers still fire but do nothing).
+CREATE OR REPLACE FUNCTION public.auto_set_primary_image()
+RETURNS trigger LANGUAGE plpgsql AS $function$ BEGIN RETURN NEW; END $function$;
+
+CREATE OR REPLACE FUNCTION public.set_vehicle_primary_image_from_vehicle_images()
+RETURNS trigger LANGUAGE plpgsql AS $function$ BEGIN RETURN NEW; END $function$;
+
+CREATE OR REPLACE FUNCTION public.set_first_image_as_primary_if_none()
+RETURNS trigger LANGUAGE plpgsql AS $function$ BEGIN RETURN NEW; END $function$;

--- a/supabase/migrations/20260621140000_device_signature_from_ios_exif.sql
+++ b/supabase/migrations/20260621140000_device_signature_from_ios_exif.sql
@@ -1,0 +1,87 @@
+-- Match the DB to the testimony model: extract the device signature the iOS capture
+-- relay already writes, which the device-attribution system was silently ignoring.
+--
+-- ROOT CAUSE: generate_device_fingerprint() and auto_attribute_image_to_device() read
+-- only STANDARD EXIF keys (Make/Model/LensModel/Software). The iOS capture-relay writes
+-- FLAT lowercase keys (camera_make/camera_model/synced_by). So every relay photo
+-- fingerprinted to 'Unknown-Unknown-Unknown-Unknown', tripped the guard, and the entire
+-- ghost-user / device_attributions system no-opped on exactly the user's own photos —
+-- and vehicle_images.device_fingerprint stayed null. Same EXIF-key drift that broke
+-- date/taken_at matching. The signature was on every frame; nothing read it.
+--
+-- FIX (testimony over declaration): read both key shapes; sign each frame at insert via
+-- the existing BEFORE-insert exif trigger (no new trigger -> no ACCESS EXCLUSIVE lock on
+-- the 38.9M-row hot table); and let the ghost-user path populate going forward.
+--
+-- BACKFILL (run separately, batched ~4k/stmt to stay under statement_timeout and the
+-- per-row value-recompute trigger; a single global UPDATE will time out):
+--   WITH b AS (SELECT id FROM vehicle_images
+--              WHERE device_fingerprint IS NULL AND exif_data IS NOT NULL
+--                AND (exif_data ? 'camera_make' OR exif_data ? 'Make') LIMIT 4000)
+--   UPDATE vehicle_images vi SET device_fingerprint = generate_device_fingerprint(vi.exif_data)
+--   FROM b WHERE vi.id=b.id
+--     AND generate_device_fingerprint(vi.exif_data) <> 'Unknown-Unknown-Unknown-Unknown';
+-- Applied for the test user 2026-06-21: 14,944 frames signed, 59 distinct devices.
+
+CREATE OR REPLACE FUNCTION public.generate_device_fingerprint(exif_data jsonb)
+RETURNS text LANGUAGE plpgsql IMMUTABLE AS $function$
+DECLARE make TEXT; model TEXT; lens TEXT; software TEXT;
+BEGIN
+  make     := COALESCE(NULLIF(exif_data->>'Make',''),       NULLIF(exif_data->>'camera_make',''),  'Unknown');
+  model    := COALESCE(NULLIF(exif_data->>'Model',''),      NULLIF(exif_data->>'camera_model',''), 'Unknown');
+  lens     := COALESCE(NULLIF(exif_data->>'LensModel',''),  NULLIF(exif_data->>'lens_model',''),   'Unknown');
+  software := COALESCE(NULLIF(exif_data->>'Software',''),   NULLIF(exif_data->>'software',''),
+                       NULLIF(exif_data->>'synced_by',''),  'Unknown');
+  RETURN make || '-' || model || '-' || lens || '-' || software;
+END;
+$function$;
+
+-- Sign the frame at insert (denormalized signature on vehicle_images.device_fingerprint).
+CREATE OR REPLACE FUNCTION public.mark_image_for_exif_extraction()
+RETURNS trigger LANGUAGE plpgsql AS $function$
+DECLARE fp text;
+BEGIN
+  IF NEW.exif_data IS NULL AND NEW.source = 'user_upload' THEN
+    NEW.ai_processing_status := COALESCE(NEW.ai_processing_status, 'pending_exif');
+  END IF;
+  IF NEW.device_fingerprint IS NULL AND NEW.exif_data IS NOT NULL THEN
+    fp := generate_device_fingerprint(NEW.exif_data);
+    IF fp <> 'Unknown-Unknown-Unknown-Unknown' THEN
+      NEW.device_fingerprint := fp;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+-- Ghost-user / device_attributions path: read the iOS relay keys too.
+CREATE OR REPLACE FUNCTION public.auto_attribute_image_to_device()
+RETURNS trigger LANGUAGE plpgsql AS $function$
+DECLARE
+  v_device_fingerprint TEXT; v_ghost_user_id UUID;
+  v_camera_make TEXT; v_camera_model TEXT; v_lens_model TEXT; v_software TEXT;
+BEGIN
+  IF NEW.exif_data IS NULL THEN RETURN NEW; END IF;
+
+  v_camera_make  := COALESCE(NULLIF(NEW.exif_data->>'Make',''),      NULLIF(NEW.exif_data->>'camera_make',''));
+  v_camera_model := COALESCE(NULLIF(NEW.exif_data->>'Model',''),     NULLIF(NEW.exif_data->>'camera_model',''));
+  v_lens_model   := COALESCE(NULLIF(NEW.exif_data->>'LensModel',''), NULLIF(NEW.exif_data->>'lens_model',''));
+  v_software     := COALESCE(NULLIF(NEW.exif_data->>'Software',''),  NULLIF(NEW.exif_data->>'software',''),
+                             NULLIF(NEW.exif_data->>'synced_by',''));
+
+  v_device_fingerprint := generate_device_fingerprint(NEW.exif_data);
+  IF v_device_fingerprint = 'Unknown-Unknown-Unknown-Unknown' THEN RETURN NEW; END IF;
+
+  v_ghost_user_id := get_or_create_ghost_user(
+    v_device_fingerprint, v_camera_make, v_camera_model, v_lens_model, v_software);
+
+  INSERT INTO device_attributions (
+    image_id, device_fingerprint, ghost_user_id, uploaded_by_user_id,
+    attribution_source, confidence_score
+  ) VALUES (
+    NEW.id, v_device_fingerprint, v_ghost_user_id, NEW.user_id, 'exif_device', 100)
+  ON CONFLICT DO NOTHING;
+
+  RETURN NEW;
+END;
+$function$;


### PR DESCRIPTION
## Two changes on this branch

### 1. Primary-image fix (already applied live — this file is drift-repair) ✅ verified
You reported random lead-image promotion, the garage showing a different image than the profile, and not seeing your latest photos. Measured root cause on the live DB:

**Five competing triggers** on `vehicle_images` set the primary with contradictory rules — `auto_set_primary_image` (arbitrary first row), `sync_vehicle_primary_image` (**oldest**-first), `set_first_image_as_primary_if_none` (**newest**-first), `set_vehicle_primary_image_from_vehicle_images` (only-if-missing). They raced on every write. The garage reads `vehicles.primary_image_url` (set oldest-first) while the profile reads the `is_primary` row (set newest-first) → **that's the mismatch you saw.** And the one correct chooser (`recompute_vehicle_primary_image`) was an uncalled RPC **gated on analysis completion**, so a brand-new photo couldn't become primary until analyzed.

**Fix:** one deterministic rule — primary = your **latest approved owner photo** (prefer a recent exterior), gated on attribution, **not** analysis. The existing AFTER-trigger function is repurposed as the sole maintainer (recursion + relevant-change guarded); the other three choosers are neutered to no-ops. Function-body swaps only — no `CREATE/DROP TRIGGER`, because `vehicle_images` is a hot 38.9M-row table where the exclusive DDL lock times out.

**Verified on your 97 real vehicles** (before → after): garage≠profile **3 → 0**; no-primary **2 → 0**; **29 lead images re-pointed** to your latest photo; re-run changes **0** (stable/idempotent).

### 2. Layer 2: interactive vehicle-agent (WIP, not yet wired for production)
Edge function + chat panel: Claude with one vehicle's observations/analyzed-images as the harness, writing provenance-stamped observations on your behalf. Structurally validated, but the live observation-insert smoke test hit a statement timeout from heavy `vehicle_observations` recompute triggers — needs follow-up before it's load-bearing.

## Still open (your "discovery mesh, not a bin" point)
The garage shows 330 vehicles but only 97 are yours; 161 Craigslist discoveries are stamped with your `user_id`. The fix is to route discoveries to the existing `UserDiscoveries` surface instead of the garage — separate change, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VY7vRRmx2gDQhhvELQ5vju

---
_Generated by [Claude Code](https://claude.ai/code/session_01VY7vRRmx2gDQhhvELQ5vju)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vehicle Agent chat panel to vehicle profiles for interactive vehicle-related queries and management.

* **Improvements**
  * Enhanced image attribution pipeline with improved vehicle-image matching accuracy.
  * Streamlined primary image selection mechanism for more reliable vehicle photo display.
  * Improved device-based image attribution logic for better image-to-vehicle association.

* **Documentation**
  * Added engineering manual chapter detailing image attribution architecture and methodology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->