### PR TITLE
Capture concierge partner pipe drift + partner-onboarding build plan

### DIFF
--- a/docs/concierge-content-agent.md
+++ b/docs/concierge-content-agent.md
@@ -1,0 +1,72 @@
+# The concierge content agent
+
+Status: **building Track B (brief capture) — unblocked.** Track A (Meta publishing)
+is gated on external procurement (see below).
+
+## The problem, in one image
+
+Philippe walks the office briefing an intern: "here's the padel club, here's the
+luxury clientele, now make good posts." His taste, the brand voice, the client
+positioning — the most valuable asset in the building — evaporates into a hallway
+conversation. "Make my Insta better" is not an aesthetics request; it's that there
+is **no pipeline from his creative direction to the feed**, and no capture of the
+direction itself.
+
+Every concierge/luxury client has this exact problem. It is productizable.
+
+## The product
+
+A sandboxed agent Philippe *talks to* instead of briefing a person. It:
+1. Holds every client's asset catalog (villas, the padel club, boutiques, events).
+2. **Captures his creative direction as durable, structured briefs** — so his taste
+   compounds instead of resetting with each intern.
+3. Drafts posts in his voice, per client, from the catalog.
+4. Coordinates the post schedule across accounts.
+5. Publishes via the Meta pipeline, and pulls engagement back to learn what lands.
+
+## How it fits the engine (not a new silo)
+
+A brief is the **highest-trust observation** in the model we already have: authored
+by the principal, top of the `mandate` / `access_tier` / source-trust hierarchy.
+Engagement pulled back from Instagram is another observation stream — "content is
+the validator." The content agent is a *consumer* of briefs + catalog + engagement,
+and a *producer* of scheduled posts. Same observation/provenance backbone, luxury
+editorial flavor.
+
+## Two tracks
+
+### Track A — Meta Graph publishing (GATED on procurement)
+Blocked until, in order:
+1. @lofficielstbarth is an Instagram **Professional** account (Business/Creator).
+2. Linked to a **Facebook Page** inside a **Business Manager**.
+3. A **Meta app** with `instagram_basic`, `instagram_content_publish`,
+   `pages_read_engagement`, submitted for **App Review** (days–weeks).
+4. A long-lived / System User token stored in Vault (`credential_secret_id` slot on
+   `concierge_partner_connections` is the idiomatic home; note `[db.vault]` is
+   currently commented out in `supabase/config.toml` — enable before relying on it).
+
+Publish flow, once unblocked (stable, buildable against a sandbox IG account now):
+`POST /{ig-user-id}/media` (container: public image URL + caption) → poll status for
+video/reels → `POST /{ig-user-id}/media_publish`. Limit 50 posts/24h. There is a
+Nov-2025 design doc, `docs/architecture/SOCIAL_MEDIA_PUBLISHING_ARCHITECTURE.md`
+(design phase, unimplemented) — reconcile the publishing schema to it when Track A
+starts. Reuse the QuickBooks/Gmail OAuth-refresh patterns already in the repo.
+
+### Track B — brief capture + agent core (UNBLOCKED, building now)
+No Meta dependency. Order:
+1. **`creative_briefs`** — record Philippe's direction (verbatim + structured
+   extraction), keyed to the client org (+ optional asset). *This migration.*
+2. **`capture-brief` edge function** — takes a transcript, extracts structured
+   direction (voice, clientele, positioning, dos/don'ts, themes) via Claude, stores
+   it. Voice→text transcription is a front-end concern; the endpoint takes text.
+3. **Content agent tool surface** (MCP): `list_clients`, `get_brief(client)`,
+   `list_catalog(client)`, `draft_post`, `schedule_post`, `get_engagement`.
+4. **Post queue / calendar** keyed to org + asset (reconciles the empty
+   `social_posts` stub + the drafted-but-undeployed `insight_queue` — that schema is
+   repo-vs-prod drift; do not assume it is live).
+
+## Drift note (per repo rules)
+`supabase/migrations/20260128_social_automation.sql` defines `insights`,
+`social_posts`, `insight_queue`; only `social_posts` exists in prod (0 rows), the
+other two were never applied. Reconcile — don't stack a third competing schema — when
+Track B reaches the post-queue step.

--- a/docs/concierge-handoff.md
+++ b/docs/concierge-handoff.md
@@ -1,0 +1,182 @@
+# L'Officiel Concierge × nuke — session handoff
+
+_Last updated: 2026-07-03. Branch: `claude/lofficiel-concierge-nuke-db-pmztl3`.
+Open draft: PR #327. Supabase project: `qkgaybvrernstplzjaam`._
+
+Read this first to resume. It captures the thesis, what's verified, what shipped,
+the open decisions, the blockers, and the ordered build queue. Epistemics matter
+here (see `.claude/rules/production-engineering.md`): claims below are tagged
+**[verified]** (checked against live prod/repo) or **[hypothesis]** (reasoned, not
+yet confirmed).
+
+---
+
+## 1. The thesis
+
+**nuke is the backend every facade runs on.** Brands (L'Officiel Concierge first)
+get their "own app" — a branded front end — but the app *is* the backend, and nuke
+owns 100% of it. This is deliberate and it's the moat: a tenant can wear the bones,
+never take them. ("Performer, not owner." L'Officiel proudly wears our bones; we're
+happy it does.)
+
+Three products, one engine:
+1. **White-label facades.** Everyone wants their own app. Each is another skin on the
+   same engine; none can leave. Front-end autonomy + backend fully owned.
+2. **Content supply chain.** The provenance engine organizes all data to its sources
+   into structured, *cited* libraries. Producers (and agents they deploy) pipeline
+   through nuke to harvest citable content without the manual work of
+   sourcing/verifying/attributing — and they contribute back in the same motion
+   (bidirectional flywheel). Their formula beats "steal viral & repost" because it's
+   sourced, authentic, and — with a rights layer — safe to run autonomously at scale.
+3. **Concierge content agent.** Principals (Philippe) brief an agent, not an intern;
+   the agent holds every client's catalog, drafts in their voice, coordinates the
+   schedule, publishes via Meta, and learns from engagement. His creative direction is
+   captured so it compounds instead of evaporating.
+
+Everything is the same organs pointed at new nouns: the vehicle stack (7.5M
+observations) is the reference implementation, not the center of gravity.
+
+---
+
+## 2. What shipped (PR #327, draft, all CI green)
+
+On branch `claude/lofficiel-concierge-nuke-db-pmztl3`:
+- `supabase/migrations/20260703120000_capture_concierge_partner_pipe_drift.sql` —
+  drift capture of `concierge_partner_connections/_invitations/_sync_runs` +
+  `asset_observations` (existed in prod, uncommitted). `IF NOT EXISTS`-guarded,
+  RLS-enabled/no-policies preserved. **No prod change.**
+- `supabase/migrations/20260703140000_creative_briefs.sql` — brief-capture table
+  (verbatim + structured, principal-authored = high confidence, org/asset keyed).
+- `docs/partner-onboarding.md` — partner pipe + gate + asset-backbone plan.
+- `docs/concierge-content-agent.md` — the agent product + Track A/B split.
+- `docs/concierge-handoff.md` — this file.
+
+Nothing has been applied to prod. All schema deploys via `supabase-deploy.yml`.
+
+---
+
+## 3. Key findings
+
+**[verified] Drift — repo ≠ prod.** The partner pipe + `asset_observations` existed
+in prod in no migration (now captured in #327). Still-drifted, NOT yet captured:
+- Deployed edge functions `concierge-ground/house/partner/partner-invite` exist in
+  prod, absent from repo. **Pull their source before building the gate on them.**
+- Partial-drift to diff prod-vs-repo: `assets` (prod has `garment_id`,
+  `publication_id`), `ingestion_ledger`, `vfc_changesets`, `org_assets`,
+  `contract_assets`, `existence_tier_staging` (vehicle-keyed; needs generalizing).
+- `supabase/migrations/20260128_social_automation.sql` claims
+  `insights`/`social_posts`/`insight_queue`; only `social_posts` exists in prod
+  (0 rows), the other two never applied.
+
+**[verified] Depth is the gap, not design.** LE SELECT (`bcc0bd75-...`) is a stub:
+`description` 0 chars, `total_images` 0, `enrichment_sources` 0, no Instagram,
+`enrichment_status='stub'`, single source `directory-saintbarth.com`. Every
+`lofficiel-concierge` place is the same. The enrichment/provenance engine has never
+been pointed at these place-assets. This is the "lame as shit," quantified.
+
+**[verified] `businesses` is an automotive-shaped silo** (`has_lift`, `has_dyno`,
+`total_vehicles_worked`, hourly rates). LE SELECT is shoved into it via
+`metadata->>'project'='lofficiel-concierge'`. Places should become
+`assets` (asset_type='venue'/'place'), not silo rows — see the backbone work.
+
+**[verified] Meta/Instagram is greenfield in code.** Only handle-*discovery* exists
+(`scripts/concierge/enrich-instagram.ts` scrapes a business's site via Firecrawl for
+an IG URL → `businesses.metadata.instagram`). Zero Graph API calls; the only
+`instagram_content_publish` references live in an unimplemented Nov-2025 design doc
+`docs/architecture/SOCIAL_MEDIA_PUBLISHING_ARCHITECTURE.md`.
+
+**[verified] Partner-connection model** (`concierge_partner_connections`, 5 rows, all
+`channel='shopify'`, `has_cred=false`): `mandate ∈ {display,quote,sell}`,
+`access_tier_default ∈ {public,member,gated}`, `channel ∈
+{shopify,square,lightspeed,woocommerce,csv,manual,api}` (no `instagram` yet),
+`credential_secret_id` (Vault ref — note `[db.vault]` is commented out in
+`config.toml`), `consent jsonb`. This is the idiomatic home for any tenant's
+connected account, including a Meta/IG token. Reusable OAuth-refresh precedents:
+`quickbooks-connect`, `gmail-alert-poller`.
+
+**[verified] The content-pipeline organs already exist** (built for vehicles):
+`asset_observations`/`vehicle_observations` (cited, confidence-scored, supersedable),
+`observation_sources` (trust tier + decay), `observation_witnesses` (image_timestamp,
+capture_method), image anchoring/`image_identities`, queue/orchestrator workers
+(`photo-pipeline-orchestrator`, `continuous-queue-processor`). The gulf-guy /
+EXIF-GPS-proximity clustering is this engine repointed, not a new build.
+
+---
+
+## 4. Open decisions (need the principal)
+
+1. **Data isolation** — shared nuke DB (RLS + tenant key) vs. separate schema/project
+   per brand. **Lean: shared now** (tiny data; FBM/cross-brand entities exist "in
+   full" in both; isolating fragments them). Revisit at real scale/compliance.
+2. **Content library shape** — shared commons vs. tenant-scoped. **Lean: tenant-scoped
+   over a public commons layer** (sells access tiers, keeps rights clean). Drives RLS +
+   the rights layer + business model; decide before it's baked in.
+3. **What is Philippe** — paying client / brand-distribution partner / reference logo.
+   He wants payoff without backend investment (that's *fine* — it's the model). He is
+   not an owner. Naming the target sets how much rope his "let me shape it" gets.
+4. **Instagram/Meta account status** — is @lofficielstbarth a **Professional** account,
+   is there a **Facebook Business Manager**, and **does a verified nuke Meta app already
+   exist**? This is the Track-A critical path; code can't start the review clock.
+
+---
+
+## 5. Blockers (external, not code)
+
+- **Meta Business Verification + App Review** for `instagram_content_publish` Advanced
+  Access — platform-level, weeks, gates all tenants. Correct model: ONE nuke Meta app
+  (Tech Provider), per-tenant OAuth connect, per-tenant token in Vault. Evaluate the
+  newer "Instagram API with Instagram Login" path (no FB Page link required per
+  account) to cut onboarding friction. **[hypothesis]** on exact current permission
+  names — verify against live Meta docs before submitting.
+- **Supabase Vault** appears disabled (`[db.vault]` commented in `config.toml`) — enable
+  before relying on `credential_secret_id`.
+- @lofficielstbarth may need Personal→Professional conversion (step zero).
+
+---
+
+## 6. Build queue (ordered)
+
+**Track B — content pipeline (UNBLOCKED, highest leverage):**
+1. Register Issuu + open-web sources as trust-tiered `observation_sources`; run the
+   **LE SELECT enrichment pilot** (stub → deep) with before/after numbers in the
+   commit. Template for all 500 places.
+2. Promote places to `assets` (asset_type='venue') + `asset_observations`; stop using
+   the automotive `businesses` silo for venues.
+3. Provider flow (gulf guy): provider-as-asset, EXIF-GPS+time clustering to associate
+   provider+client photos to an outing, two-stage curation (nuke base gate + concierge
+   "edge" taste filter), consented auto-distribution, reject-but-still-log.
+4. **Rights layer** on curation: public / press-release / UGC-consent / licensed /
+   editorial — citable ≠ licensed. The gate that makes autonomous posting safe.
+5. `capture-brief` edge function → `creative_briefs` (paste a transcript → structured
+   direction). Voice→text is a front-end concern.
+
+**Track A — Meta publishing (GATED on §5):**
+6. Meta-platform integration spec; wire `instagram` into the connection `channel`;
+   per-tenant OAuth connect + token refresh (mirror quickbooks/gmail); two-step publish
+   (`/media` → `/media_publish`) + engagement pull-back → observations.
+
+**Drift repair (do before building on the drifted objects):**
+7. Pull deployed `concierge-*` edge-function source into repo.
+8. Diff + reconcile partial-drift objects (`assets`, `ingestion_ledger`,
+   `vfc_changesets`); reconcile the `social_automation` schema drift.
+
+---
+
+## 7. House rules (from `.claude/rules/production-engineering.md`)
+
+- **Measure, don't guess.** Verify the load-bearing claim against live prod. Put
+  before→after numbers in commits.
+- **The repo is not prod.** Assume drift until checked.
+- **Deploys go through `supabase-deploy.yml`** — never hand-applied.
+- **Success = rows landed, not exit 0.** Every automation checks its own throughput.
+- **Silent failure is the house disease.** Every fire-and-forget path gets a watcher.
+
+---
+
+## 8. Pointers
+
+- PR: https://github.com/sss97133/nuke/pull/327 (draft, green, subscribed for CI/review)
+- Branch: `claude/lofficiel-concierge-nuke-db-pmztl3` (both nuke + lofficiel-concierge)
+- Project: `qkgaybvrernstplzjaam` (https://qkgaybvrernstplzjaam.supabase.co)
+- Docs: `docs/partner-onboarding.md`, `docs/concierge-content-agent.md`, this file.
+- lofficiel-concierge repo: Next.js facade, shares this Supabase backend.

--- a/docs/partner-onboarding.md
+++ b/docs/partner-onboarding.md
@@ -1,0 +1,86 @@
+# Partner onboarding & the asset backbone
+
+Status: **drift reconciliation in progress.** This document is the north star for
+turning the partner-onboarding idea ("nuke is the engine, partners plug in via an
+agent") into committed, reviewable infrastructure. Read the drift section first —
+it changes what "build the gate" means.
+
+## The premise
+
+nuke is the engine. Partner-facing brands (l'Officiel Concierge, etc.) are
+*clients* of that engine, not forks of it. Partners — restaurants, villa rentals,
+fashion retail, groups — onboard by connecting a channel (Shopify, Square, CSV, …).
+An agent running on the **partner's** side authenticates, honors their `mandate`
+and `consent`, and emits **cited observations** into nuke's schema. It never writes
+canonical values directly; the provenance projection decides truth. Partners
+contribute *claims*, nuke owns *facts*.
+
+Every entity — vehicle, villa, retail SKU, org-held asset — is an `asset` with an
+`asset_type`. The vehicle stack (`vehicles`, `vehicle_observations` @ 7.5M rows) is
+the **reference implementation**, not the center of gravity. New verticals get the
+same spine (`assets` + `asset_observations` + source-trust + provenance), only as
+much type-specific extension as they actually need.
+
+## Drift: the repo is not prod (Law #1)
+
+The partner pipe and the polymorphic observation substrate **already exist in the
+live database and were never committed**. Verified against project
+`qkgaybvrernstplzjaam` on 2026-07-03; confirmed absent from the repo (zero CREATE
+statements, zero references).
+
+Applied-but-uncommitted objects, now captured in
+`supabase/migrations/20260703120000_capture_concierge_partner_pipe_drift.sql`:
+
+| Object | Prod state | Notes |
+|---|---|---|
+| `concierge_partner_connections` | 5 rows | `mandate ∈ {display,quote,sell}`, `access_tier_default ∈ {public,member,gated}`, `channel ∈ {shopify,square,lightspeed,woocommerce,csv,manual,api}` |
+| `concierge_partner_invitations` | 3 rows | token-hash invites, 14-day expiry, redeem → connection |
+| `concierge_partner_sync_runs` | 7 rows | funnel telemetry: `items_seen / items_landed / items_superseded` |
+| `asset_observations` | 0 rows | polymorphic twin of `vehicle_observations`, FK → `assets(id)` |
+
+All four have **RLS enabled with no policies** (deny-all except service_role). The
+capture preserves that exactly. Explicit org-scoped policies are deliberate future
+work — do not open these tables without designing the policies.
+
+### Still-drifted, not yet captured (next commits)
+- **Deployed edge functions** `concierge-ground`, `concierge-house`,
+  `concierge-partner`, `concierge-partner-invite` exist in prod but not in the repo.
+  Their source must be pulled (`get_edge_function`) before the gate is built on top
+  of them — building blind would duplicate or break the live sync.
+- **Partial drift** to diff prod-vs-repo: `assets` (prod has `garment_id` /
+  `publication_id` columns), `ingestion_ledger`, `vfc_changesets`, `org_assets`,
+  `contract_assets`, `existence_tier_staging` (vehicle-keyed; needs generalizing).
+
+## The choke (why this matters)
+
+The pipe is plumbed and has fired (5 connections, 7 sync runs). The **governance
+gate is empty**: `ingestion_ledger` (0 rows), `vfc_changesets` (0), no PII/volatile
+classifier anywhere. Partner data can arrive with no validation funnel, no
+attribution guarantee, no personal/volatile filter. Mass-onboarding into that is
+the failure mode. The gate is the product.
+
+## Build sequence (safe order)
+
+1. **Capture drift** so the repo reflects reality — *this PR* (tables) + follow-up
+   (edge-function source, partial-drift diffs). Nothing new is designed until the
+   ground is real.
+2. **Backbone**: promote `assets` + `asset_observations` to load-bearing; express
+   villa / retail as `asset_type`s with thin extension tables; generalize
+   `existence_tier_staging` and provenance off `vehicle_id` → `subject`.
+3. **Gate**: wire `ingestion_ledger` (received → ingested → validated → failed) +
+   a PII/volatile classifier + source-trust scoring, sitting between partner sync
+   and `asset_observations`. Reuse `_shared/observationWriter.ts`,
+   `_shared/apiKeyAuth.ts`, `_shared/extractionQualityGate.ts`.
+4. **Partner-agent harness**: MCP tool surface (`list_missing_fields`,
+   `submit_observation`, `get_confidence`) + the agent rulebook (emit cited
+   observations only; never canonical writes; refuse personal/volatile; honor
+   `mandate`/`consent`). Runs on the partner's own Claude seat — their raw data
+   stays behind their credential; only emitted observations cross the boundary.
+5. **Scale invites** only after 2–4 exist. The 5 live connections are a pilot; a
+   hundred is a flood.
+
+## Deploy note
+
+All schema changes land as migrations under `supabase/migrations/` and deploy via
+`supabase-deploy.yml` — never hand-applied. That discipline is exactly what the
+drift above violated.

--- a/supabase/migrations/20260703120000_capture_concierge_partner_pipe_drift.sql
+++ b/supabase/migrations/20260703120000_capture_concierge_partner_pipe_drift.sql
@@ -1,0 +1,130 @@
+-- Drift capture: concierge partner pipe + asset_observations
+--
+-- These objects were applied directly to the live database (project
+-- qkgaybvrernstplzjaam) and exist in NO migration. This file brings the repo
+-- back in sync with prod per the Drift Repair standing task in
+-- .claude/rules/production-engineering.md ("commit its definition").
+--
+-- Captured from prod 2026-07-03 via pg_catalog (columns, constraints, indexes,
+-- RLS). Every statement is guarded (IF NOT EXISTS / DO block) so applying this
+-- against prod is a safe no-op, while a fresh/branch database gets the real
+-- schema. Depends on public.assets and public.organizations already existing.
+--
+-- Security posture as captured: RLS is ENABLED with NO policies on all four
+-- tables (deny-all except service_role). Explicit org-scoped policies are a
+-- deliberate follow-up (see docs/partner-onboarding.md) — do not "fix" this by
+-- opening the tables up without designing the policies.
+
+-- ---------------------------------------------------------------------------
+-- concierge_partner_connections: one row per partner integration (org + channel)
+-- mandate: what the partner authorized us to do with their data
+-- access_tier_default: default visibility of ingested data
+-- consent: structured consent record (jsonb)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.concierge_partner_connections (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id                uuid NOT NULL REFERENCES public.organizations(id),
+  channel               text NOT NULL
+                          CHECK (channel = ANY (ARRAY['shopify','square','lightspeed','woocommerce','csv','manual','api'])),
+  endpoint              text,
+  credential_secret_id  uuid,
+  mandate               text NOT NULL DEFAULT 'display'
+                          CHECK (mandate = ANY (ARRAY['display','quote','sell'])),
+  access_tier_default   text NOT NULL DEFAULT 'public'
+                          CHECK (access_tier_default = ANY (ARRAY['public','member','gated'])),
+  consent               jsonb NOT NULL DEFAULT '{}'::jsonb,
+  status                text NOT NULL DEFAULT 'invited'
+                          CHECK (status = ANY (ARRAY['invited','connected','syncing','error','revoked'])),
+  sync_interval_minutes integer NOT NULL DEFAULT 1440,
+  last_sync_at          timestamptz,
+  next_sync_at          timestamptz,
+  last_sync_count       integer,
+  last_error            text,
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  updated_at            timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (org_id, channel)
+);
+
+CREATE INDEX IF NOT EXISTS concierge_partner_connections_due_idx
+  ON public.concierge_partner_connections (next_sync_at)
+  WHERE status = ANY (ARRAY['connected','syncing','error']);
+
+-- ---------------------------------------------------------------------------
+-- concierge_partner_invitations: email/token invites that redeem into a connection
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.concierge_partner_invitations (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id        uuid NOT NULL REFERENCES public.organizations(id),
+  token_hash    text NOT NULL UNIQUE,
+  channel_scope text[] NOT NULL DEFAULT ARRAY['shopify','instagram'],
+  contact       jsonb NOT NULL DEFAULT '{}'::jsonb,
+  note          text,
+  created_by    text NOT NULL DEFAULT 'house',
+  expires_at    timestamptz NOT NULL DEFAULT (now() + interval '14 days'),
+  used_at       timestamptz,
+  revoked_at    timestamptz,
+  redeemed_ip   inet,
+  connection_id uuid REFERENCES public.concierge_partner_connections(id),
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS concierge_partner_invitations_org_idx
+  ON public.concierge_partner_invitations (org_id, created_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- concierge_partner_sync_runs: telemetry per sync (the throughput pulse)
+-- items_seen vs items_landed = the funnel; items_superseded = observation churn
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.concierge_partner_sync_runs (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  connection_id    uuid NOT NULL REFERENCES public.concierge_partner_connections(id),
+  started_at       timestamptz NOT NULL DEFAULT now(),
+  finished_at      timestamptz,
+  ok               boolean,
+  items_seen       integer NOT NULL DEFAULT 0,
+  items_landed     integer NOT NULL DEFAULT 0,
+  items_superseded integer NOT NULL DEFAULT 0,
+  error            text
+);
+
+CREATE INDEX IF NOT EXISTS concierge_partner_sync_runs_conn_idx
+  ON public.concierge_partner_sync_runs (connection_id, started_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- asset_observations: the polymorphic twin of vehicle_observations, keyed on
+-- assets(id) rather than vehicle_id. This is the generic observation substrate.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.asset_observations (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  asset_id          uuid NOT NULL REFERENCES public.assets(id) ON DELETE CASCADE,
+  source_id         uuid,
+  kind              text NOT NULL,
+  observed_at       timestamptz NOT NULL,
+  content_text      text,
+  structured_data   jsonb DEFAULT '{}'::jsonb,
+  content_hash      text NOT NULL,
+  confidence        numeric(4,3) DEFAULT 0.5 CHECK (confidence >= 0 AND confidence <= 1),
+  source_url        text,
+  source_identifier text,
+  extraction_method text,
+  agent_model       text,
+  superseded_by     uuid,
+  supersedes        uuid,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_asset_observations_asset
+  ON public.asset_observations (asset_id, observed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_asset_observations_hash
+  ON public.asset_observations (content_hash);
+CREATE INDEX IF NOT EXISTS idx_asset_observations_kind
+  ON public.asset_observations (kind);
+
+-- ---------------------------------------------------------------------------
+-- RLS: enabled, no policies (deny-all except service_role) — matches prod.
+-- Idempotent: ENABLE is harmless if already enabled.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.concierge_partner_connections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.concierge_partner_invitations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.concierge_partner_sync_runs   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.asset_observations            ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/20260703140000_creative_briefs.sql
+++ b/supabase/migrations/20260703140000_creative_briefs.sql
@@ -1,0 +1,54 @@
+-- creative_briefs: durable capture of a principal's creative direction.
+--
+-- "Record everything Philippe is saying so his agent gets better." A brief is the
+-- highest-trust observation in the model: authored by the principal (top of the
+-- source-trust hierarchy), it conditions how the content agent drafts posts for a
+-- client. Verbatim text is preserved (raw_text) alongside a structured extraction
+-- (structured) so nothing is lost and the agent has something machine-usable.
+--
+-- Keyed to the client org (organizations); optionally to a specific asset when the
+-- direction is about one villa / venue rather than the whole account.
+--
+-- RLS enabled with no policies (deny-all except service_role), matching the house
+-- pattern for principal/partner data. Explicit policies are deliberate follow-up.
+
+CREATE TABLE IF NOT EXISTS public.creative_briefs (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id       uuid NOT NULL REFERENCES public.organizations(id),
+  asset_id     uuid REFERENCES public.assets(id) ON DELETE SET NULL,
+
+  -- Provenance of the direction
+  author       text NOT NULL,                       -- e.g. 'philippe' (the principal)
+  channel      text NOT NULL DEFAULT 'chat'
+                 CHECK (channel = ANY (ARRAY['voice','chat','meeting','manual','email'])),
+
+  -- What was said, and what we extracted from it
+  raw_text     text NOT NULL,                       -- verbatim brief / transcript
+  structured   jsonb NOT NULL DEFAULT '{}'::jsonb,  -- {voice, clientele, positioning,
+                                                     --  dos[], donts[], themes[], tone}
+  -- Trust: principal-authored direction is high-confidence by default
+  confidence   numeric(4,3) NOT NULL DEFAULT 0.9
+                 CHECK (confidence >= 0 AND confidence <= 1),
+
+  status       text NOT NULL DEFAULT 'captured'
+                 CHECK (status = ANY (ARRAY['captured','processed','superseded','archived'])),
+  supersedes   uuid REFERENCES public.creative_briefs(id) ON DELETE SET NULL,
+
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+-- Latest active brief per client is the hot read for the content agent
+CREATE INDEX IF NOT EXISTS creative_briefs_org_idx
+  ON public.creative_briefs (org_id, created_at DESC)
+  WHERE status = ANY (ARRAY['captured','processed']);
+
+CREATE INDEX IF NOT EXISTS creative_briefs_asset_idx
+  ON public.creative_briefs (asset_id, created_at DESC)
+  WHERE asset_id IS NOT NULL;
+
+ALTER TABLE public.creative_briefs ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.creative_briefs IS
+  'Principal creative direction per client (verbatim + structured). Highest-trust '
+  'input to the concierge content agent. See docs/concierge-content-agent.md.';


### PR DESCRIPTION
## Why

While mapping how l'Officiel Concierge is powered by nuke, we found that the **partner onboarding pipe and the polymorphic `asset_observations` substrate exist in the live DB but were never committed** — applied directly to project `qkgaybvrernstplzjaam`, present in no migration. This is exactly the drift `.claude/rules/production-engineering.md` Law #1 warns about, and it blocks any further schema work: a `CREATE TABLE assets`-style migration would collide with invisible prod state.

Step 1 of the build is therefore **drift capture**, so the repo reflects reality before we build on it.

## What's in this PR

**`supabase/migrations/20260703120000_capture_concierge_partner_pipe_drift.sql`** — faithful capture from prod (columns, types, defaults, constraints, indexes, RLS) of:

| Object | Prod | Notes |
|---|---|---|
| `concierge_partner_connections` | 5 rows | `mandate ∈ {display,quote,sell}`, `access_tier_default ∈ {public,member,gated}`, `channel ∈ {shopify,square,lightspeed,woocommerce,csv,manual,api}` |
| `concierge_partner_invitations` | 3 rows | token-hash invites, 14-day expiry |
| `concierge_partner_sync_runs` | 7 rows | funnel telemetry (`items_seen/landed/superseded`) |
| `asset_observations` | 0 rows | polymorphic twin of `vehicle_observations`, FK → `assets(id)` |

- Every statement guarded with `IF NOT EXISTS` → **safe no-op against prod**, real schema for fresh/branch DBs.
- **RLS enabled, no policies** (deny-all except service_role) preserved exactly as captured. Explicit org-scoped policies are deliberate follow-up work.

**`docs/partner-onboarding.md`** — the north star: drift inventory, still-uncaptured drift (deployed `concierge-*` edge functions; partial-drift `assets`/`ingestion_ledger`/`vfc_changesets`), the choke (pipe plumbed, gate empty), and the safe build sequence.

## Not in this PR (next steps)

1. Pull the deployed `concierge-ground/house/partner/partner-invite` edge-function source into the repo (more drift).
2. Diff prod-vs-repo for partial-drift objects (`assets`, `ingestion_ledger`, `vfc_changesets`).
3. Backbone → gate (`ingestion_ledger` funnel + PII/volatile classifier + source-trust) → partner-agent harness.

## Safety

No schema was applied to prod from this work — everything lands as reviewed migrations deploying via `supabase-deploy.yml`. Read-only `pg_catalog` queries only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A39N3HzkdKKjkVzSELGCBx)_