### PR TITLE
St Barth entity resolution: Guest Book 2024 advertisers → organizations

### DIFF
--- a/scripts/stbarth/pubfeat-00-export.mjs
+++ b/scripts/stbarth/pubfeat-00-export.mjs
@@ -1,0 +1,67 @@
+// pubfeat-00-export.mjs — Stage 00: export the working corpus.
+// Pulls publication_features (Guest Book 2024) split into frontier (org_id null)
+// and calibration (org_id set), plus the BL organizations slice. Writes JSON
+// artifacts to a fresh run dir and prints per-key field coverage.
+//
+// Usage: set -a; source ~/.nuke_env; set +a; node scripts/stbarth/pubfeat-00-export.mjs
+
+import { restClient, featureKeys, orgKeys, runDir, writeJson } from './pubfeat-lib.mjs';
+
+const GUESTBOOK_PUBLICATION_ID = 'c033ba62-8208-4476-9a58-d5df0f30a23d';
+
+const db = restClient();
+const dir = runDir();
+
+const features = await db.getAll(
+  'publication_features',
+  `publication_id=eq.${GUESTBOOK_PUBLICATION_ID}&select=*&order=id`
+);
+const frontier = features.filter((f) => f.org_id === null);
+const calibration = features.filter((f) => f.org_id !== null);
+
+const orgs = await db.getAll(
+  'organizations',
+  'country=eq.BL&select=id,business_name,name,legal_name,entity_type,business_type,email,phone,website,address,city,country,discovered_via,metadata&order=id'
+);
+
+console.log(`features total=${features.length} frontier=${frontier.length} calibration=${calibration.length}`);
+console.log(`BL organizations=${orgs.length}`);
+
+// Field-coverage report (drives expectations for deterministic capture)
+const cov = (rows, fn) => {
+  const n = rows.filter(fn).length;
+  return `${n} (${((100 * n) / rows.length).toFixed(0)}%)`;
+};
+const coverage = {
+  frontier: {
+    phone: cov(frontier, (f) => featureKeys(f).phones.size > 0),
+    instagram: cov(frontier, (f) => !!featureKeys(f).instagram),
+    domain: cov(frontier, (f) => featureKeys(f).domains.size > 0),
+    name: cov(frontier, (f) => featureKeys(f).names.length > 0),
+  },
+  calibration: {
+    phone: cov(calibration, (f) => featureKeys(f).phones.size > 0),
+    instagram: cov(calibration, (f) => !!featureKeys(f).instagram),
+    domain: cov(calibration, (f) => featureKeys(f).domains.size > 0),
+    name: cov(calibration, (f) => featureKeys(f).names.length > 0),
+  },
+  organizations: {
+    phone: cov(orgs, (o) => orgKeys(o).phones.size > 0),
+    instagram: cov(orgs, (o) => !!orgKeys(o).instagram),
+    domain: cov(orgs, (o) => orgKeys(o).domains.size > 0),
+  },
+};
+console.log(JSON.stringify(coverage, null, 2));
+
+writeJson(dir, 'features-frontier.json', frontier);
+writeJson(dir, 'features-calibration.json', calibration);
+writeJson(dir, 'organizations-bl.json', orgs);
+writeJson(dir, 'coverage.json', coverage);
+writeJson(dir, 'run-meta.json', {
+  run_id: dir.split('/').pop(),
+  exported_at: new Date().toISOString(),
+  publication_id: GUESTBOOK_PUBLICATION_ID,
+  counts: { features: features.length, frontier: frontier.length, calibration: calibration.length, orgs: orgs.length },
+});
+
+console.log(`\nArtifacts → ${dir}`);

--- a/scripts/stbarth/pubfeat-01-calibrate.mjs
+++ b/scripts/stbarth/pubfeat-01-calibrate.mjs
@@ -1,0 +1,107 @@
+// pubfeat-01-calibrate.mjs — Stage 01: measure matcher quality on the 184
+// already-linked features BEFORE anything is written.
+//
+// Gates (written to calibration-report.json):
+//   deterministic precision ≥ 0.98  (of auto-accepts, agree with existing org_id)
+//   shortlist recall        ≥ 0.95  (true org appears in the top-8 shortlist)
+// Disagreements are printed as evidence cards — they may indicate a wrong
+// EXISTING link (the prior pipeline was ~0.95 confidence); they are logged,
+// never auto-fixed.
+//
+// Usage: node scripts/stbarth/pubfeat-01-calibrate.mjs [run-dir]
+
+import {
+  buildOrgIndex, deterministicMatch, shortlist,
+  latestRunDir, readJson, writeJson,
+} from './pubfeat-lib.mjs';
+
+const dir = process.argv[2] ?? latestRunDir();
+const calibration = readJson(dir, 'features-calibration.json');
+const orgs = readJson(dir, 'organizations-bl.json');
+const index = buildOrgIndex(orgs);
+
+let accepts = 0;
+let agree = 0;
+let shortlistHits = 0;
+let shortlistApplicable = 0;
+const disagreements = [];
+const hardRows = []; // calibration rows the deterministic tier does NOT catch → Opus spot-check corpus
+
+for (const f of calibration) {
+  const truth = f.org_id;
+  const det = deterministicMatch(f, index);
+  const list = shortlist(f, index, 8);
+
+  // Shortlist recall only counts rows whose true org is in the BL slice at all
+  if (index.byId.has(truth)) {
+    shortlistApplicable++;
+    if (list.some((c) => c.id === truth)) shortlistHits++;
+  }
+
+  if (det.decision && det.decision !== 'AMBIGUOUS') {
+    accepts++;
+    if (det.decision === truth) {
+      agree++;
+    } else {
+      const predicted = index.byId.get(det.decision);
+      const existing = index.byId.get(truth);
+      disagreements.push({
+        feature_id: f.id,
+        org_name_printed: f.org_name_printed,
+        details: f.details,
+        method: det.method,
+        evidence: det.evidence,
+        predicted: predicted
+          ? { id: predicted.id, business_name: predicted.business_name, phone: predicted.phone, website: predicted.website }
+          : { id: det.decision, note: 'not in BL slice' },
+        existing: existing
+          ? { id: existing.id, business_name: existing.business_name, phone: existing.phone, website: existing.website }
+          : { id: truth, note: 'existing link points outside BL slice' },
+      });
+    }
+  } else {
+    hardRows.push({ feature_id: f.id, truth, deterministic: det.decision ?? 'NO_KEYS' });
+  }
+}
+
+const precision = accepts ? agree / accepts : 0;
+const recall = shortlistApplicable ? shortlistHits / shortlistApplicable : 0;
+const detCoverage = accepts / calibration.length;
+
+const report = {
+  calibration_rows: calibration.length,
+  deterministic_accepts: accepts,
+  deterministic_agreements: agree,
+  deterministic_precision: Number(precision.toFixed(4)),
+  deterministic_coverage: Number(detCoverage.toFixed(4)),
+  shortlist_applicable: shortlistApplicable,
+  shortlist_recall: Number(recall.toFixed(4)),
+  truth_outside_bl_slice: calibration.length - shortlistApplicable,
+  gates: {
+    precision_gate: precision >= 0.98,
+    recall_gate: recall >= 0.95,
+  },
+  gate_passed: precision >= 0.98 && recall >= 0.95,
+  disagreements,
+  hard_rows_for_opus_spotcheck: hardRows.slice(0, 25),
+};
+
+writeJson(dir, 'calibration-report.json', report);
+
+console.log(`calibration rows:        ${report.calibration_rows}`);
+console.log(`deterministic accepts:   ${accepts} (coverage ${(detCoverage * 100).toFixed(0)}%)`);
+console.log(`deterministic precision: ${(precision * 100).toFixed(1)}%  (gate ≥98: ${report.gates.precision_gate})`);
+console.log(`shortlist recall:        ${(recall * 100).toFixed(1)}% of ${shortlistApplicable} applicable  (gate ≥95: ${report.gates.recall_gate})`);
+console.log(`truth outside BL slice:  ${report.truth_outside_bl_slice}`);
+console.log(`disagreements:           ${disagreements.length}`);
+console.log(`GATE_PASSED: ${report.gate_passed}`);
+if (disagreements.length) {
+  console.log('\n── Disagreement evidence cards ──');
+  for (const d of disagreements) {
+    console.log(
+      `\n[${d.feature_id}] printed="${d.org_name_printed}" via ${d.method} (${d.evidence.join(', ')})\n` +
+      `  matcher → ${d.predicted.business_name ?? d.predicted.id}\n` +
+      `  existing → ${d.existing.business_name ?? d.existing.id}`
+    );
+  }
+}

--- a/scripts/stbarth/pubfeat-02-deterministic.mjs
+++ b/scripts/stbarth/pubfeat-02-deterministic.mjs
@@ -1,0 +1,60 @@
+// pubfeat-02-deterministic.mjs — Stage 02: deterministic key joins on the
+// frontier (org_id null). Auto-accepts only unique, uncontradicted key hits;
+// everything else goes to ambiguous.json with a top-8 candidate shortlist for
+// the LLM matching tier.
+//
+// Usage: node scripts/stbarth/pubfeat-02-deterministic.mjs [run-dir]
+
+import {
+  buildOrgIndex, deterministicMatch, shortlist,
+  latestRunDir, readJson, writeJson,
+} from './pubfeat-lib.mjs';
+
+const dir = process.argv[2] ?? latestRunDir();
+const frontier = readJson(dir, 'features-frontier.json');
+const orgs = readJson(dir, 'organizations-bl.json');
+const index = buildOrgIndex(orgs);
+
+const matched = [];
+const ambiguous = [];
+const methodCounts = {};
+
+for (const f of frontier) {
+  const det = deterministicMatch(f, index);
+  if (det.decision && det.decision !== 'AMBIGUOUS') {
+    const org = index.byId.get(det.decision);
+    matched.push({
+      feature_id: f.id,
+      org_id: det.decision,
+      org_business_name: org?.business_name ?? null,
+      method: det.method,
+      evidence: det.evidence,
+      confidence: 0.97,
+      org_name_printed: f.org_name_printed,
+    });
+    methodCounts[det.method] = (methodCounts[det.method] ?? 0) + 1;
+  } else {
+    ambiguous.push({
+      feature: {
+        id: f.id,
+        org_name_printed: f.org_name_printed,
+        category: f.category,
+        feature_kind: f.feature_kind,
+        page: f.page,
+        printed_page: f.printed_page,
+        details: f.details,
+      },
+      deterministic_state: det.decision ?? 'NO_KEYS',
+      key_evidence: det.evidence,
+      shortlist: shortlist(f, index, 8),
+    });
+  }
+}
+
+writeJson(dir, 'matches-deterministic.json', matched);
+writeJson(dir, 'ambiguous.json', ambiguous);
+
+console.log(`frontier rows:        ${frontier.length}`);
+console.log(`deterministic match:  ${matched.length} (${JSON.stringify(methodCounts)})`);
+console.log(`→ LLM tier:           ${ambiguous.length}`);
+console.log(`Artifacts → ${dir}/matches-deterministic.json, ambiguous.json`);

--- a/scripts/stbarth/pubfeat-03-prep-batches.mjs
+++ b/scripts/stbarth/pubfeat-03-prep-batches.mjs
@@ -1,0 +1,63 @@
+// pubfeat-03-prep-batches.mjs — Stage 03 prep: split ambiguous.json into
+// batch files of 10 for the LLM matcher fleet, and build the Opus
+// spot-calibration corpus (hard calibration rows, truth withheld from the
+// batch files; truth map emitted separately for the orchestrator's gate).
+//
+// Usage: node scripts/stbarth/pubfeat-03-prep-batches.mjs [run-dir]
+
+import {
+  buildOrgIndex, shortlist, latestRunDir, readJson, writeJson,
+} from './pubfeat-lib.mjs';
+
+const dir = process.argv[2] ?? latestRunDir();
+const ambiguous = readJson(dir, 'ambiguous.json');
+const calibration = readJson(dir, 'features-calibration.json');
+const report = readJson(dir, 'calibration-report.json');
+const orgs = readJson(dir, 'organizations-bl.json');
+const index = buildOrgIndex(orgs);
+
+const BATCH = 10;
+let nBatches = 0;
+for (let i = 0; i < ambiguous.length; i += BATCH) {
+  nBatches++;
+  writeJson(dir, `ambiguous-batch-${String(nBatches).padStart(2, '0')}.json`,
+    ambiguous.slice(i, i + BATCH));
+}
+
+// Spot-calibration corpus: calibration rows the deterministic tier missed.
+const hardIds = new Set(report.hard_rows_for_opus_spotcheck.map((r) => r.feature_id));
+const spot = calibration
+  .filter((f) => hardIds.has(f.id))
+  .slice(0, 20)
+  .map((f) => ({
+    feature: {
+      id: f.id,
+      org_name_printed: f.org_name_printed,
+      category: f.category,
+      feature_kind: f.feature_kind,
+      page: f.page,
+      printed_page: f.printed_page,
+      details: f.details,
+    },
+    shortlist: shortlist(f, index, 8),
+  }));
+
+const spotBatches = [];
+for (let i = 0; i < spot.length; i += BATCH) {
+  const name = `spot-batch-${String(spotBatches.length + 1).padStart(2, '0')}.json`;
+  writeJson(dir, name, spot.slice(i, i + BATCH));
+  spotBatches.push(name);
+}
+
+const truthMap = Object.fromEntries(
+  calibration.filter((f) => hardIds.has(f.id)).slice(0, 20).map((f) => [f.id, f.org_id])
+);
+writeJson(dir, 'spot-truth.json', truthMap);
+
+console.log(JSON.stringify({
+  run_dir: dir,
+  ambiguous_batches: nBatches,
+  ambiguous_rows: ambiguous.length,
+  spot_batches: spotBatches.length,
+  spot_rows: spot.length,
+}, null, 2));

--- a/scripts/stbarth/pubfeat-05-apply.mjs
+++ b/scripts/stbarth/pubfeat-05-apply.mjs
@@ -1,0 +1,148 @@
+// pubfeat-05-apply.mjs — Stage 05: write verified matches to publication_features.
+//
+// Safety model:
+//   - refuses to run unless calibration-report.json has gate_passed: true
+//   - every org_id must exist in the exported BL slice; LLM matches must also
+//     be members of that feature's candidate shortlist
+//   - fresh snapshot of every target row is taken first (rollback input)
+//   - guarded PATCH: ...?id=eq.<id>&org_id=is.null  → never clobbers a link
+//   - batches of 50 with 250ms pauses (Hard Rules: no unbounded writes)
+//   - DRY-RUN by default; pass --apply to execute
+//
+// Usage: node scripts/stbarth/pubfeat-05-apply.mjs [run-dir] [--apply]
+
+import {
+  restClient, sleep, latestRunDir, readJson, writeJson,
+} from './pubfeat-lib.mjs';
+
+const argv = process.argv.slice(2);
+const apply = argv.includes('--apply');
+const dirArg = argv.find((a) => !a.startsWith('--'));
+const dir = dirArg ?? latestRunDir();
+
+const calibration = readJson(dir, 'calibration-report.json');
+if (!calibration.gate_passed) {
+  console.error('REFUSING: calibration gate not passed (calibration-report.json).');
+  process.exit(1);
+}
+
+const deterministic = readJson(dir, 'matches-deterministic.json');
+const verified = readJson(dir, 'matches-verified.json'); // from the Opus fleet
+const orgs = readJson(dir, 'organizations-bl.json');
+const ambiguous = readJson(dir, 'ambiguous.json');
+
+const orgIds = new Set(orgs.map((o) => o.id));
+const orgName = new Map(orgs.map((o) => [o.id, o.business_name]));
+const shortlistByFeature = new Map(
+  ambiguous.map((e) => [e.feature.id, new Set(e.shortlist.map((c) => c.id))])
+);
+
+// Assemble the write set with validation
+const writes = [];
+const invalid = [];
+for (const m of deterministic) {
+  if (!orgIds.has(m.org_id)) { invalid.push({ ...m, why: 'org not in BL slice' }); continue; }
+  writes.push({ feature_id: m.feature_id, org_id: m.org_id, confidence: m.confidence, method: m.method, evidence: m.evidence });
+}
+for (const m of verified) {
+  if (!orgIds.has(m.decision)) { invalid.push({ ...m, why: 'org not in BL slice' }); continue; }
+  const sl = shortlistByFeature.get(m.feature_id);
+  if (!sl || !sl.has(m.decision)) { invalid.push({ ...m, why: 'decision outside feature shortlist' }); continue; }
+  writes.push({
+    feature_id: m.feature_id, org_id: m.decision, confidence: m.confidence,
+    method: 'opus', evidence: m.evidence, skeptics: m.skeptics ?? null,
+  });
+}
+
+// Duplicate-feature guard
+const seen = new Set();
+for (const w of writes) {
+  if (seen.has(w.feature_id)) {
+    console.error(`REFUSING: duplicate write for feature ${w.feature_id}`);
+    process.exit(1);
+  }
+  seen.add(w.feature_id);
+}
+
+console.log(`write set: ${writes.length} (deterministic ${deterministic.length}, opus-verified ${verified.length}, invalid ${invalid.length})`);
+if (invalid.length) console.log('invalid entries:', JSON.stringify(invalid, null, 2));
+
+const db = restClient();
+
+// Fresh snapshot of target rows (also re-checks org_id is still null)
+const ids = writes.map((w) => w.feature_id);
+const current = [];
+for (let i = 0; i < ids.length; i += 50) {
+  const chunk = ids.slice(i, i + 50);
+  current.push(
+    ...(await db.getAll('publication_features', `id=in.(${chunk.join(',')})&select=id,org_id,confidence,details`))
+  );
+}
+const currentById = new Map(current.map((r) => [r.id, r]));
+const conflicted = writes.filter((w) => currentById.get(w.feature_id)?.org_id !== null);
+if (conflicted.length) {
+  console.log(`WARNING: ${conflicted.length} rows no longer have org_id null — they will be SKIPPED (guard would no-op anyway).`);
+}
+const applicable = writes.filter((w) => currentById.get(w.feature_id)?.org_id === null);
+
+writeJson(dir, 'snapshot-features.json', {
+  run_id: dir.split('/').pop(),
+  table: 'publication_features',
+  rows: applicable.map((w) => ({
+    id: w.feature_id,
+    before: currentById.get(w.feature_id),
+    after: { org_id: w.org_id, confidence: w.confidence },
+  })),
+});
+
+if (!apply) {
+  console.log('\n── DRY RUN (pass --apply to execute) ──');
+  for (const w of applicable) {
+    console.log(`${w.feature_id} → ${orgName.get(w.org_id)} [${w.method}] conf=${w.confidence}`);
+  }
+  console.log(`\nWould update ${applicable.length} rows. Snapshot written.`);
+  process.exit(0);
+}
+
+const applied = [];
+const errors = [];
+for (let i = 0; i < applicable.length; i += 50) {
+  const batch = applicable.slice(i, i + 50);
+  for (const w of batch) {
+    const row = currentById.get(w.feature_id);
+    const details = {
+      ...(row.details || {}),
+      org_match: {
+        method: w.method,
+        confidence: w.confidence,
+        evidence: w.evidence,
+        ...(w.skeptics ? { skeptics: w.skeptics } : {}),
+        run_id: dir.split('/').pop(),
+      },
+    };
+    try {
+      const res = await db.patch(
+        'publication_features',
+        `id=eq.${w.feature_id}&org_id=is.null`,
+        { org_id: w.org_id, confidence: w.confidence, details }
+      );
+      if (res.length === 1) applied.push({ feature_id: w.feature_id, org_id: w.org_id });
+      else errors.push({ feature_id: w.feature_id, why: `guard matched ${res.length} rows` });
+    } catch (e) {
+      errors.push({ feature_id: w.feature_id, why: String(e).slice(0, 300) });
+    }
+  }
+  await sleep(250);
+  console.log(`applied ${Math.min(i + 50, applicable.length)}/${applicable.length}...`);
+}
+
+writeJson(dir, 'apply-log.json', {
+  applied_at: new Date().toISOString(),
+  applied_count: applied.length,
+  error_count: errors.length,
+  applied,
+  errors,
+  skipped_conflicts: conflicted.map((w) => w.feature_id),
+});
+console.log(`\nAPPLIED: ${applied.length}  errors: ${errors.length}  skipped: ${conflicted.length}`);
+if (errors.length) console.log(JSON.stringify(errors, null, 2));

--- a/scripts/stbarth/pubfeat-06-verify-e2e.mjs
+++ b/scripts/stbarth/pubfeat-06-verify-e2e.mjs
@@ -1,0 +1,106 @@
+// pubfeat-06-verify-e2e.mjs — Stage 06: end-to-end verification after apply.
+//
+// Checks (per approved plan):
+//   1. count arithmetic on publication_features (nulls = 184 − applied; total 368)
+//   2. every newly written org_id joins to a country=BL organization
+//   3. projections untouched (businesses / concierge_supply_stbarth counts)
+//   4. concentration: no org received > 8 new links
+//   5. idempotency probe: deterministic matcher reproduces 20 random applied rows
+//   6. spine: unique (publication_id, issue_number); all editorial_stories
+//      resolve into publication_issues; none still on the legacy id;
+//      frontend natural-key query returns exactly 1 row for 5 sampled issues
+//   7. prints 15 random evidence cards for human spot-check
+//
+// Usage: node scripts/stbarth/pubfeat-06-verify-e2e.mjs [run-dir]
+
+import {
+  restClient, buildOrgIndex, deterministicMatch,
+  latestRunDir, readJson, writeJson,
+} from './pubfeat-lib.mjs';
+
+const dir = process.argv[2] ?? latestRunDir();
+const db = restClient();
+const applyLog = readJson(dir, 'apply-log.json');
+const meta = readJson(dir, 'run-meta.json');
+const orgs = readJson(dir, 'organizations-bl.json');
+const frontier = readJson(dir, 'features-frontier.json');
+
+const results = [];
+const check = (name, ok, detail) => {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+};
+
+const PUB = meta.publication_id;
+
+// 1. count arithmetic
+const total = await db.count('publication_features', `publication_id=eq.${PUB}`);
+const stillNull = await db.count('publication_features', `publication_id=eq.${PUB}&org_id=is.null`);
+const expectedNull = meta.counts.frontier - applyLog.applied_count;
+check('feature row total unchanged', total === meta.counts.features, `${total}`);
+check('null-org arithmetic', stillNull === expectedNull, `nulls=${stillNull} expected=${expectedNull}`);
+
+// 2. BL join integrity for newly written rows
+const orgIds = new Set(orgs.map((o) => o.id));
+const badJoins = applyLog.applied.filter((a) => !orgIds.has(a.org_id));
+check('all applied org_ids in BL slice', badJoins.length === 0, `${badJoins.length} bad`);
+
+// 3. projections untouched
+const bizCount = await db.count('businesses', '');
+const supplyCount = await db.count('concierge_supply_stbarth', '');
+check('businesses projection readable & plausible', bizCount >= 5000, `${bizCount}`);
+check('concierge_supply_stbarth untouched', supplyCount === 1717, `${supplyCount}`);
+
+// 4. concentration
+const perOrg = {};
+for (const a of applyLog.applied) perOrg[a.org_id] = (perOrg[a.org_id] ?? 0) + 1;
+const concentrated = Object.entries(perOrg).filter(([, n]) => n > 8);
+check('no org over-concentrated (>8 new links)', concentrated.length === 0,
+  concentrated.map(([id, n]) => `${id}:${n}`).join(' ') || 'max ok');
+
+// 5. idempotency probe — deterministic matcher must reproduce its own applied rows
+const index = buildOrgIndex(orgs);
+const detApplied = readJson(dir, 'matches-deterministic.json')
+  .filter((m) => applyLog.applied.some((a) => a.feature_id === m.feature_id));
+const sample = detApplied.sort(() => 0.5 - Math.random()).slice(0, 20);
+const featureById = new Map(frontier.map((f) => [f.id, f]));
+let reproduced = 0;
+for (const m of sample) {
+  const det = deterministicMatch(featureById.get(m.feature_id), index);
+  if (det.decision === m.org_id) reproduced++;
+}
+check('idempotency probe (deterministic rows reproduce)', reproduced === sample.length,
+  `${reproduced}/${sample.length}`);
+
+// 6. spine — read-only validation of the live spine (seeded 2026-07-15 by the
+// external 'spine_build' process, not by this pipeline)
+const issues = await db.getAll('publication_issues', 'select=id,publication_id,issue_number,issue_title');
+const keys = issues.map((i) => `${i.publication_id}|${i.issue_number}`);
+check('publication_issues natural key unique', new Set(keys).size === keys.length, `${issues.length} issues`);
+
+const stories = await db.getAll('editorial_stories', 'select=id,issue_id,attributes');
+const issueIdSet = new Set(issues.map((i) => i.id));
+const unresolved = stories.filter((s) => !issueIdSet.has(s.issue_id));
+check('all editorial_stories resolve to publication_issues', unresolved.length === 0, `${unresolved.length} orphans of ${stories.length}`);
+
+let nkOk = 0;
+const nkSample = issues.slice(0, 5);
+for (const i of nkSample) {
+  const n = await db.count('publication_issues', `publication_id=eq.${i.publication_id}&issue_number=eq.${encodeURIComponent(i.issue_number)}`);
+  if (n === 1) nkOk++;
+}
+check('frontend natural-key query returns exactly 1', nkOk === nkSample.length, `${nkOk}/${nkSample.length}`);
+
+// 7. evidence cards
+const orgName = new Map(orgs.map((o) => [o.id, o.business_name]));
+const printedName = new Map(frontier.map((f) => [f.id, f.org_name_printed]));
+const cards = applyLog.applied.sort(() => 0.5 - Math.random()).slice(0, 15);
+console.log('\n── 15 random applied matches (human spot-check) ──');
+for (const c of cards) {
+  console.log(`  "${printedName.get(c.feature_id)}"  →  ${orgName.get(c.org_id)}`);
+}
+
+const failed = results.filter((r) => !r.ok);
+writeJson(dir, 'verify-e2e-report.json', { results, all_passed: failed.length === 0 });
+console.log(`\n${failed.length === 0 ? 'ALL CHECKS PASSED' : `${failed.length} CHECKS FAILED`}`);
+process.exit(failed.length === 0 ? 0 : 1);

--- a/scripts/stbarth/pubfeat-lib.mjs
+++ b/scripts/stbarth/pubfeat-lib.mjs
@@ -1,0 +1,422 @@
+// pubfeat-lib.mjs — shared library for the publication_features → organizations
+// entity-resolution pipeline (Guest Book 2024 advertiser linking).
+//
+// Dependency-free: uses Node's native fetch against PostgREST directly, so the
+// pipeline runs without a root node_modules install. Semantics mirror
+// seed-publications.mjs (service-role key, batch writes of 50, guarded updates).
+//
+// Env (source ~/.nuke_env): VITE_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+// ── PostgREST client ────────────────────────────────────────────────────────
+
+export function restClient() {
+  const url = process.env.VITE_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('Missing VITE_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY (source ~/.nuke_env)');
+    process.exit(1);
+  }
+  const base = `${url.replace(/\/$/, '')}/rest/v1`;
+  const headers = {
+    apikey: key,
+    Authorization: `Bearer ${key}`,
+    'Content-Type': 'application/json',
+  };
+
+  async function request(method, pathAndQuery, { body, prefer } = {}) {
+    const h = { ...headers };
+    if (prefer) h.Prefer = prefer;
+    const res = await fetch(`${base}/${pathAndQuery}`, {
+      method,
+      headers: h,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await res.text();
+    if (!res.ok) {
+      throw new Error(`${method} ${pathAndQuery} → ${res.status}: ${text.slice(0, 500)}`);
+    }
+    return text ? JSON.parse(text) : null;
+  }
+
+  return {
+    // Paginated GET of every row matching the query.
+    async getAll(table, query, pageSize = 1000) {
+      const rows = [];
+      for (let offset = 0; ; offset += pageSize) {
+        const sep = query ? '&' : '';
+        const page = await request(
+          'GET',
+          `${table}?${query}${sep}limit=${pageSize}&offset=${offset}`
+        );
+        rows.push(...page);
+        if (page.length < pageSize) break;
+      }
+      return rows;
+    },
+    async count(table, query) {
+      const sep = query ? '&' : '';
+      const res = await fetch(`${base}/${table}?${query}${sep}select=*`, {
+        method: 'HEAD',
+        headers: { ...headers, Prefer: 'count=exact', Range: '0-0' },
+      });
+      const range = res.headers.get('content-range') || '';
+      return parseInt(range.split('/')[1], 10);
+    },
+    patch: (table, query, body, prefer = 'return=representation') =>
+      request('PATCH', `${table}?${query}`, { body, prefer }),
+    insert: (table, rows, prefer = 'return=representation') =>
+      request('POST', table, { body: rows, prefer }),
+    delete: (table, query, prefer = 'return=representation') =>
+      request('DELETE', `${table}?${query}`, { prefer }),
+  };
+}
+
+export const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── Normalizers ─────────────────────────────────────────────────────────────
+
+// Phone → set of E.164 +590XXXXXXXXX strings.
+// St Barth uses Guadeloupe numbering: landlines 0590…, mobiles 0690/0691….
+export function normalizePhones(raw) {
+  const out = new Set();
+  if (!raw || typeof raw !== 'string') return out;
+  for (const token of raw.split(/\s*(?:\/|,|;|·|\bou\b|\bor\b)\s*/i)) {
+    let digits = token.replace(/[^\d+]/g, '');
+    if (!digits) continue;
+    if (digits.startsWith('+590')) digits = digits.slice(4);
+    else if (digits.startsWith('00590')) digits = digits.slice(5);
+    else if (digits.startsWith('590') && digits.length > 9) digits = digits.slice(3);
+    else if (digits.startsWith('0') && digits.length === 10) digits = digits.slice(1);
+    digits = digits.replace(/\D/g, '');
+    if (digits.length === 9 && /^[56]9[01]/.test(digits)) out.add(`+590${digits}`);
+    // Keep other 9-digit French-form numbers too (rare metropolitan-format ads)
+    else if (digits.length === 9) out.add(`+590${digits}`);
+  }
+  return out;
+}
+
+const IG_STOPLIST = new Set(['p', 'reel', 'reels', 'stories', 'explore', 'accounts', 'tv']);
+
+// Instagram URL or @handle → lowercase handle, or null.
+export function normalizeInstagram(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  const url = raw.match(/instagram\.com\/([a-zA-Z0-9_.]+)/i);
+  let handle = url ? url[1] : null;
+  if (!handle) {
+    const at = raw.trim().match(/^@?([a-zA-Z0-9_.]{2,30})$/);
+    handle = at ? at[1] : null;
+  }
+  if (!handle) return null;
+  handle = handle.toLowerCase().replace(/[./]+$/, '');
+  return IG_STOPLIST.has(handle) ? null : handle;
+}
+
+const PLATFORM_HOSTS = new Set([
+  'wixsite.com', 'business.site', 'facebook.com', 'instagram.com',
+  'linktr.ee', 'squarespace.com', 'google.com', 'youtube.com', 'wordpress.com',
+]);
+const FREEMAIL = new Set([
+  'gmail.com', 'hotmail.com', 'hotmail.fr', 'yahoo.com', 'yahoo.fr',
+  'outlook.com', 'outlook.fr', 'orange.fr', 'wanadoo.fr', 'icloud.com', 'live.com',
+]);
+
+// Website URL (or email for fromEmail=true) → naive eTLD+1, or null.
+export function normalizeDomain(raw, { fromEmail = false } = {}) {
+  if (!raw || typeof raw !== 'string') return null;
+  let host = raw.trim().toLowerCase();
+  if (fromEmail) {
+    const at = host.lastIndexOf('@');
+    if (at === -1) return null;
+    host = host.slice(at + 1);
+  } else {
+    host = host.replace(/^[a-z]+:\/\//, '').replace(/^www\./, '').split(/[/?#]/)[0];
+  }
+  if (!host || !host.includes('.')) return null;
+  const parts = host.split('.');
+  // naive eTLD+1 with a couple of common two-part TLDs
+  const twoPart = new Set(['co.uk', 'com.fr', 'wixsite.com', 'business.site']);
+  const lastTwo = parts.slice(-2).join('.');
+  const domain = twoPart.has(lastTwo) && parts.length >= 3 ? parts.slice(-3).join('.') : lastTwo;
+  if (PLATFORM_HOSTS.has(domain)) return null;
+  if (fromEmail && FREEMAIL.has(domain)) return null;
+  return domain;
+}
+
+const LEGAL_SUFFIXES = /\b(sarl|sasu|sas|snc|eurl|sci|sa|sc|ltd|inc|co|llc)\b\.?$/;
+const ISLAND_QUALIFIERS = /\b(st\.?\s*barth(elemy|s)?|saint\s*barth(elemy|s)?|sbh)\b/g;
+
+export function normalizeName(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  let s = raw
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/\bet\b/g, 'and')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  s = s.replace(LEGAL_SUFFIXES, '').trim();
+  return s || null;
+}
+
+export function nameVariants(raw) {
+  const base = normalizeName(raw);
+  if (!base) return [];
+  const variants = new Set([base]);
+  const noArticle = base.replace(/^(le|la|les|l)\s+/, '').trim();
+  if (noArticle) variants.add(noArticle);
+  const noIsland = base.replace(ISLAND_QUALIFIERS, '').replace(/\s+/g, ' ').trim();
+  if (noIsland) variants.add(noIsland);
+  const noBoth = noArticle.replace(ISLAND_QUALIFIERS, '').replace(/\s+/g, ' ').trim();
+  if (noBoth) variants.add(noBoth);
+  return [...variants].filter(Boolean);
+}
+
+// ── Similarity ──────────────────────────────────────────────────────────────
+
+function trigrams(s) {
+  const padded = `  ${s} `;
+  const grams = new Set();
+  for (let i = 0; i < padded.length - 2; i++) grams.add(padded.slice(i, i + 3));
+  return grams;
+}
+
+export function trigramSim(a, b) {
+  if (!a || !b) return 0;
+  const ta = trigrams(a);
+  const tb = trigrams(b);
+  let inter = 0;
+  for (const g of ta) if (tb.has(g)) inter++;
+  return inter / (ta.size + tb.size - inter);
+}
+
+export function tokenSetSim(a, b) {
+  if (!a || !b) return 0;
+  const sa = new Set(a.split(' '));
+  const sb = new Set(b.split(' '));
+  let inter = 0;
+  for (const t of sa) if (sb.has(t)) inter++;
+  return inter / Math.max(sa.size, sb.size);
+}
+
+export const nameSim = (a, b) => Math.max(trigramSim(a, b), tokenSetSim(a, b));
+
+// ── Feature + org field extraction ──────────────────────────────────────────
+
+export function featureKeys(f) {
+  const d = f.details || {};
+  return {
+    phones: normalizePhones(d.phone),
+    instagram: normalizeInstagram(d.instagram),
+    domains: new Set(
+      [
+        normalizeDomain(d.website),
+        normalizeDomain(d.email, { fromEmail: true }),
+      ].filter(Boolean)
+    ),
+    names: nameVariants(f.org_name_printed),
+  };
+}
+
+export function orgKeys(o) {
+  const md = o.metadata || {};
+  const facts = md.access_sb?.facts || {};
+  const phones = new Set([
+    ...normalizePhones(o.phone),
+    ...normalizePhones(typeof facts.phone === 'string' ? facts.phone : ''),
+  ]);
+  const domains = new Set(
+    [
+      normalizeDomain(o.website),
+      normalizeDomain(o.email, { fromEmail: true }),
+      normalizeDomain(typeof facts.email === 'string' ? facts.email : '', { fromEmail: true }),
+    ].filter(Boolean)
+  );
+  const names = [
+    ...new Set([...nameVariants(o.business_name), ...nameVariants(o.name)]),
+  ];
+  return {
+    phones,
+    instagram: normalizeInstagram(md.instagram),
+    domains,
+    names,
+  };
+}
+
+// Completeness score — tiebreaker idiom from scripts/concierge/dedupe-businesses.ts
+export function completenessScore(o) {
+  const md = o.metadata || {};
+  let s = 0;
+  if (o.website) s += 10;
+  if (o.phone) s += 5;
+  if (o.email) s += 5;
+  if (md.instagram) s += 20;
+  if (md.facebook) s += 10;
+  if (md.investigated_at) s += 15;
+  s += Object.keys(md).length;
+  return s;
+}
+
+// ── Org index ───────────────────────────────────────────────────────────────
+
+export function buildOrgIndex(orgs) {
+  const byPhone = new Map();
+  const byInstagram = new Map();
+  const byDomain = new Map();
+  const byName = new Map();
+  const keyed = [];
+
+  const push = (map, key, id) => {
+    if (!map.has(key)) map.set(key, new Set());
+    map.get(key).add(id);
+  };
+
+  for (const o of orgs) {
+    const k = orgKeys(o);
+    keyed.push({ org: o, keys: k });
+    for (const p of k.phones) push(byPhone, p, o.id);
+    if (k.instagram) push(byInstagram, k.instagram, o.id);
+    for (const d of k.domains) push(byDomain, d, o.id);
+    for (const n of k.names) push(byName, n, o.id);
+  }
+  return { byPhone, byInstagram, byDomain, byName, keyed, byId: new Map(orgs.map((o) => [o.id, o])) };
+}
+
+// Top-K candidate shortlist for a feature: name similarity ranked, with forced
+// inclusion of any contact-key sharer; ordered by (sim, completeness).
+export function shortlist(feature, index, K = 8) {
+  const fk = featureKeys(feature);
+  const forced = new Set();
+  for (const p of fk.phones) for (const id of index.byPhone.get(p) || []) forced.add(id);
+  if (fk.instagram) for (const id of index.byInstagram.get(fk.instagram) || []) forced.add(id);
+  for (const d of fk.domains) for (const id of index.byDomain.get(d) || []) forced.add(id);
+
+  const scored = index.keyed.map(({ org, keys }) => {
+    let best = 0;
+    for (const fn of fk.names) for (const on of keys.names) best = Math.max(best, nameSim(fn, on));
+    return { org, keys, sim: best };
+  });
+  scored.sort(
+    (a, b) => b.sim - a.sim || completenessScore(b.org) - completenessScore(a.org)
+  );
+
+  const picked = [];
+  const seen = new Set();
+  for (const id of forced) {
+    const entry = scored.find((s) => s.org.id === id);
+    if (entry && !seen.has(id)) {
+      picked.push(entry);
+      seen.add(id);
+    }
+  }
+  for (const entry of scored) {
+    if (picked.length >= K) break;
+    if (!seen.has(entry.org.id) && entry.sim > 0.15) {
+      picked.push(entry);
+      seen.add(entry.org.id);
+    }
+  }
+  return picked.map(({ org, keys, sim }) => ({
+    id: org.id,
+    business_name: org.business_name,
+    name: org.name,
+    entity_type: org.entity_type,
+    phones: [...keys.phones],
+    instagram: keys.instagram,
+    domains: [...keys.domains],
+    address: org.address,
+    city: org.city,
+    category_fr: org.metadata?.category_fr ?? null,
+    super_category: org.metadata?.super_category ?? null,
+    name_sim: Number(sim.toFixed(3)),
+    completeness: completenessScore(org),
+  }));
+}
+
+// ── Deterministic matcher ───────────────────────────────────────────────────
+// Returns {decision, method, evidence} — decision is an org id, 'AMBIGUOUS', or null.
+// Auto-accept requires the key value to be UNIQUE in the index and no other key
+// to contradict it. Any collision demotes to AMBIGUOUS (LLM tier).
+
+export function deterministicMatch(feature, index) {
+  const fk = featureKeys(feature);
+  const hits = []; // {key, value, orgIds}
+
+  if (fk.instagram) {
+    const ids = index.byInstagram.get(fk.instagram);
+    if (ids) hits.push({ key: 'instagram', value: fk.instagram, orgIds: [...ids] });
+  }
+  for (const d of fk.domains) {
+    const ids = index.byDomain.get(d);
+    if (ids) hits.push({ key: 'domain', value: d, orgIds: [...ids] });
+  }
+  for (const p of fk.phones) {
+    const ids = index.byPhone.get(p);
+    if (ids) hits.push({ key: 'phone', value: p, orgIds: [...ids] });
+  }
+  for (const n of fk.names) {
+    const ids = index.byName.get(n);
+    if (ids) hits.push({ key: 'name', value: n, orgIds: [...ids] });
+  }
+
+  if (!hits.length) return { decision: null, method: null, evidence: [] };
+
+  // Union of every org implicated by any key
+  const allIds = new Set(hits.flatMap((h) => h.orgIds));
+  if (allIds.size === 1) {
+    const id = [...allIds][0];
+    const uniqueHit = hits.find((h) => h.orgIds.length === 1);
+    if (uniqueHit) {
+      return {
+        decision: id,
+        method: uniqueHit.key,
+        evidence: hits.map((h) => `${h.key}=${h.value}`),
+      };
+    }
+  }
+  return {
+    decision: 'AMBIGUOUS',
+    method: null,
+    evidence: hits.map((h) => `${h.key}=${h.value}→${h.orgIds.length} orgs`),
+  };
+}
+
+// ── Run-dir + snapshot helpers ──────────────────────────────────────────────
+
+export function runDir(existing) {
+  const base = path.join(import.meta.dirname, 'data');
+  if (existing) {
+    const p = path.isAbsolute(existing) ? existing : path.join(base, existing);
+    if (!fs.existsSync(p)) {
+      console.error(`Run dir not found: ${p}`);
+      process.exit(1);
+    }
+    return p;
+  }
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const p = path.join(base, `pubfeat-run-${ts}`);
+  fs.mkdirSync(p, { recursive: true });
+  return p;
+}
+
+export function latestRunDir() {
+  const base = path.join(import.meta.dirname, 'data');
+  const runs = fs
+    .readdirSync(base)
+    .filter((d) => d.startsWith('pubfeat-run-'))
+    .sort();
+  if (!runs.length) {
+    console.error('No pubfeat-run-* dir found under scripts/stbarth/data/');
+    process.exit(1);
+  }
+  return path.join(base, runs[runs.length - 1]);
+}
+
+export const readJson = (dir, name) =>
+  JSON.parse(fs.readFileSync(path.join(dir, name), 'utf8'));
+export const writeJson = (dir, name, obj) =>
+  fs.writeFileSync(path.join(dir, name), JSON.stringify(obj, null, 2));

--- a/scripts/stbarth/pubfeat-rollback.mjs
+++ b/scripts/stbarth/pubfeat-rollback.mjs
@@ -1,0 +1,51 @@
+// pubfeat-rollback.mjs — restore publication_features org links from a run's
+// snapshot file.
+//
+// No-clobber guard: a row is only restored if its CURRENT org_id equals what
+// the run wrote (i.e., nothing else has touched it since).
+//
+// Usage:
+//   node scripts/stbarth/pubfeat-rollback.mjs <run-dir> [--apply]
+//     (default is dry-run: prints the restore plan)
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { restClient, sleep, readJson, writeJson } from './pubfeat-lib.mjs';
+
+const argv = process.argv.slice(2);
+const apply = argv.includes('--apply');
+const dirArg = argv.find((a) => !a.startsWith('--'));
+if (!dirArg) {
+  console.error('Usage: node pubfeat-rollback.mjs <run-dir> [--apply]');
+  process.exit(1);
+}
+const dir = path.isAbsolute(dirArg) ? dirArg : path.join(import.meta.dirname, 'data', dirArg);
+if (!fs.existsSync(path.join(dir, 'snapshot-features.json'))) {
+  console.error(`No snapshot-features.json in ${dir}`);
+  process.exit(1);
+}
+
+const db = restClient();
+const snap = readJson(dir, 'snapshot-features.json');
+const log = { restored: [], skipped: [], errors: [] };
+console.log(`features snapshot: ${snap.rows.length} rows`);
+
+for (let i = 0; i < snap.rows.length; i += 50) {
+  for (const r of snap.rows.slice(i, i + 50)) {
+    if (!apply) { log.restored.push({ id: r.id, to: r.before.org_id }); continue; }
+    try {
+      const res = await db.patch(
+        'publication_features',
+        `id=eq.${r.id}&org_id=eq.${r.after.org_id}`,
+        { org_id: r.before.org_id, confidence: r.before.confidence, details: r.before.details }
+      );
+      (res.length === 1 ? log.restored : log.skipped).push({ id: r.id });
+    } catch (e) {
+      log.errors.push({ id: r.id, why: String(e).slice(0, 200) });
+    }
+  }
+  if (apply) await sleep(250);
+}
+
+writeJson(dir, apply ? 'rollback-log.json' : 'rollback-plan.json', log);
+console.log(`\n${apply ? 'ROLLBACK EXECUTED' : 'DRY RUN'}: restore=${log.restored.length} skipped=${log.skipped.length} errors=${log.errors.length}`);


### PR DESCRIPTION
## What this is

A gated entity-resolution pipeline linking `publication_features` rows (advertiser ads extracted from Saint Barth Guest Book 2024) to St Barth (`country=BL`) `organizations` — the publishing ↔ concierge-supply bridge. 184 of 368 rows were already linked; this pipeline resolves the remaining 184.

## Pipeline (scripts/stbarth/pubfeat-*.mjs)

1. **00-export** — snapshot features + BL orgs to run-dir artifacts; per-key field coverage report
2. **01-calibrate** — blind-run the matcher on the 184 pre-linked rows: **100% deterministic precision** (105/105), **99.5% shortlist recall**. The apply stage refuses to run without this gate
3. **02-deterministic** — unique, uncontradicted key joins (instagram handle → domain → phone E.164-set → normalized name): 46/184
4. **LLM tier** (orchestrated externally; artifacts in run dir): matcher agents over per-feature top-8 shortlists, then two adversarial skeptic lenses (collision + evidence-sufficiency), unanimous UPHOLD required. Spot-calibration 20/20 after encoding the featured-entity convention and duplicate-row equivalences. Yield: 64 verified, 37 needs-human (left null), 37 NO_MATCH (left null)
5. **05-apply** — dry-run default; guarded PATCH (`id=eq.X&org_id=is.null`), batch 50 + pauses, provenance in `details.org_match`
6. **06-verify-e2e** — count arithmetic, BL join integrity, projections untouched, concentration flags, idempotency probe, spine checks
7. **rollback** — snapshot-based restore with no-clobber guards

## Notes for review

- **Dependency-free**: native `fetch` against PostgREST (root `node_modules` isn't installed); same guarded-update semantics as `seed-publications.mjs`
- Hard Rules respected: batched guarded writes, idempotent, no new tables, no edge functions
- Credentials via env vars only; data artifacts (business contact data) stay local, not committed
- Registry duplicate rows surfaced by calibration (L'ISOLA/LISOLA, Le Grain de Sel ×2, Beach Club Hotel Toiny/LE TOINY, Sotheby's ×2, Le Barthélemy ×2) — worth a dedupe follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a staged workflow for exporting, reviewing, matching, applying, verifying, and rolling back publication feature organization links.
  - Added deterministic and shortlist-based matching with quality metrics, evidence, and validation reports.
  - Added safe dry-run, snapshot, guarded update, conflict handling, and rollback capabilities.
  - Added end-to-end checks for data integrity, consistency, concentration, and repeatability.
- **Documentation**
  - Added structured JSON artifacts, run metadata, batch files, audit logs, and verification reports for each workflow run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->