### PR TITLE
feat(extraction): canonical contract + perceptual-hash + burst-dedup organ

### DIFF
--- a/docs/library/technical/engineering-manual/19-extraction-contract.md
+++ b/docs/library/technical/engineering-manual/19-extraction-contract.md
@@ -1,0 +1,122 @@
+# Chapter 19: The Extraction Contract (schema-as-decision-tree)
+
+## Why this chapter exists
+
+`vehicle_images` has **162 columns**. On a real vehicle (the 1966 Mustang test case,
+2026-06-22) only ~15 are meaningfully filled; the rest are **dead duplicates** or
+**unfed load-bearing fields**. "Fill all the schema fields" is the stated goal — but it
+is the wrong goal stated against this table, because half the columns are redundant and a
+handful of the important ones have no extractor feeding them.
+
+This chapter defines the **canonical extraction contract**: the real, minimal set of
+fields each image should carry, *where each comes from*, and the **decision tree** that
+says which fields apply to which image. It is the spec the analyzer fills, the dedup map
+for the 130 junk columns, and the acceptance test for "the pipeline works."
+
+The mental model the owner gave: the schema is a standardized request — an **if-then tree**
+(if this is a data plate, then read the VIN; if an engine bay, then read the block/heads)
+— not "describe the picture." Captioning is freeform and unscoreable; a contract is
+checkable: every applicable field is either filled or explicitly `unknown`.
+
+---
+
+## The three sources of a field
+
+Every canonical field is filled from exactly one of three sources, cheapest first. The
+pipeline must try them in order; vision is the *last* resort, not the first.
+
+1. **Capture (free, deterministic).** Already in the file or the upload: `taken_at`
+   (EXIF DateTimeOriginal), `latitude`/`longitude` (EXIF GPS), `camera`/`device_fingerprint`
+   (EXIF Make/Model/serial), `mime_type`, `file_size`, dimensions, `upload_batch_id`.
+   *Never* spend a model on these. (As of 2026-06-22 the drain did not even read EXIF —
+   dates were null fleet-wide; see Ch.16/18.)
+2. **Derived (free, compute-only).** Computed from pixels with no model: `phash`/`dhash`
+   (perceptual hash → dedup + burst detection), blur/sharpness, dominant color,
+   resolution class. These gate everything downstream (a blurry burst-duplicate should
+   never reach a paid model).
+3. **Vision (paid, conditional).** Only the fields a model must judge: `scene_type`,
+   `build_phase_guess`, `components_seen`, `text_regions` (OCR), `state_observations`,
+   `camera_pose`, `narrative_one_line`, `intent`. These are gated by the decision tree
+   below so we never ask for engine fields on a document.
+
+The cost work (Ch. cost notes) showed the model call is the expensive step; sources 1–2
+must do as much as possible so source 3 runs on the fewest images with the smallest prompt.
+
+---
+
+## The decision tree (what to extract, conditioned on what it is)
+
+`scene_type` is the discriminator. It is cheap to get (a tiny first-pass classifier) and
+it decides which expensive fields are even asked for:
+
+```
+every image →  capture fields (1) + derived fields (2) + scene_type + is_vehicle?
+  ├─ not a vehicle / personal / document-of-people → STOP. image_vehicle_match_status='unrelated'. no vehicle vision.
+  ├─ scene_type = data_plate | vin | receipt_document  → text_regions/OCR is PRIMARY (VIN, serial, part #, price, date). minimal component pass.
+  ├─ scene_type = body_exterior                         → camera_pose (framing/angle/distance), paint_state, completeness, hero_score inputs.
+  ├─ scene_type = engine_bay                            → components_seen (block, heads, intake, carb...), part_number_guess, casting OCR.
+  ├─ scene_type = undercarriage                         → components (frame, axle, suspension), rust_severity, damage_localized.
+  ├─ scene_type = interior                              → components (seats, dash, gauges), completeness.
+  └─ scene_type = shop_context | off_property           → presence, place_hint (GPS-resolved). low component effort; often a session anchor, not a subject.
+```
+
+The point: a document gets OCR, not a carburetor hunt; an exterior gets pose+paint, not a
+fastener inventory. Same model, different *contract slice*, so tokens are spent only where
+the field can exist.
+
+---
+
+## The canonical fields (the real contract)
+
+| field | source | applies to | today |
+|---|---|---|---|
+| `taken_at` | capture (EXIF) | all | fixed 2026-06-22 (was null) |
+| `latitude`/`longitude`/`location_name` | capture (EXIF GPS + legend) | all w/ GPS | partial (iOS only) |
+| `device_fingerprint` | capture (EXIF) | all | partial |
+| `upload_batch_id` | capture (upload) | all | **0% — unfed** |
+| `phash` (+ `dhash`) | derived | all | **0% — unfed (this chapter builds it)** |
+| `is_duplicate`/`duplicate_of` | derived (phash) | all | **0% — unfed** |
+| `image_hero_score` (computed) | derived (from vision pose) | exterior | live (migration 20260622050000) |
+| `scene_type` | vision (cheap pass) | all | in JSONB |
+| `image_vehicle_match_status` | vision/classifier | all | partial |
+| `work_session_id` | derived (taken_at+device+gps cluster) | all | **18% — barely fed** |
+| `components_seen` | vision (conditional) | engine/undercarriage/interior | in JSONB |
+| `text_regions` (OCR) | vision (conditional) | data_plate/document | in JSONB |
+| `camera_pose` | vision (conditional) | exterior | in JSONB (dead column) |
+| `state_observations` | vision (conditional) | most | in JSONB |
+| `narrative_one_line` | vision | all | live |
+| provenance (`agent_model`,`agent_cost_cents`,tokens) | harness | all | fixed 2026-06-22 (cost capture) |
+
+Everything else in the 162 columns is one of: a **dead duplicate** (`filename`+`file_name`;
+`category`+`image_category`+`image_type`; `vehicle_make/model/year/vin` columns that
+identity already lives for on the vehicle record; four hash columns where one is
+canonical; five quality scores where `image_hero_score` is canonical), or **scaffolding
+for a stage that never ran** (`fabrication_stage`, `surface_coord_u/v`, `yono_queued_at`).
+Those are consolidation/deletion targets, not fill targets.
+
+---
+
+## Dedup is burst-collapse, not library-halving (correction, 2026-06-22)
+
+A perceptual-hash probe disproved the assumption that the HD-archive and iOS capture-relay
+copies are the same photos double-stored: across a 36-frame sample there were **zero**
+cross-copy matches. The two are largely **distinct shoots** (2024 build originals vs later
+captures). So dedup's job is **within-burst collapse** — the 5 near-identical frames of one
+moment where only the best should anchor the cover/gallery (the "last-of-burst not
+best-of-set" problem) — plus catching genuine re-uploads. Worth doing (fewer redundant
+paid analyses, cleaner galleries, a real burst→representative signal), but it is **not** a
+2× cost cut. Be precise about this when costing a rerun.
+
+---
+
+## Acceptance test ("does the pipeline work")
+
+For a vehicle, the contract is met when, for every non-superseded image:
+1. capture fields are filled wherever the file carries them (no null `taken_at` on a dated file);
+2. `phash` is set and the image is either a burst representative or flagged `is_duplicate`;
+3. `scene_type` + `image_vehicle_match_status` are set;
+4. the **applicable** vision fields for that `scene_type` are filled or explicitly `unknown`;
+5. provenance records the model + real per-image cost.
+
+That is a checkable definition of "filled ALL possible schema fields" — *possible* meaning
+*applicable under the decision tree*, not all 162 columns.

--- a/scripts/backfill-perceptual-hash.py
+++ b/scripts/backfill-perceptual-hash.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+backfill-perceptual-hash.py — fill vehicle_images.phash/dhash from the source pixels.
+
+A load-bearing field the pipeline never populated: phash/dhash were 0% filled, so dedup
+was impossible (is_duplicate=0 even where bursts obviously exist). This computes them — a
+free, deterministic, no-AI step (source #2 in the extraction contract, Ch.19) — so the
+burst-dedup organ (flag_image_burst_duplicates) has an input.
+
+Perceptual hashing is resolution-independent: the same shot at different sizes hashes the
+same, so it also catches genuine re-uploads. (Note: it is NOT a library-halving 2x dedup —
+the HD-archive and capture-relay copies were shown to be distinct shoots; this mainly
+collapses bursts. See Ch.19.)
+
+Storage: phash + dhash as 16-char hex (64-bit). Idempotent: only rows where phash IS NULL.
+
+Usage:
+  python3 scripts/backfill-perceptual-hash.py --vehicle-id <uuid> [--limit N]
+  python3 scripts/backfill-perceptual-hash.py --all [--limit N]
+
+Env: SUPABASE_URL (or VITE_SUPABASE_URL), SUPABASE_SERVICE_ROLE_KEY
+Deps: pip install pillow pillow-heif imagehash requests
+"""
+import os, sys, io, argparse, requests, imagehash
+from PIL import Image
+import pillow_heif
+pillow_heif.register_heif_opener()
+
+URL = os.environ.get("SUPABASE_URL") or os.environ.get("VITE_SUPABASE_URL")
+KEY = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+if not URL or not KEY:
+    sys.exit("Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY")
+H = {"apikey": KEY, "authorization": f"Bearer {KEY}", "content-type": "application/json"}
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--vehicle-id"); ap.add_argument("--all", action="store_true")
+ap.add_argument("--limit", type=int, default=500)
+a = ap.parse_args()
+if not a.vehicle_id and not a.all:
+    sys.exit("need --vehicle-id <uuid> or --all")
+
+sess = requests.Session()
+
+def fetch_pending(limit):
+    q = (f"{URL}/rest/v1/vehicle_images?select=id,image_url"
+         f"&phash=is.null&image_url=not.is.null&is_superseded=eq.false&limit={limit}")
+    if not a.all:
+        q += f"&vehicle_id=eq.{a.vehicle_id}"
+    r = sess.get(q, headers=H, timeout=60); r.raise_for_status()
+    return r.json()
+
+def hashes(url):
+    # EXIF/whole-image needed for perceptual hash — pull the file (cap at a sane size).
+    resp = sess.get(url, timeout=60); resp.raise_for_status()
+    im = Image.open(io.BytesIO(resp.content)).convert("RGB")
+    return str(imagehash.phash(im)), str(imagehash.dhash(im))
+
+done = err = 0
+rows = fetch_pending(a.limit)
+print(f"to hash: {len(rows)}")
+for r in rows:
+    try:
+        ph, dh = hashes(r["image_url"])
+        u = sess.patch(f"{URL}/rest/v1/vehicle_images?id=eq.{r['id']}&phash=is.null",
+                       headers={**H, "prefer": "return=minimal"},
+                       json={"phash": ph, "dhash": dh}, timeout=60)
+        u.raise_for_status(); done += 1
+    except Exception as e:
+        err += 1; print("ERR", r["id"][:8], str(e)[:80])
+print(f"phash backfill: filled={done} errors={err}")

--- a/supabase/migrations/20260622070000_image_burst_dedup.sql
+++ b/supabase/migrations/20260622070000_image_burst_dedup.sql
@@ -1,0 +1,62 @@
+-- Burst-dedup organ: collapse near-identical frames to one representative.
+--
+-- The audit (2026-06-22) found phash 0% filled → is_duplicate 0% → the "last of the burst
+-- not the best of the set" problem had no fix, and bursts inflated galleries and paid
+-- re-analysis. With phash now populated (scripts/backfill-perceptual-hash.py), this flags
+-- the redundant frames of a burst as duplicates of the BEST one, by:
+--   - same vehicle, both non-superseded, both with a 16-hex phash
+--   - perceptual Hamming distance <= p_max_hamming (near-identical pixels)
+--   - shot within p_window_seconds of each other (a burst, not two separate visits)
+--   - "best" = highest image_hero_score, then larger file, then newer, then id
+-- The best frame in each neighborhood has no strictly-better near neighbor, so it is kept;
+-- every other frame is flagged is_duplicate=true with duplicate_of -> its best neighbor.
+-- Reversible (clear is_duplicate/duplicate_of). NOT a 2x library dedup — bursts only
+-- (HD-archive vs capture-relay were shown to be distinct shoots; see Ch.19).
+
+CREATE OR REPLACE FUNCTION public.flag_image_burst_duplicates(
+  p_vehicle_id uuid,
+  p_max_hamming int DEFAULT 6,
+  p_window_seconds int DEFAULT 300
+) RETURNS jsonb
+LANGUAGE plpgsql AS $$
+DECLARE n_flagged int;
+BEGIN
+  WITH imgs AS (
+    SELECT id, phash,
+           COALESCE(taken_at, created_at) AS ts,
+           COALESCE(file_size,0) AS fsize,
+           public.image_hero_score(ai_scan_metadata, file_size) AS hs
+    FROM vehicle_images
+    WHERE vehicle_id = p_vehicle_id
+      AND COALESCE(is_superseded,false) = false
+      AND phash IS NOT NULL AND length(phash) = 16
+  ),
+  pairs AS (   -- a has a strictly-better near neighbor b within the burst window
+    SELECT a.id AS a_id, b.id AS b_id, b.hs AS b_hs, b.fsize AS b_fs
+    FROM imgs a
+    JOIN imgs b ON a.id <> b.id
+      AND length(translate(
+            (('x'||a.phash)::bit(64) # ('x'||b.phash)::bit(64))::text, '0','')) <= p_max_hamming
+      AND abs(extract(epoch FROM (a.ts - b.ts))) <= p_window_seconds
+      AND (b.hs, b.fsize, b.id) > (a.hs, a.fsize, a.id)
+  ),
+  keeper AS (  -- each loser points at its best better-neighbor
+    SELECT a_id, b_id FROM (
+      SELECT a_id, b_id,
+             row_number() OVER (PARTITION BY a_id ORDER BY b_hs DESC, b_fs DESC, b_id DESC) rn
+      FROM pairs
+    ) r WHERE rn = 1
+  )
+  UPDATE vehicle_images vi
+  SET is_duplicate = true, duplicate_of = k.b_id, updated_at = now()
+  FROM keeper k
+  WHERE vi.id = k.a_id
+    AND (COALESCE(vi.is_duplicate,false) = false OR vi.duplicate_of IS DISTINCT FROM k.b_id);
+  GET DIAGNOSTICS n_flagged = ROW_COUNT;
+
+  RETURN jsonb_build_object('vehicle_id', p_vehicle_id, 'flagged_duplicate', n_flagged);
+END $$;
+
+COMMENT ON FUNCTION public.flag_image_burst_duplicates(uuid,int,int) IS
+  'Flag burst near-duplicates within a vehicle (phash Hamming + time window), keeping the '
+  'highest hero-scored frame. Requires phash populated. Reversible. See engineering-manual Ch.19.';


### PR DESCRIPTION
## Context
The schema-completeness audit (the Mustang fills ~15 of 162 `vehicle_images` columns; the rest are dead duplicates or unfed load-bearing fields) showed "fill all fields" is the wrong goal — we need a canonical contract and to feed the few load-bearing fields that have no extractor.

## What's in this PR
1. **`docs/.../19-extraction-contract.md`** — the canonical per-image field set as a **schema-as-decision-tree**: `scene_type` gates which fields apply (data_plate → OCR; engine_bay → components; exterior → pose/paint), each field tagged by **source** (capture/EXIF · derived/compute · vision-conditional), plus the 162→canonical consolidation map and a checkable "pipeline works" acceptance test. Also corrects my earlier **2× dedup overclaim** — a pHash probe showed HD-archive and capture-relay are *distinct shoots*, not double-stored copies; dedup is **burst-collapse**, not library-halving.

2. **`scripts/backfill-perceptual-hash.py`** — fills `phash`/`dhash` (0% before) from source pixels. Free, no-AI (contract source #2). Unblocks dedup; idempotent.

3. **`migration … flag_image_burst_duplicates()`** — collapses near-identical burst frames to the best (highest `image_hero_score`) within a pHash Hamming + time window; flags the rest `is_duplicate` + `duplicate_of`. Hamming via `bit(64)` XOR, verified 64/1/0. Reversible.

## Not yet wired
The extractor + dedup are organs; wiring them into the drain (run pHash at ingest, dedup per work-session) is the follow-up. Running the backfill at scale needs the service-role environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VY7vRRmx2gDQhhvELQ5vju)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added engineering manual chapter defining the canonical extraction contract schema, field sources, and acceptance criteria.

* **Chores**
  * Added utility script to compute image hashes from URLs and populate database records.
  * Added database migration enabling automated detection and flagging of duplicate frames in burst image sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->