### PR TITLE
fix(rls): close vehicles/qb_transactions/receipts anon exposure

### DIFF
--- a/nuke_frontend/src/components/vehicle/VehicleLedgerDocumentsCard.tsx
+++ b/nuke_frontend/src/components/vehicle/VehicleLedgerDocumentsCard.tsx
@@ -79,8 +79,27 @@ export function VehicleLedgerDocumentsCard(props: {
       if (docsRes.error) throw docsRes.error;
       if (receiptsRes.error) throw receiptsRes.error;
 
+      let receiptRows = (receiptsRes.data as any[]) || [];
+
+      // Fallback for anon / non-owner visitors: base `receipts` is owner-only
+      // RLS (2026-07-06 RLS lockdown). For a public vehicle, pull the same
+      // safe columns from `receipts_public_summary` instead.
+      if (receiptRows.length === 0) {
+        const publicReceiptsRes = await supabase
+          .from('receipts_public_summary')
+          .select('id,source_document_id,source_document_table,processing_status,vendor_name,total,currency,created_at')
+          .eq('source_document_table', 'vehicle_documents')
+          .eq('scope_type', 'vehicle')
+          .eq('scope_id', vehicleId)
+          .order('created_at', { ascending: false })
+          .limit(2000);
+        if (!publicReceiptsRes.error && publicReceiptsRes.data) {
+          receiptRows = publicReceiptsRes.data as any[];
+        }
+      }
+
       setDocs((docsRes.data as any[]) || []);
-      setReceipts((receiptsRes.data as any[]) || []);
+      setReceipts(receiptRows);
     } catch (e: any) {
       setDocs([]);
       setReceipts([]);

--- a/nuke_frontend/src/pages/vehicle-profile/hooks/useInvestmentLedger.ts
+++ b/nuke_frontend/src/pages/vehicle-profile/hooks/useInvestmentLedger.ts
@@ -66,7 +66,8 @@ export function useInvestmentLedger(vehicleId: string | undefined) {
           .select('*')
           .eq('vehicle_id', vehicleId)
           .order('work_order_created'),
-        // Receipts
+        // Receipts (owner-scoped RLS on the base table — empty for anon/non-owner
+        // visitors on someone else's vehicle even if it's public; see fallback below)
         supabase
           .from('receipts')
           .select('id, vendor_name, total, receipt_date, invoice_number')
@@ -84,6 +85,22 @@ export function useInvestmentLedger(vehicleId: string | undefined) {
       if (dealRes.error) throw new Error(dealRes.error.message);
       if (woRes.error) throw new Error(woRes.error.message);
       if (vehicleRes.error) throw new Error(vehicleRes.error.message);
+
+      // Fallback for anon / non-owner visitors: the base `receipts` table is
+      // owner-only RLS (2026-07-06 RLS lockdown). For a public vehicle, pull
+      // the same safe columns from `receipts_public_summary`, a column-limited
+      // view scoped to is_public=true vehicles — never card/PII fields.
+      if (!receiptsRes.error && (receiptsRes.data == null || receiptsRes.data.length === 0)) {
+        const publicReceiptsRes = await supabase
+          .from('receipts_public_summary')
+          .select('id, vendor_name, total, receipt_date, invoice_number')
+          .eq('vehicle_id', vehicleId)
+          .eq('status', 'processed')
+          .order('receipt_date');
+        if (!publicReceiptsRes.error && publicReceiptsRes.data) {
+          receiptsRes.data = publicReceiptsRes.data;
+        }
+      }
 
       // Parse deal jackets
       const dealJackets: DealJacketRow[] = (dealRes.data || []).map((d: any) => ({

--- a/supabase/migrations/20260706000000_lock_down_vehicles_qb_receipts_rls.sql
+++ b/supabase/migrations/20260706000000_lock_down_vehicles_qb_receipts_rls.sql
@@ -1,0 +1,140 @@
+-- ============================================================================
+-- Close 3 wide-open RLS holes found by independent audit (2026-07-05 night):
+-- vehicles, qb_transactions, receipts all had a USING(true) "public read"
+-- policy that ORs (PERMISSIVE) against every other, correctly-scoped policy
+-- on the same table — meaning the correct policies were being fully defeated.
+-- Highest blast radius: vehicles (323,830 rows, incl. VIN, on is_public=false
+-- rows readable by anon). Verified live before touching anything.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. vehicles — "Anyone can view auction pricing dashboard"
+--
+-- Origin: supabase/migrations/20251203_auction_outcome_disclosure.sql. That
+-- migration built a `auction_pricing_dashboard` VIEW (id, vehicle label,
+-- auction_outcome, sale_price, high_bid, bat_auction_url, a computed
+-- price_display, and a data_quality_check debug string like "ERROR: RNM but
+-- has sale_price") — an internal QA tool for auditing auction-price
+-- disclosure accuracy, not a public feature. It never touches VIN, title, or
+-- any identifying field. Nothing in nuke_frontend/src or supabase/functions
+-- references `auction_pricing_dashboard` — it has zero consumers, confirmed
+-- by grep. The mistake: whoever wrote it added
+--   CREATE POLICY "Anyone can view auction pricing dashboard"
+--     ON vehicles FOR SELECT USING (true);
+-- directly on the BASE TABLE (probably intending to gate the view, or
+-- copy-pasted a "make it visible" policy without realizing PERMISSIVE
+-- policies OR together). This has silently overridden the correct policies
+-- vehicles_public_select (is_public = true) and vehicles_private_select
+-- (owner/uploader/contributor match) for ~7 months: every SELECT on
+-- vehicles by any role, including anon, matched USING(true) and got the row
+-- regardless of is_public. Confirmed live: anon could read all 323,830
+-- is_public=false rows including VIN.
+--
+-- Fix: just drop the bad policy. vehicles_public_select and
+-- vehicles_private_select already correctly implement "the pattern every
+-- other table uses" — no replacement policy is needed. The
+-- auction_pricing_dashboard view still works fine for anyone with a
+-- legitimate reason to query it (service_role, or an owner viewing their own
+-- rows) — it just no longer bypasses privacy for everyone else.
+-- ----------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "Anyone can view auction pricing dashboard" ON vehicles;
+
+
+-- ----------------------------------------------------------------------------
+-- 2. qb_transactions — "Public read"
+--
+-- QuickBooks-synced bookkeeping transactions (vendor_name, total_amount,
+-- memo, line_account_name, doc_number, category, organization_id,
+-- vehicle_id...) — Skylar's own business financial ledger data, ingested by
+-- scripts/qb-load-transactions.mjs and scripts/bridge-invoice-to-qb.mjs,
+-- both of which use SUPABASE_SERVICE_ROLE_KEY. Confirmed by grep: zero
+-- references to `qb_transactions` anywhere in nuke_frontend/src or
+-- supabase/functions — no frontend or edge-function feature reads this
+-- table today. The "Service write" policy (ALL, service_role) already gives
+-- the ingestion scripts everything they need; "Public read" (true) served no
+-- product purpose and just leaked every transaction, including amounts and
+-- memos, to anon.
+--
+-- Fix: drop it. No replacement needed — there is no legitimate non-service
+-- consumer today. If/when an authenticated owner-facing bookkeeping view
+-- ships, it should get its own narrow, auth.uid()-scoped policy then.
+-- ----------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "Public read" ON qb_transactions;
+
+
+-- ----------------------------------------------------------------------------
+-- 3. receipts — "Anyone views receipts"
+--
+-- receipts already has a correct, narrow set of owner-scoped policies
+-- ("Users can view own receipts": user_id = auth.uid(); "Users can view
+-- vehicle receipts": vehicle's uploaded_by = auth.uid() or user_id match;
+-- receipts_insert/update/delete: created_by = auth.uid()) — same pattern as
+-- payment_events' fix tonight (#265). But "Anyone views receipts"
+-- USING(true) ORs against all of them and opens every column of every row —
+-- including card_last4 and card_holder (confirmed live: real last-4 digits
+-- readable by anon) — to anyone, for every receipt in the system, private
+-- vehicle or not.
+--
+-- UNLIKE qb_transactions, receipts has a real, live, anon-facing consumer:
+-- the vehicle profile page renders for every visitor (WorkspaceContent.tsx,
+-- no owner gate at the page level) and two of its cards query `receipts`
+-- directly assuming public readability:
+--   - useInvestmentLedger.ts: id, vendor_name, total, receipt_date,
+--     invoice_number  (filtered by vehicle_id + status='processed')
+--   - VehicleLedgerDocumentsCard.tsx: id, source_document_id,
+--     processing_status, vendor_name, total, currency, created_at
+--     (filtered by scope_type='vehicle' + scope_id=vehicleId)
+-- Dropping the wide policy outright would go dark for every non-owner
+-- visitor on every PUBLIC vehicle profile — a real regression to a shipping
+-- feature, not just closing a hole.
+--
+-- Fix: drop the wide table policy (base table reverts to owner-only, closing
+-- the PII leak completely), and add a narrow, hardcoded-safe VIEW that
+-- exposes only the non-sensitive columns those two call sites actually use,
+-- for receipts attached to a vehicle that is_public = true. The view
+-- intentionally does NOT set security_invoker (so it does not depend on, or
+-- get re-opened by, whatever RLS the base table has later) — its own WHERE
+-- clause is the entire access-control boundary, and its column list simply
+-- never includes card_last4 / card_holder / vendor_address / raw_extraction
+-- / raw_json / file_url etc., so no policy change on the base table can ever
+-- leak them through this view. security_barrier=true stops the planner from
+-- pushing caller-supplied filters ahead of that WHERE clause.
+-- ----------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "Anyone views receipts" ON receipts;
+
+DROP VIEW IF EXISTS receipts_public_summary;
+
+CREATE VIEW receipts_public_summary WITH (security_barrier = true) AS
+SELECT
+  r.id,
+  r.vehicle_id,
+  r.scope_type,
+  r.scope_id,
+  r.source_document_id,
+  r.source_document_table,
+  r.vendor_name,
+  r.total,
+  r.total_amount,
+  r.currency,
+  r.receipt_date,
+  r.transaction_date,
+  r.purchase_date,
+  r.invoice_number,
+  r.transaction_number,
+  r.processing_status,
+  r.status,
+  r.created_at
+FROM receipts r
+JOIN vehicles v
+  ON v.id = r.vehicle_id
+  OR (r.scope_type = 'vehicle' AND v.id::text = r.scope_id)
+WHERE v.is_public = true;
+
+REVOKE ALL ON receipts_public_summary FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON receipts_public_summary TO anon, authenticated;
+
+COMMENT ON VIEW receipts_public_summary IS
+  'Safe, column-limited public view of receipts for is_public=true vehicles only. Backs the vehicle-profile Investment Ledger + Ledger Documents cards for anon/non-owner visitors. Never exposes card_last4/card_holder/vendor_address/raw_extraction/file_url — those stay behind the owner-only base-table policies.';


### PR DESCRIPTION
## Summary

Catches git history up to what's already live in prod. This migration and frontend patch were verified and deployed directly to production tonight (independent RLS audit) but the work only existed on an isolated branch (`fable5/vehicles-rls-fix-1783308908`) that was never pushed or opened as a PR. This PR cherry-picks that exact, already-verified commit (`1081e30c6`) onto current `main` so a rebuild from `main` doesn't silently lose it — same pattern as #328 (VLVA revenue fix).

Independent audit found three ~7-month-old `USING(true)` PERMISSIVE RLS policies, each silently defeating the correctly-scoped policy already sitting next to it on the same table:

1. **`vehicles`** — `"Anyone can view auction pricing dashboard"` OR'd against `vehicles_public_select` / `vehicles_private_select`, giving anon full read (including VIN) on all 323,830 `is_public=false` rows. Origin: an internal QA view (`auction_pricing_dashboard`) with zero frontend/edge-function consumers. Dropped outright — the two existing `is_public`-gated policies already cover every legitimate case.
2. **`qb_transactions`** — `"Public read"` opened every QuickBooks transaction (vendor, amounts, memos) to anon. Zero frontend consumers (only service-role scripts). Dropped outright; `service_role` retains full access via the existing "Service write" policy.
3. **`receipts`** — `"Anyone views receipts"` opened every column of every receipt to anon, confirmed live leaking real `card_last4`/`card_holder` values. Unlike the other two, this backs a real feature: the vehicle-profile Investment Ledger and Ledger Documents cards render for every visitor (no owner gate at the page level) and query `receipts` directly. Dropped the wide policy (base table reverts to owner-only, matching `payment_events` #265) and added `receipts_public_summary`, a column-limited view (never `card_last4`/`card_holder`/`vendor_address`/`raw_extraction`/`file_url`) scoped to `is_public=true` vehicles, with the two real frontend call sites (`useInvestmentLedger.ts`, `VehicleLedgerDocumentsCard.tsx`) falling back to it when the owner-scoped base-table query returns nothing.

Verified live before/after via anon-key REST calls: `is_public=false` vehicle rows and card fields go from fully readable to empty; `is_public=true` vehicles unaffected; the public-vehicle receipt summary still resolves through the new view.

**Note on branches:** the original work branch (`fable5/vehicles-rls-fix-1783308908`) has diverged heavily from `main` (126 ahead / 88 behind, ~9,600 files in its raw diff — mostly session/debris and other already-merged-elsewhere work with different hashes). Rather than open a 9,600-file PR, this PR is a clean cherry-pick of just the one real commit (`1081e30c6`) onto current `main` — diff-identical to the original (only the commit hash line differs).

## Test plan
- [x] Migration SQL reviewed; matches what's deployed live in prod (`20260706000000_lock_down_vehicles_qb_receipts_rls.sql`)
- [x] Frontend fallback patches reviewed; match what's deployed live in prod
- [x] Diff verified identical to the already-prod-verified commit `1081e30c6` (only commit hash differs)
- [x] Independently verified live in prod: anon read on `is_public=false` vehicles and `receipts` card fields closed; public-vehicle Investment Ledger / Ledger Documents cards still render via `receipts_public_summary`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vehicle ledger pages so receipt details load correctly for public and non-owner visitors when permitted.
  * Improved fallback behavior so public receipt summaries appear instead of empty results.
  * Kept document and receipt data aligned when loading vehicle profile ledgers.

* **Security**
  * Tightened access to sensitive financial data while preserving a safe public summary view for eligible vehicles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->