### PR TITLE
feat(attribution): owned-only candidates + subscription subject-classifier

### DIFF
--- a/.github/workflows/subject-classify.yml
+++ b/.github/workflows/subject-classify.yml
@@ -1,0 +1,65 @@
+name: Subject Classify (text-only, subscription)
+
+# Reconcile which OWNED vehicle each already-analyzed frame depicts, using the narratives
+# the analysis drain already wrote — NO new vision, NO API tokens. Auth is the Claude
+# SUBSCRIPTION (CLAUDE_CODE_OAUTH_TOKEN). Stages reversible proposals + de-pollution flags;
+# never moves images. This is the cost-aligned path to organizing the backlog when the
+# pay-per-token Anthropic API is unavailable/undesired.
+#
+# REQUIRED SECRETS: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, CLAUDE_CODE_OAUTH_TOKEN.
+
+on:
+  workflow_dispatch:
+    inputs:
+      user_id:
+        description: Owner whose frames to classify
+        default: '0b9f107a-d124-49de-9ded-94698f63c1c4'
+      minutes:
+        description: Time budget (minutes)
+        default: '30'
+      batch:
+        description: Frames per batch
+        default: '40'
+      model:
+        description: Claude model
+        default: 'claude-sonnet-4-6'
+
+permissions:
+  contents: read
+concurrency:
+  group: subject-classify
+  cancel-in-progress: false
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - name: Install deps
+        run: |
+          npm install
+          npm install -g @dotenvx/dotenvx @anthropic-ai/claude-code
+      - name: Classify
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          BYOK_MODEL: ${{ github.event.inputs.model || 'claude-sonnet-4-6' }}
+        run: |
+          unset ANTHROPIC_API_KEY
+          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "::error::CLAUDE_CODE_OAUTH_TOKEN (subscription) not set."; exit 1
+          fi
+          USER_ID="${{ github.event.inputs.user_id || '0b9f107a-d124-49de-9ded-94698f63c1c4' }}"
+          BATCH="${{ github.event.inputs.batch || '40' }}"
+          MINUTES="${{ github.event.inputs.minutes || '30' }}"
+          DEADLINE=$(( $(date +%s) + MINUTES*60 ))
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            bash scripts/daily-receipt/subject-classify-batch.sh "$USER_ID" "$BATCH"; rc=$?
+            [ "$rc" -eq 3 ] && { echo "drained"; break; }
+            [ "$rc" -eq 1 ] && { echo "batch error — stopping"; break; }
+          done

--- a/.github/workflows/subject-classify.yml
+++ b/.github/workflows/subject-classify.yml
@@ -23,6 +23,8 @@ on:
       model:
         description: Claude model
         default: 'claude-sonnet-4-6'
+  schedule:
+    - cron: '17 9 * * *'   # daily; idempotent (only classifies unclassified frames)
 
 permissions:
   contents: read

--- a/scripts/classify-image-subjects.mjs
+++ b/scripts/classify-image-subjects.mjs
@@ -1,0 +1,130 @@
+/**
+ * classify-image-subjects.mjs — subscription-powered, TEXT-ONLY subject classifier.
+ *
+ * The deep-analysis drain already spent vision and wrote a narrative for every frame
+ * (vehicle_images.ai_scan_metadata.byok_deep_analysis.narrative_one_line). This pass
+ * does NOT re-spend vision: it reads those narratives and asks Claude (via `claude
+ * --print`, billed to the SUBSCRIPTION — see subject-classify-batch.sh) which of the
+ * owner's OWNED vehicles each frame actually depicts. That is the only reliable subject
+ * signal (SQL keyword-matching was proven wrong repeatedly; see engineering-manual
+ * Ch.16). It then stages REVERSIBLE proposals — nothing is moved automatically.
+ *
+ * Modes:
+ *   prepare  --user-id <uuid> [--limit N]   -> prints a JSON job {candidates, frames}
+ *   ingest   --user-id <uuid> --results <f> -> applies the classification (flags + proposals)
+ *
+ * Provenance/safety:
+ *   - candidates are OWNED vehicles only (owner_id, non-craigslist) so a frame can never
+ *     be proposed onto a discovery comp.
+ *   - 'NONE' (facility / document / not-an-owned-vehicle) -> image_vehicle_match_status
+ *     'unrelated' (the gallery honors it; de-pollutes the current vehicle).
+ *   - matched-but-different owned vehicle -> a row in image_attribution_review
+ *     (status 'proposed') + match_status 'mismatch'. The actual vehicle_id move is a
+ *     separate, reviewed apply — this script never moves images.
+ */
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync } from 'node:fs';
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SERVICE_KEY) { console.error('Missing SUPABASE_URL / SERVICE_ROLE_KEY'); process.exit(1); }
+const sb = createClient(SUPABASE_URL, SERVICE_KEY);
+
+const args = process.argv.slice(2);
+const mode = args[0];
+const arg = (n, d) => { const i = args.indexOf(n); return i >= 0 ? args[i + 1] : d; };
+const LABELS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+async function ownedCandidates(userId) {
+  // Cross-make on purpose: the pollution is cross-make (a Scout on a Mustang), so the
+  // candidate set must span makes. Owned only; no craigslist comps.
+  const { data, error } = await sb
+    .from('vehicles')
+    .select('id, year, make, model, trim')
+    .eq('owner_id', userId)
+    .neq('source', 'craigslist')
+    .not('make', 'is', null)
+    .order('make').order('model');
+  if (error) { console.error('candidates: ' + error.message); process.exit(1); }
+  return (data || []).slice(0, 26).map((v, i) => ({
+    letter: LABELS[i],
+    id: v.id,
+    label: [v.year, v.make, v.model, v.trim].filter(Boolean).join(' '),
+  }));
+}
+
+async function prepare() {
+  const userId = arg('--user-id'); const limit = parseInt(arg('--limit', '40'), 10);
+  if (!userId) { console.error('prepare: --user-id required'); process.exit(1); }
+  const candidates = await ownedCandidates(userId);
+
+  // Frames already deep-analyzed (narrative exists) but not yet subject-classified.
+  const { data, error } = await sb
+    .from('vehicle_images')
+    .select('id, vehicle_id, ai_scan_metadata')
+    .eq('user_id', userId)
+    .is('image_vehicle_match_status', null)
+    .not('ai_scan_metadata->byok_deep_analysis', 'is', null)
+    .limit(limit);
+  if (error) { console.error('prepare: ' + error.message); process.exit(1); }
+
+  const frames = (data || []).map((r) => ({
+    image_id: r.id,
+    current_vehicle_id: r.vehicle_id,
+    narrative: r.ai_scan_metadata?.byok_deep_analysis?.narrative_one_line || '',
+  })).filter((f) => f.narrative);
+
+  console.log(JSON.stringify({ candidates, frames }));
+}
+
+async function ingest() {
+  const userId = arg('--user-id'); const resultsFile = arg('--results');
+  if (!userId || !resultsFile) { console.error('ingest: --user-id and --results required'); process.exit(1); }
+
+  // Re-derive the letter->vehicle map exactly as prepare built it (deterministic order).
+  const candidates = await ownedCandidates(userId);
+  const byLetter = new Map(candidates.map((c) => [c.letter, c.id]));
+
+  const raw = readFileSync(resultsFile, 'utf8');
+  // Accept either a JSON array or JSONL.
+  let rows = [];
+  try { rows = JSON.parse(raw); if (!Array.isArray(rows)) rows = rows.results || []; }
+  catch { rows = raw.split('\n').map((l) => l.trim()).filter(Boolean).map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean); }
+
+  let confirmed = 0, unrelated = 0, proposed = 0, skipped = 0;
+  for (const r of rows) {
+    const imageId = r.image_id; const letter = (r.vehicle_letter || r.letter || '').toUpperCase().trim();
+    const conf = typeof r.confidence === 'number' ? r.confidence : 0.7;
+    if (!imageId) { skipped++; continue; }
+
+    const { data: img } = await sb.from('vehicle_images').select('vehicle_id').eq('id', imageId).maybeSingle();
+    if (!img) { skipped++; continue; }
+
+    if (letter === 'NONE' || letter === '') {
+      await sb.from('vehicle_images').update({ image_vehicle_match_status: 'unrelated' }).eq('id', imageId);
+      unrelated++; continue;
+    }
+    const target = byLetter.get(letter);
+    if (!target) { skipped++; continue; }
+
+    if (target === img.vehicle_id) {
+      await sb.from('vehicle_images').update({ image_vehicle_match_status: 'confirmed' }).eq('id', imageId);
+      confirmed++;
+    } else {
+      // Different owned vehicle: stage a reversible proposal; flag mismatch so it leaves
+      // the wrong gallery. The vehicle_id move stays a separate, reviewed apply.
+      await sb.from('image_attribution_review').insert({
+        image_id: imageId, from_vehicle_id: img.vehicle_id, proposed_vehicle_id: target,
+        resolution: 'classified', evidence: `subscription subject-classify (conf ${conf})`,
+        session_key: 'subject_classify', status: 'proposed',
+      }).then(() => {}, () => {}); // ignore unique-conflict on re-runs
+      await sb.from('vehicle_images').update({ image_vehicle_match_status: 'mismatch' }).eq('id', imageId);
+      proposed++;
+    }
+  }
+  console.log(`ingest: confirmed=${confirmed} unrelated=${unrelated} proposed=${proposed} skipped=${skipped}`);
+}
+
+if (mode === 'prepare') await prepare();
+else if (mode === 'ingest') await ingest();
+else { console.error('mode must be "prepare" or "ingest"'); process.exit(1); }

--- a/scripts/daily-receipt/subject-classify-batch.sh
+++ b/scripts/daily-receipt/subject-classify-batch.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# subject-classify-batch.sh — TEXT-ONLY subject classification on the SUBSCRIPTION.
+#
+# Reads the narratives the deep-analysis drain already wrote (NO new vision, no API
+# tokens) and asks Claude which OWNED vehicle each frame depicts, so mis-attributed
+# frames can be flagged/re-homed. Auth is the Claude subscription via
+# CLAUDE_CODE_OAUTH_TOKEN (same as the analysis drain); we never set ANTHROPIC_API_KEY.
+#
+# Usage: subject-classify-batch.sh <user-id> [batch_size]
+set -u
+cd "$(dirname "$0")/../.." || exit 1
+USER_ID="${1:?usage: subject-classify-batch.sh <user-id> [batch_size]}"
+BATCH="${2:-40}"
+MODEL="${BYOK_MODEL:-claude-sonnet-4-6}"
+DIR="$(mktemp -d)"; JOB="$DIR/job.json"; PROMPT="$DIR/prompt.txt"; OUT="$DIR/out.json"
+log(){ echo "$(date -u '+%F %T') | subject-classify | $*"; }
+trap 'rm -rf "$DIR"' EXIT
+
+# 1) PREPARE — owned candidates + a batch of unclassified analyzed frames (narratives).
+dotenvx run -- node scripts/classify-image-subjects.mjs prepare --user-id "$USER_ID" --limit "$BATCH" > "$JOB" 2>/dev/null
+FRAMES=$(node -e 'const j=require(process.argv[1]);process.stdout.write(String((j.frames||[]).length))' "$JOB" 2>/dev/null || echo 0)
+CANDS=$(node -e 'const j=require(process.argv[1]);process.stdout.write(String((j.candidates||[]).length))' "$JOB" 2>/dev/null || echo 0)
+if [ "${FRAMES:-0}" -eq 0 ]; then log "no unclassified frames — done"; exit 3; fi
+if [ "${CANDS:-0}" -eq 0 ]; then log "no owned candidate vehicles — abort"; exit 1; fi
+log "classifying $FRAMES frames against $CANDS owned vehicles"
+
+# 2) BUILD PROMPT — text only: the owner's vehicles + the frame narratives.
+{
+  echo "You are reconciling which of an owner's OWN vehicles each photo depicts, using the"
+  echo "analyst's one-line description of each photo. You are NOT guessing from pixels — you"
+  echo "have the descriptions. Match each photo to exactly one vehicle from the OWNER'S LIST,"
+  echo "or NONE if it depicts no vehicle on the list (a building, a document, a tool, or a"
+  echo "vehicle the owner does not own)."
+  echo
+  echo "OWNER'S VEHICLES:"
+  node -e 'const j=require(process.argv[1]);for(const c of j.candidates)console.log(`  ${c.letter}) ${c.label}`)' "$JOB"
+  echo
+  echo "PHOTOS (image_id :: description):"
+  node -e 'const j=require(process.argv[1]);for(const f of j.frames)console.log(`  ${f.image_id} :: ${f.narrative}`)' "$JOB"
+  echo
+  echo "Output ONLY JSON lines, one per photo, no prose:"
+  echo '  {"image_id":"<uuid>","vehicle_letter":"<A..Z or NONE>","confidence":<0..1>}'
+  echo "Be conservative: if the description does not clearly match one listed vehicle, use NONE."
+  echo "Write the JSON lines to: $OUT"
+  echo "Write nothing else. When done, stop."
+} > "$PROMPT"
+
+# 3) CLASSIFY — subscription-billed claude --print (NOT --bare; reads prompt from stdin).
+env -u CLAUDE_EFFORT -u ANTHROPIC_API_KEY timeout 600 \
+  claude --print --model "$MODEL" --permission-mode bypassPermissions --add-dir "$DIR" \
+  < "$PROMPT" >>"$DIR/claude.log" 2>&1 || log "claude --print returned non-zero (ingesting whatever landed)"
+
+if [ ! -s "$OUT" ]; then
+  # Fallback: some runs echo the JSON to stdout instead of writing the file.
+  grep -oE '\{"image_id".*\}' "$DIR/claude.log" > "$OUT" 2>/dev/null || true
+fi
+LINES=$(grep -c '{' "$OUT" 2>/dev/null || echo 0)
+if [ "${LINES:-0}" -eq 0 ]; then log "no classifications produced — abort ingest"; exit 1; fi
+log "got $LINES classifications; ingesting"
+
+# 4) INGEST — flags + reversible proposals (never moves images).
+dotenvx run -- node scripts/classify-image-subjects.mjs ingest --user-id "$USER_ID" --results "$OUT" 2>&1 | sed 's/^/  /'

--- a/supabase/migrations/20260621160000_sibling_vehicles_owned_no_comps.sql
+++ b/supabase/migrations/20260621160000_sibling_vehicles_owned_no_comps.sql
@@ -1,0 +1,40 @@
+-- Scope the attribution matcher's candidate set to OWNED vehicles, excluding
+-- discovery comps.
+--
+-- get_sibling_vehicles feeds check-image-vehicle-match's candidate list (the vehicles
+-- a frame can be re-homed to). It had two bugs: (1) it unioned discovered_vehicles, so
+-- a user's Craigslist discovery comps became re-home targets — a frame could be moved
+-- onto a listing of a *different* physical vehicle (observed live 2026-06-21); (2) it
+-- never included vehicles owned directly via vehicles.owner_id, so genuinely-owned
+-- vehicles could be missing as candidates. Fix: candidates come from real ownership
+-- (owner_id + verification/permission/contributor tables) and craigslist-source comps
+-- are excluded outright.
+
+CREATE OR REPLACE FUNCTION public.get_sibling_vehicles(p_vehicle_id uuid, p_user_id uuid)
+RETURNS TABLE(vehicle_id uuid, v_year integer, v_make text, v_model text, v_trim text, v_vin text, image_count bigint, gps_image_count bigint, visual_signature jsonb, primary_image_url text)
+LANGUAGE sql STABLE AS $function$
+  WITH user_vehicles AS (
+    SELECT DISTINCT uv.vid FROM (
+      SELECT id AS vid FROM vehicles WHERE owner_id = p_user_id
+      UNION SELECT vehicle_id FROM ownership_verifications WHERE user_id = p_user_id
+      UNION SELECT vehicle_id FROM vehicle_user_permissions WHERE user_id = p_user_id AND is_active = true
+      UNION SELECT vehicle_id FROM vehicle_contributors WHERE user_id = p_user_id AND status != 'inactive'
+    ) uv
+  ),
+  target AS (SELECT v.make, v.model FROM vehicles v WHERE v.id = p_vehicle_id)
+  SELECT v.id, v.year, v.make, v.model, v."trim", v.vin,
+    (SELECT count(*) FROM vehicle_images vi WHERE vi.vehicle_id = v.id) as image_count,
+    (SELECT count(*) FROM vehicle_images vi WHERE vi.vehicle_id = v.id AND vi.latitude IS NOT NULL) as gps_image_count,
+    v.visual_signature, v.primary_image_url
+  FROM vehicles v
+  JOIN user_vehicles uv ON uv.vid = v.id
+  CROSS JOIN target t
+  WHERE v.id != p_vehicle_id
+    AND v.status IN ('active', 'pending', 'discovered', 'pending_backfill')
+    AND COALESCE(v.source,'') <> 'craigslist'
+    AND (
+      v.make = t.make OR v.make ILIKE t.make || '%' OR t.make ILIKE v.make || '%'
+      OR (v.make IN ('GMC', 'Chevrolet') AND t.make IN ('GMC', 'Chevrolet'))
+    )
+  ORDER BY v.year;
+$function$;


### PR DESCRIPTION
Two corrections that make the attribution system actually organize images — on the **subscription**, with **no per-token API cost**.

## 1. Scope matcher candidates to owned vehicles, exclude comps
`get_sibling_vehicles` (the matcher's candidate source) unioned `discovered_vehicles`, so Craigslist comps became re-home targets — the cause of a frame landing on a *listing* instead of the owned vehicle. It also missed `owner_id`-owned vehicles. Fixed: candidates = real ownership, craigslist comps excluded. Applied live (Mustang → 17 clean owned candidates).

## 2. Subscription subject-classifier (the cost-aligned organization path)
The pay-per-token Anthropic API is out of credits, so the content matcher (Haiku vision) can't run. This path doesn't need it: the analysis drain **already wrote a narrative for every frame** — this reads those narratives and asks Claude, via `claude --print` (billed to the **subscription**, like the analysis drain), which **owned** vehicle each frame depicts. No new vision, no API tokens.

- `classify-image-subjects.mjs` — prepare (owned, cross-make candidates + unclassified analyzed frames) / ingest. `NONE` → `image_vehicle_match_status='unrelated'` (de-pollutes; the gallery honors it). A *different* owned vehicle → a reversible `image_attribution_review` proposal + `mismatch`. **Never moves images** — the `vehicle_id` move stays a reviewed apply.
- `subject-classify-batch.sh` — prepare → prompt → `claude --print` (subscription) → ingest. Text-only; unsets `ANTHROPIC_API_KEY` so the subscription token wins.
- `subject-classify.yml` — dispatch **+ daily schedule** so the backlog (7,050 analyzed frames) self-classifies idempotently once merged.

Untested from the dev env (runs in CI on `CLAUDE_CODE_OAUTH_TOKEN`); modeled on the proven analysis drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VY7vRRmx2gDQhhvELQ5vju

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated vehicle subject classification system powered by AI that processes images with existing narratives to intelligently assign vehicle matches.
  * Implemented capability to suggest corrections for vehicle attributions with reviewable proposals when mismatches are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->