### PR TITLE
feat(primary-image): data-derived quality score + EXIF date backfill

### DIFF
--- a/scripts/backfill-taken-at-from-exif.mjs
+++ b/scripts/backfill-taken-at-from-exif.mjs
@@ -1,0 +1,84 @@
+/**
+ * backfill-taken-at-from-exif.mjs — recover real capture dates from file EXIF.
+ *
+ * Problem (measured 2026-06-22): the HD-archive frames (full-res originals, e.g. the
+ * 1966 Mustang's finished-car shots) have vehicle_images.taken_at = NULL and empty
+ * exif_data in the DB, even though the real capture date (2024) sits in each file's
+ * embedded EXIF (DateTimeOriginal). With no taken_at the chronology has holes, "latest"
+ * silently favors the capture-relay frames that *do* have dates, and build-era vs
+ * finished-era can't be separated. This backfills taken_at from the file EXIF.
+ *
+ * Efficient: EXIF lives in the first chunk of the file, so we range-GET only the first
+ * ~256 KB instead of downloading multi-MB originals. Public bucket → no auth for the read;
+ * the DB write uses the service role. Idempotent: only touches rows where taken_at IS NULL.
+ *
+ * Usage:
+ *   node scripts/backfill-taken-at-from-exif.mjs --vehicle-id <uuid> [--limit N] [--dry-run]
+ *   node scripts/backfill-taken-at-from-exif.mjs --all [--limit N] [--dry-run]
+ *
+ * Env: SUPABASE_URL (or VITE_SUPABASE_URL), SUPABASE_SERVICE_ROLE_KEY.
+ * Dep: exifr (npm i exifr) — reads JPEG/HEIC/PNG EXIF.
+ */
+import { createClient } from '@supabase/supabase-js';
+import exifr from 'exifr';
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SERVICE_KEY) { console.error('Missing SUPABASE_URL / SERVICE_ROLE_KEY'); process.exit(1); }
+const sb = createClient(SUPABASE_URL, SERVICE_KEY);
+
+const args = process.argv.slice(2);
+const arg = (n, d) => { const i = args.indexOf(n); return i >= 0 ? args[i + 1] : d; };
+const VEHICLE_ID = arg('--vehicle-id');
+const ALL = args.includes('--all');
+const DRY = args.includes('--dry-run');
+const LIMIT = parseInt(arg('--limit', '500'), 10);
+if (!VEHICLE_ID && !ALL) { console.error('need --vehicle-id <uuid> or --all'); process.exit(1); }
+
+// Pull only the bytes that hold EXIF (first ~256 KB). Falls back to a full GET on the
+// rare file whose EXIF block sits past the range.
+async function readShotAt(url) {
+  for (const range of ['bytes=0-262143', null]) {
+    try {
+      const res = await fetch(url, range ? { headers: { Range: range } } : {});
+      if (!res.ok && res.status !== 206) continue;
+      const buf = Buffer.from(await res.arrayBuffer());
+      const ex = await exifr.parse(buf, { pick: ['DateTimeOriginal', 'CreateDate', 'ModifyDate'] }).catch(() => null);
+      const d = ex?.DateTimeOriginal || ex?.CreateDate || ex?.ModifyDate;
+      if (d instanceof Date && !isNaN(d) && d.getFullYear() > 1990) return d.toISOString();
+      if (range) continue; // ranged read had no date — try full
+    } catch { /* try next */ }
+  }
+  return null;
+}
+
+async function page(from, to) {
+  let q = sb.from('vehicle_images')
+    .select('id, image_url')
+    .is('taken_at', null)
+    .not('image_url', 'is', null)
+    .order('id')
+    .range(from, to);
+  if (!ALL) q = q.eq('vehicle_id', VEHICLE_ID);
+  const { data, error } = await q;
+  if (error) { console.error('query: ' + error.message); process.exit(1); }
+  return data || [];
+}
+
+let scanned = 0, updated = 0, nodate = 0;
+for (let off = 0; off < LIMIT; off += 200) {
+  const rows = await page(off, Math.min(off + 199, LIMIT - 1));
+  if (!rows.length) break;
+  for (const r of rows) {
+    scanned++;
+    const iso = await readShotAt(r.image_url);
+    if (!iso) { nodate++; continue; }
+    if (DRY) { updated++; console.log(`would set ${r.id.slice(0, 8)} -> ${iso}`); continue; }
+    const { error } = await sb.from('vehicle_images')
+      .update({ taken_at: iso }).eq('id', r.id).is('taken_at', null); // re-check guard
+    if (error) { console.error(`update ${r.id.slice(0, 8)}: ${error.message}`); continue; }
+    updated++;
+  }
+  if (rows.length < 200) break;
+}
+console.log(`backfill-taken-at: scanned=${scanned} updated=${updated} no_date=${nodate}${DRY ? ' (dry-run)' : ''}`);

--- a/supabase/migrations/20260622050000_image_hero_score_quality_primary.sql
+++ b/supabase/migrations/20260622050000_image_hero_score_quality_primary.sql
@@ -1,0 +1,154 @@
+-- Data-derived image quality ("hero") score + quality-first primary-image selection.
+--
+-- The lead image was chosen by RECENCY ("latest confirmed exterior"), which on a burst
+-- picks the last frame, not the best, and with broken dates smears build-era and
+-- finished-era shots together. "Best" is not a policy to hard-code — it is *measured from
+-- the data the analysis already produced*: camera_pose (framing/distance/angle), presence
+-- (people/pets), state_observations.completeness, build_phase_guess, and resolution.
+--
+-- image_hero_score(meta, file_size) turns those signals into one number:
+--   + full-vehicle exterior (scene_type), assembled, finished build phase
+--   + framed as a whole car (~2–4 m) at a three-quarter/profile angle
+--   - close-up / rotated / window-cowl-decklid crops, people or pets in frame
+--   + a small resolution/confidence nudge
+-- It is IMMUTABLE (depends only on its inputs) so it can be used in ORDER BY / indexes.
+--
+-- recompute_vehicle_primary_image then selects the highest-scoring CONFIRMED frame as the
+-- cover (best-of-set), falling back to the prior recency tiers only when nothing is
+-- classified yet. Picking the single max score also means the cover is burst-deduped by
+-- construction. No date dependency: quality drives the cover, not upload time.
+
+CREATE OR REPLACE FUNCTION public.image_hero_score(meta jsonb, fsize bigint)
+RETURNS numeric LANGUAGE plpgsql IMMUTABLE AS $$
+DECLARE
+  a jsonb := meta->'byok_deep_analysis';
+  s numeric := 0;
+  framing text; az numeric; dist numeric;
+BEGIN
+  IF a IS NULL THEN RETURN 0; END IF;
+  framing := coalesce(a->'camera_pose'->>'framing','');
+  BEGIN az := nullif(a->'camera_pose'->>'azimuth_deg','')::numeric; EXCEPTION WHEN others THEN az := NULL; END;
+  BEGIN dist := nullif(regexp_replace(coalesce(a->'camera_pose'->>'distance_est',''),'[^0-9.]','','g'),'')::numeric; EXCEPTION WHEN others THEN dist := NULL; END;
+
+  -- what the frame is OF: a whole-vehicle exterior is the hero material
+  s := s + CASE a->>'scene_type'
+             WHEN 'body_exterior' THEN 1.5
+             WHEN 'body_interior' THEN 0.3
+             ELSE 0 END;
+  -- the car as a finished, whole object
+  s := s + CASE WHEN a->'state_observations'->>'completeness' = 'assembled' THEN 0.5 ELSE 0 END;
+  s := s + CASE WHEN a->>'build_phase_guess' IN ('final_assembly','drivable','show_finish') THEN 0.5 ELSE 0 END;
+  -- framed as a whole car, not a close-up
+  s := s + CASE WHEN dist BETWEEN 2 AND 4 THEN 1.0
+                WHEN dist BETWEEN 1.5 AND 5 THEN 0.5
+                ELSE 0.15 END;
+  -- three-quarter/profile angle reads best; head-on/rear-flat less so
+  IF az IS NOT NULL THEN
+    s := s + (1 - least(least(abs(az-45), least(abs(az-135), least(abs(az-225), abs(az-315)))), 90) / 90.0) * 0.8;
+  END IF;
+  -- framing language: reward whole-car shots, punish crops / orientation problems / clutter
+  s := s + CASE WHEN framing ~* '(profile|three-quarter|3/4|full)' THEN 0.4 ELSE 0 END;
+  s := s + CASE WHEN framing ~* '(rotated|window|cowl|windshield|roof and rear|decklid|opening|macro|close)' THEN -0.7 ELSE 0 END;
+  s := s + CASE WHEN framing ~* '(dog|tools|packaging|clutter)' THEN -0.3 ELSE 0 END;
+  -- people in a hero shot are a distraction
+  s := s + CASE WHEN a->'presence'->>'person' = 'true' THEN -1.0 ELSE 0 END;
+  -- small nudges: analyst confidence + resolution proxy
+  BEGIN s := s + coalesce((a->>'confidence')::numeric, 0) * 0.3; EXCEPTION WHEN others THEN NULL; END;
+  s := s + coalesce(fsize, 0) / 1.0e7;
+  RETURN s;
+END $$;
+
+COMMENT ON FUNCTION public.image_hero_score(jsonb, bigint) IS
+  'Data-derived quality score for a frame as a cover/hero image, from byok_deep_analysis camera_pose/presence/state + resolution. Higher = better whole-car exterior. IMMUTABLE.';
+
+CREATE OR REPLACE FUNCTION public.recompute_vehicle_primary_image(p_vehicle_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_old text; v_latest timestamptz;
+  v_id uuid; v_url text; v_taken timestamptz; v_zone text; v_tier text := 'none';
+  c_owner text[] := ARRAY['iphoto','user_upload','capture_relay','capture_relay_ios','daily_receipt',
+                          'photo_auto_sync','drop-folder','owner_import','user-submission','owner_submission'];
+BEGIN
+  SELECT primary_image_url INTO v_old FROM vehicles WHERE id = p_vehicle_id;
+
+  -- Tier 1 (quality-first): highest hero-scored CONFIRMED frame that has analysis.
+  -- Best-of-set, burst-deduped by construction, date-independent.
+  SELECT id,image_url,COALESCE(taken_at,created_at),vehicle_zone INTO v_id,v_url,v_taken,v_zone
+  FROM vehicle_images
+  WHERE vehicle_id = p_vehicle_id
+    AND COALESCE(is_superseded,false)=false AND COALESCE(is_duplicate,false)=false
+    AND image_vehicle_match_status = 'confirmed'
+    AND ai_scan_metadata->'byok_deep_analysis' IS NOT NULL
+    AND image_url IS NOT NULL AND image_url <> ''
+  ORDER BY public.image_hero_score(ai_scan_metadata, file_size) DESC, COALESCE(taken_at,created_at) DESC
+  LIMIT 1;
+  IF v_id IS NOT NULL THEN v_tier := 'hero_score'; END IF;
+
+  -- Tier 2: any CONFIRMED frame (no analysis yet) — latest.
+  IF v_id IS NULL THEN
+    SELECT id,image_url,COALESCE(taken_at,created_at),vehicle_zone INTO v_id,v_url,v_taken,v_zone
+    FROM vehicle_images
+    WHERE vehicle_id = p_vehicle_id
+      AND COALESCE(is_superseded,false)=false AND COALESCE(is_duplicate,false)=false
+      AND image_vehicle_match_status = 'confirmed'
+      AND image_url IS NOT NULL AND image_url <> ''
+    ORDER BY COALESCE(taken_at,created_at) DESC LIMIT 1;
+    IF v_id IS NOT NULL THEN v_tier := 'confirmed_any'; END IF;
+  END IF;
+
+  -- Tiers 3-4: no confirmed frames yet — prior behavior, but rank eligible owner frames
+  -- by hero score (still excludes mismatch/unrelated) so the cover is the best available,
+  -- not merely the newest.
+  IF v_id IS NULL THEN
+    SELECT id,image_url,COALESCE(taken_at,created_at),vehicle_zone INTO v_id,v_url,v_taken,v_zone
+    FROM vehicle_images
+    WHERE vehicle_id = p_vehicle_id AND source = ANY(c_owner)
+      AND COALESCE(vision_gate_status,'approved') = 'approved'
+      AND COALESCE(is_superseded,false)=false AND COALESCE(is_duplicate,false)=false
+      AND COALESCE(image_vehicle_match_status,'pending') NOT IN ('mismatch','unrelated')
+      AND ai_scan_metadata->'byok_deep_analysis' IS NOT NULL
+      AND image_url IS NOT NULL AND image_url <> ''
+    ORDER BY public.image_hero_score(ai_scan_metadata, file_size) DESC, COALESCE(taken_at,created_at) DESC
+    LIMIT 1;
+    IF v_id IS NOT NULL THEN v_tier := 'owner_hero'; END IF;
+  END IF;
+
+  IF v_id IS NULL THEN
+    SELECT id,image_url,COALESCE(taken_at,created_at),vehicle_zone INTO v_id,v_url,v_taken,v_zone
+    FROM vehicle_images
+    WHERE vehicle_id = p_vehicle_id AND source = ANY(c_owner)
+      AND COALESCE(vision_gate_status,'approved') = 'approved'
+      AND COALESCE(is_superseded,false)=false AND COALESCE(is_duplicate,false)=false
+      AND COALESCE(image_vehicle_match_status,'pending') NOT IN ('mismatch','unrelated')
+      AND image_url IS NOT NULL AND image_url <> ''
+    ORDER BY COALESCE(taken_at,created_at) DESC LIMIT 1;
+    IF v_id IS NOT NULL THEN v_tier := 'owner_latest'; END IF;
+  END IF;
+
+  -- Tier 5: any approved non-dup image (scraped-only comps).
+  IF v_id IS NULL THEN
+    SELECT id,image_url,COALESCE(taken_at,created_at),vehicle_zone INTO v_id,v_url,v_taken,v_zone
+    FROM vehicle_images
+    WHERE vehicle_id = p_vehicle_id
+      AND COALESCE(is_superseded,false)=false AND COALESCE(is_duplicate,false)=false
+      AND COALESCE(image_vehicle_match_status,'pending') NOT IN ('mismatch','unrelated')
+      AND image_url IS NOT NULL AND image_url <> ''
+    ORDER BY COALESCE(is_primary,false) DESC, COALESCE(taken_at,created_at) DESC LIMIT 1;
+    IF v_id IS NOT NULL THEN v_tier := 'any_approved'; END IF;
+  END IF;
+
+  IF v_id IS NULL THEN
+    RETURN jsonb_build_object('vehicle_id',p_vehicle_id,'changed',false,'reason','no_candidate','primary',v_old);
+  END IF;
+
+  UPDATE vehicle_images SET is_primary=false WHERE vehicle_id=p_vehicle_id AND is_primary=true AND id<>v_id;
+  UPDATE vehicle_images SET is_primary=true  WHERE id=v_id AND COALESCE(is_primary,false)=false;
+  UPDATE vehicles SET primary_image_url=v_url WHERE id=p_vehicle_id AND primary_image_url IS DISTINCT FROM v_url;
+
+  RETURN jsonb_build_object('vehicle_id',p_vehicle_id,'changed',(v_old IS DISTINCT FROM v_url),
+    'tier',v_tier,'chosen_image_id',v_id,'taken_at',v_taken,'zone',v_zone,'was',left(v_old,40),'now',left(v_url,40));
+END $function$;


### PR DESCRIPTION
## What
Addresses three real flaws in how the cover/lead image is chosen (it was recency-based — "last of the burst, not best of the set" — and mixed build-era with finished-era because dates are broken).

### 1. Data-derived quality score (`image_hero_score`)
"Best" is measured from the analysis the system already produced, not hard-coded. IMMUTABLE function scoring each frame from `camera_pose` (framing / distance / angle), `presence` (people/pets), `state_observations.completeness`, `build_phase_guess`, and resolution: rewards a whole-car exterior at a three-quarter/profile angle (~2–4 m), punishes close-ups / rotated crops / people in frame.

### 2. Quality-first primary picker
`recompute_vehicle_primary_image` now selects the highest-scoring **confirmed** frame as the cover — best-of-set, **burst-deduped by construction** (single max), and **date-independent**. Falls back to the prior recency tiers only when nothing is classified yet.

### 3. Date backfill (`backfill-taken-at-from-exif.mjs`)
The HD-archive originals have `taken_at = NULL` even though their real 2024 capture dates are in the file EXIF (verified: a range-GET of the first 256 KB recovers `DateTimeOriginal` — e.g. the finished-car hero shot is 2024-07-10). Recovers them so chronology / "latest" / build-vs-finished separation become trustworthy. Idempotent (only `NULL taken_at`), reads the public bucket, writes via service role.

Migration is idempotent `CREATE OR REPLACE`; deploys via supabase-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VY7vRRmx2gDQhhvELQ5vju)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic population of missing image capture timestamps using embedded metadata.
  * Implemented intelligent image quality scoring and enhanced primary vehicle image selection based on scene analysis, completeness, and composition heuristics.

* **Chores**
  * Added data backfill tooling to populate historical image timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->