### PR TITLE
feat(schema): promote image depth from JSONB into reserved columns (audit: not dead)

### DIFF
--- a/docs/library/technical/engineering-manual/19-extraction-contract.md
+++ b/docs/library/technical/engineering-manual/19-extraction-contract.md
@@ -2,11 +2,13 @@
 
 ## Why this chapter exists
 
-`vehicle_images` has **162 columns**. On a real vehicle (the 1966 Mustang test case,
-2026-06-22) only ~15 are meaningfully filled; the rest are **dead duplicates** or
-**unfed load-bearing fields**. "Fill all the schema fields" is the stated goal — but it
-is the wrong goal stated against this table, because half the columns are redundant and a
-handful of the important ones have no extractor feeding them.
+`vehicle_images` has **172 columns**. On a real vehicle (the 1966 Mustang test case,
+2026-06-22) only ~15 are meaningfully filled; the rest are **aspirational targets** the
+pipeline is only now producing data for — reserved fields for stages that haven't run,
+columns whose depth still lives in JSONB awaiting promotion, and a small redundant residue
+(see the 2026-06-23 audit below). The schema is the *contract the pipeline grows into*, so
+"fill all the schema fields" is directionally right; the work is wiring an extractor to each
+field and promoting JSONB depth into columns, not pruning the table.
 
 This chapter defines the **canonical extraction contract**: the real, minimal set of
 fields each image should carry, *where each comes from*, and the **decision tree** that
@@ -82,17 +84,42 @@ the field can exist.
 | `work_session_id` | derived (taken_at+device+gps cluster) | all | **18% — barely fed** |
 | `components_seen` | vision (conditional) | engine/undercarriage/interior | in JSONB |
 | `text_regions` (OCR) | vision (conditional) | data_plate/document | in JSONB |
-| `camera_pose` | vision (conditional) | exterior | in JSONB (dead column) |
+| `camera_pose` | vision (conditional) | exterior | in JSONB → column (promoted, migration 20260623010000) |
 | `state_observations` | vision (conditional) | most | in JSONB |
 | `narrative_one_line` | vision | all | live |
 | provenance (`agent_model`,`agent_cost_cents`,tokens) | harness | all | fixed 2026-06-22 (cost capture) |
 
-Everything else in the 162 columns is one of: a **dead duplicate** (`filename`+`file_name`;
-`category`+`image_category`+`image_type`; `vehicle_make/model/year/vin` columns that
-identity already lives for on the vehicle record; four hash columns where one is
-canonical; five quality scores where `image_hero_score` is canonical), or **scaffolding
-for a stage that never ran** (`fabrication_stage`, `surface_coord_u/v`, `yono_queued_at`).
-Those are consolidation/deletion targets, not fill targets.
+### The unfilled columns are aspirational targets, not dead weight (audit, 2026-06-23)
+
+A two-axis audit (live `pg_stats` fill-rate × full-repo code-reference sweep × view-dependency
+check) re-classified every near-empty column. The earlier "dead duplicate / deletion target"
+framing was wrong on two counts, and **nothing is being dropped** — per the owner, these columns
+are *aspirational targets becoming more and more reality* as the pipeline matures.
+
+First, the trap: a column reading ~0% filled across the whole table does **not** mean dead. The
+table is dominated by ~38.9M bulk-scraped listing rows where even `user_id` is only **0.08%**
+filled; any column set only on *owned, analyzed* frames reads ~0% globally while being alive on
+the slice that matters. Fill-rate alone condemns nothing — it must be crossed with code refs.
+
+Crossed that way, the unfilled columns fall into three buckets, none of them "drop now":
+
+- **Reserved / not-yet-run** — referenced by the vision roadmap or the extraction contract, empty
+  only because the stage hasn't executed: `surface_coord_u/v`, `yaw_deg`/`yaw_confidence`,
+  `yono_queued_at`, `bbox`, `spatial_tags`. Fill targets when the YONO/COLMAP phase ships.
+- **Promotable now** — the data already exists in `ai_scan_metadata->'byok_deep_analysis'` JSONB
+  and just needed lifting into columns: `camera_pose`, `components`, `ai_component_count`,
+  `ai_avg_confidence`. Done by `promote_image_depth_to_columns()` (migration 20260623010000),
+  wired into the drain (step 8) so each batch promotes itself and re-runs converge idempotently.
+- **Active but low-coverage** — written by yono-analyze / photo-pipeline / our backfills on the
+  owned slice, so ~0% global is rollout, not death: `vehicle_zone`/`zone_*`, `fabrication_stage`/
+  `stage_confidence`, `interior_quality`, `image_vehicle_match_status`, `work_session_id`, `phash`,
+  `taken_at`, the `vehicle_make/model/year/vin` denorm block (written by `backfill-images`).
+
+A genuinely redundant residue exists (`perceptual_hash` superseded by `phash`; the abandoned
+"personal photo library" taxonomy `area`/`part`/`damage_type`/`operation`/`materials`/
+`perspective`/`process_stage`/`workflow_role`/`image_context`, still `SELECT`ed only by six
+frontend-unused legacy views), but even these stay — consolidation can wait; the schema is the
+contract the pipeline grows into.
 
 ---
 

--- a/nuke_frontend/src/pages/settings/AnalysisSettingsPage.tsx
+++ b/nuke_frontend/src/pages/settings/AnalysisSettingsPage.tsx
@@ -36,6 +36,23 @@ interface AnalysisSettings {
   updated_at: string;
 }
 
+// One row per vehicle from get_user_ingestion_status — the "see the ingestion" board.
+interface IngestionRow {
+  vehicle_id: string;
+  vehicle: string;
+  total_images: number;
+  analyzed: number;
+  pending: number;
+  dated: number;
+  hashed: number;
+  sessioned: number;
+  duplicates: number;
+  confirmed: number;
+  unrelated: number;
+  analysis_cost_usd: number;
+  last_analyzed: string | null;
+}
+
 const METHODS: { value: Method; label: string; blurb: string; needsCredential: boolean }[] = [
   {
     value: 'nuke_hosted',
@@ -74,6 +91,7 @@ export default function AnalysisSettingsPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [settings, setSettings] = useState<AnalysisSettings | null>(null);
+  const [ingestion, setIngestion] = useState<IngestionRow[]>([]);
   const [error, setError] = useState('');
   const [notice, setNotice] = useState('');
 
@@ -109,6 +127,12 @@ export default function AnalysisSettingsPage() {
         setMethod(s.method);
         if (s.provider) setProvider(s.provider);
         if (s.model) setModel(s.model);
+      }
+      // Ingestion board — per-vehicle progress against the extraction contract.
+      const uid = session?.user?.id;
+      if (uid) {
+        const { data: ing } = await supabase.rpc('get_user_ingestion_status', { p_user_id: uid });
+        if (Array.isArray(ing)) setIngestion(ing as IngestionRow[]);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load settings');
@@ -441,6 +465,69 @@ export default function AnalysisSettingsPage() {
       <p style={{ fontSize: '10px', color: 'var(--text-muted)', marginTop: '8px' }}>
         "Analyze Now" runs a short cloud burst over your vehicles. The hourly schedule keeps going on its own.
       </p>
+
+      {/* INGESTION BOARD — see each vehicle fill against the extraction contract. */}
+      {ingestion.length > 0 && (() => {
+        const sum = (k: keyof IngestionRow) =>
+          ingestion.reduce((a, r) => a + (Number(r[k]) || 0), 0);
+        const total = sum('total_images');
+        const analyzed = sum('analyzed');
+        const cost = ingestion.reduce((a, r) => a + (Number(r.analysis_cost_usd) || 0), 0);
+        const pct = (n: number, d: number) => (d > 0 ? Math.round((n / d) * 100) : 0);
+        const chipStyle = {
+          fontFamily: "'Courier New', monospace",
+          fontSize: '10px',
+          color: 'var(--text-muted)',
+          whiteSpace: 'nowrap' as const,
+        };
+        return (
+          <div style={{ marginTop: '28px' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '8px' }}>
+              <label style={labelStyle}>Ingestion · {ingestion.length} vehicles</label>
+              <span style={chipStyle}>
+                {analyzed.toLocaleString()}/{total.toLocaleString()} analyzed ({pct(analyzed, total)}%)
+                {cost > 0 ? ` · $${cost.toFixed(2)}` : ' · subscription'}
+              </span>
+            </div>
+            <div style={{ border: '1px solid var(--border)' }}>
+              {ingestion.map((r, i) => {
+                const ap = pct(r.analyzed, r.total_images);
+                return (
+                  <div
+                    key={r.vehicle_id}
+                    style={{
+                      padding: '8px 10px',
+                      borderTop: i === 0 ? 'none' : '1px solid var(--border)',
+                      background: i % 2 ? 'var(--bg-secondary)' : 'transparent',
+                    }}
+                  >
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '8px' }}>
+                      <span style={{ fontSize: '12px', fontWeight: 700 }}>{r.vehicle || 'Unknown'}</span>
+                      <span style={chipStyle}>
+                        {r.analyzed}/{r.total_images} · {ap}%
+                      </span>
+                    </div>
+                    {/* analyzed progress bar (2px, no radius) */}
+                    <div style={{ height: '4px', background: 'var(--border)', marginTop: '5px' }}>
+                      <div style={{ height: '4px', width: `${ap}%`, background: 'var(--accent)' }} />
+                    </div>
+                    {/* contract fill chips */}
+                    <div style={{ display: 'flex', gap: '12px', marginTop: '5px', flexWrap: 'wrap' }}>
+                      <span style={chipStyle}>dated {r.dated}</span>
+                      <span style={chipStyle}>hashed {r.hashed}</span>
+                      <span style={chipStyle}>sessions {r.sessioned}</span>
+                      {r.duplicates > 0 && <span style={chipStyle}>dupes {r.duplicates}</span>}
+                      {r.confirmed > 0 && <span style={chipStyle}>confirmed {r.confirmed}</span>}
+                      {r.unrelated > 0 && <span style={chipStyle}>off-subject {r.unrelated}</span>}
+                      {r.pending > 0 && <span style={{ ...chipStyle, color: 'var(--accent)' }}>pending {r.pending}</span>}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/scripts/daily-receipt/byok-image-batch.sh
+++ b/scripts/daily-receipt/byok-image-batch.sh
@@ -294,11 +294,13 @@ const { createClient } = require("@supabase/supabase-js");
 const url = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
 const sb = createClient(url, process.env.SUPABASE_SERVICE_ROLE_KEY);
 (async () => {
-  for (const fn of ["flag_image_burst_duplicates", "derive_work_sessions"]) {
+  // promote_image_depth_to_columns lifts this batch's verdicts (camera_pose, components_seen)
+  // out of ai_scan_metadata JSONB into the first-class columns so the depth is queryable (Ch.19).
+  for (const fn of ["flag_image_burst_duplicates", "derive_work_sessions", "promote_image_depth_to_columns"]) {
     const { data, error } = await sb.rpc(fn, { p_vehicle_id: process.argv[1] });
     console.log(fn, error ? ("ERR " + error.message) : JSON.stringify(data));
   }
 })();
-' "$VEHICLE_ID" >>"$LOG" 2>&1 || log "dedup/session rpc returned non-zero (non-fatal)"
+' "$VEHICLE_ID" >>"$LOG" 2>&1 || log "dedup/session/promote rpc returned non-zero (non-fatal)"
 
 log "=== batch done: day ${DAY:-unknown}, ingest $WROTE / $N ==="

--- a/supabase/migrations/20260623010000_promote_image_depth_to_columns.sql
+++ b/supabase/migrations/20260623010000_promote_image_depth_to_columns.sql
@@ -1,0 +1,82 @@
+-- Promote per-image depth from the JSONB verdict into the reserved columns.
+--
+-- The deep-analysis drain writes its full verdict into ai_scan_metadata->'byok_deep_analysis'
+-- (camera_pose, components_seen[], state_observations, ...). Several first-class columns on
+-- vehicle_images were created as the queryable home for that depth but were never filled —
+-- they are NOT dead, they are aspirational targets the pipeline is only now producing data for
+-- (see engineering-manual Ch.19). This function lifts the JSONB up into the columns so the
+-- depth is indexable / joinable / visible without digging through JSONB on every read.
+--
+-- Mapping (verdict key -> column):
+--   camera_pose       (object) -> camera_pose          jsonb
+--   components_seen   (array)  -> components            jsonb
+--                              -> ai_component_count    int     (length of the array)
+--                              -> ai_avg_confidence     numeric (mean of element confidence)
+--
+-- Idempotent: only rows whose target column actually differs are touched, so re-runs after the
+-- drain analyzes more frames are cheap and converge. Scope to a vehicle (drain per-batch) or a
+-- user (owner backfill); the unscoped form exists but should not be run on the full table.
+-- SECURITY DEFINER so the drain/app can call it; no model spend.
+
+CREATE OR REPLACE FUNCTION public.promote_image_depth_to_columns(
+  p_vehicle_id uuid DEFAULT NULL,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $$
+DECLARE
+  v_count bigint;
+BEGIN
+  IF p_vehicle_id IS NULL AND p_user_id IS NULL THEN
+    RAISE EXCEPTION 'promote_image_depth_to_columns requires p_vehicle_id or p_user_id (refusing full-table scan)';
+  END IF;
+
+  WITH src AS (
+    SELECT vi.id,
+           vi.ai_scan_metadata->'byok_deep_analysis' AS da
+    FROM vehicle_images vi
+    WHERE vi.ai_scan_metadata ? 'byok_deep_analysis'
+      AND (p_vehicle_id IS NULL OR vi.vehicle_id = p_vehicle_id)
+      AND (p_user_id    IS NULL OR vi.user_id    = p_user_id)
+  ),
+  computed AS (
+    SELECT s.id,
+           CASE WHEN jsonb_typeof(s.da->'components_seen') = 'array'
+                THEN s.da->'components_seen' END AS comp,
+           CASE WHEN jsonb_typeof(s.da->'camera_pose') = 'object'
+                THEN s.da->'camera_pose' END AS pose,
+           CASE WHEN jsonb_typeof(s.da->'components_seen') = 'array'
+                THEN jsonb_array_length(s.da->'components_seen') END AS cc,
+           (
+             SELECT round(avg((e->>'confidence')::numeric), 4)
+             FROM jsonb_array_elements(
+               CASE WHEN jsonb_typeof(s.da->'components_seen') = 'array'
+                    THEN s.da->'components_seen' ELSE '[]'::jsonb END) AS e
+             WHERE (e->>'confidence') ~ '^[0-9]*\.?[0-9]+$'
+           ) AS avgc
+    FROM src s
+  )
+  UPDATE vehicle_images vi
+  SET components         = COALESCE(c.comp, vi.components),
+      camera_pose        = COALESCE(c.pose, vi.camera_pose),
+      ai_component_count = COALESCE(c.cc,   vi.ai_component_count),
+      ai_avg_confidence  = COALESCE(c.avgc, vi.ai_avg_confidence)
+  FROM computed c
+  WHERE vi.id = c.id
+    AND (
+      (c.comp IS NOT NULL AND vi.components         IS DISTINCT FROM c.comp) OR
+      (c.pose IS NOT NULL AND vi.camera_pose        IS DISTINCT FROM c.pose) OR
+      (c.cc   IS NOT NULL AND vi.ai_component_count IS DISTINCT FROM c.cc)   OR
+      (c.avgc IS NOT NULL AND vi.ai_avg_confidence  IS DISTINCT FROM c.avgc)
+    );
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+COMMENT ON FUNCTION public.promote_image_depth_to_columns(uuid, uuid) IS
+  'Lift per-image depth (camera_pose, components_seen) from ai_scan_metadata->byok_deep_analysis '
+  'into the first-class columns camera_pose/components/ai_component_count/ai_avg_confidence. '
+  'Idempotent, vehicle- or user-scoped. The columns are aspirational targets the pipeline now '
+  'fills (Ch.19), not dead columns. No model spend.';


### PR DESCRIPTION
## Why

"Dead columns, or not yet used?" — audited the ~130 unfilled `vehicle_images` columns on two axes (live `pg_stats` fill-rate × full-repo code-reference sweep × view-dependency check).

**Finding: near-zero fill ≠ dead.** The table is ~38.9M rows dominated by bulk-scraped listings — even `user_id` is only **0.08%** filled. Any column set only on *owned, analyzed* frames reads ~0% globally while being alive on the slice that matters. Fill-rate alone condemns nothing. Crossed with code refs, the unfilled columns are **aspirational targets**, not deletion candidates:

- **Reserved / unrun stage** — `surface_coord_u/v`, `yaw_deg`, `yono_queued_at`, `bbox`, `spatial_tags`
- **Promotable now** — depth already in `ai_scan_metadata->'byok_deep_analysis'` JSONB, just not lifted into columns
- **Active but low-coverage** — yono zone/stage, `work_session_id`, `phash`, `taken_at`, the `vehicle_make/model/year/vin` denorm block (rollout, not death)

Per the owner: nothing gets dropped — the schema is the contract the pipeline grows into.

## What

- **`migration 20260623010000`** — `promote_image_depth_to_columns(p_vehicle_id, p_user_id)` lifts `camera_pose` + `components_seen[]` out of the verdict JSONB into the first-class columns `camera_pose` / `components` / `ai_component_count` / `ai_avg_confidence`. Idempotent (`IS DISTINCT FROM` guard), scope-required (refuses a full-table scan), `SECURITY DEFINER`, no model spend. Read-only dry-run on owned analyzed frames produced correct `comp_count` / `avg_conf` / `camera_pose`.
- **Drain step 8** — each batch promotes its own verdicts after dedup/session, so column coverage tracks analysis and re-runs converge.
- **Ch.19** — replaced the old "dead duplicate / deletion target" framing with the three-bucket audit.

## After merge

`supabase-deploy` creates the function; one scoped call backfills the **7,332** already-analyzed owned frames: `select promote_image_depth_to_columns(p_user_id => '…')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VY7vRRmx2gDQhhvELQ5vju

---
_Generated by [Claude Code](https://claude.ai/code/session_01VY7vRRmx2gDQhhvELQ5vju)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ingestion progress board now displays per-vehicle analysis status with coverage metrics and subscription costs.
  * Image metadata processing enhanced to extract camera pose, detected components, and confidence scores.

* **Documentation**
  * Technical documentation updated to clarify data extraction schema targets and field coverage expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->