### PR TITLE
Map reachability: /?tab=map redirect + PublicMap pagination past the 1,000-row cap

### DIFF
--- a/nuke_frontend/src/App.tsx
+++ b/nuke_frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from 'react';
-import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Routes, useLocation, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from './contexts/ThemeContext';
 import { BrandingProvider } from './branding/BrandingContext';
@@ -48,6 +48,10 @@ const LazyFallback = <div style={{ height: '100vh', background: 'var(--bg)' }} /
  */
 function HomeGate() {
   const { user, loading } = useAuth();
+  // Legacy links use /?tab=map, but no such tab exists — the org map is /map
+  if (new URLSearchParams(window.location.search).get('tab') === 'map') {
+    return <Navigate to="/map" replace />;
+  }
   if (loading) return LazyFallback;
   if (!user) {
     const params = new URLSearchParams(window.location.search);

--- a/nuke_frontend/src/components/map/PublicMap.tsx
+++ b/nuke_frontend/src/components/map/PublicMap.tsx
@@ -263,11 +263,24 @@ export default function PublicMap() {
 
   useEffect(() => {
     async function load() {
-      const { data, error } = await supabase
-        .from('organizations')
-        .select('id, name, slug, latitude, longitude, business_type, brand_design_language')
-        .not('latitude', 'is', null)
-        .limit(5000);
+      // PostgREST silently caps unordered queries at 1,000 rows — page through
+        // everything with GPS instead of a single capped .limit()
+        const PAGE = 1000;
+        const data: any[] = [];
+        let pageError: any = null;
+        for (let from = 0; ; from += PAGE) {
+          const { data: page, error } = await supabase
+            .from('organizations')
+            .select('id, name, slug, latitude, longitude, business_type, brand_design_language')
+            .not('latitude', 'is', null)
+            .order('id')
+            .range(from, from + PAGE - 1);
+          if (error) { pageError = error; break; }
+          if (!page?.length) break;
+          data.push(...page);
+          if (page.length < PAGE) break;
+        }
+        const error = pageError;
 
       if (error) console.error('Org query error:', error);
       if (data) {


### PR DESCRIPTION
Two surgical fixes so the org map works for St Barth at scale:

1. **`/?tab=map` → `/map` redirect** (App.tsx HomeGate): the homepage has no 'map' tab, so legacy links silently fell through to the feed. The org map is PublicMap at /map (already St-Barth-centered by default).
2. **PublicMap pagination** (PublicMap.tsx): PostgREST silently caps unordered `.limit(5000)` at 1,000 rows. Once the St Barth boutiques/hotels are published (~2,100 orgs with GPS), pins would be dropped arbitrarily. Now pages via `.order('id').range()` until exhausted.

Companion to the staged data-side fix (is_public flags + GPS column fills) that makes boutiques/hotels/brand stores appear — data change, no deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seamless redirection to the public map when visitors open the map tab while logged out.

* **Bug Fixes**
  * Improved public map loading to support larger location datasets, ensuring more map markers are displayed reliably.
  * Preserved location details, categories, and branding when displaying map markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->