### PR TITLE
Anon-safe advertiser-graph view for the app

### DIFF
--- a/supabase/migrations/20260717120000_publication_features_public_view.sql
+++ b/supabase/migrations/20260717120000_publication_features_public_view.sql
@@ -1,0 +1,15 @@
+-- Anon-safe projection of the Guest Book advertiser graph.
+-- The frontend (anon key) cannot read publication_features (RLS), which hides
+-- the advertiser graph from the app entirely. This view exposes ONLY
+-- publishable fields — printed name, page, category, confidence, org link —
+-- and deliberately omits the details jsonb (raw contact blocks stay
+-- service-role-only, per the data-governance tiering).
+create or replace view public.publication_features_public as
+  select id, publication_id, publication, edition, page, printed_page,
+         org_name_printed, category, feature_kind, confidence, org_id
+  from public.publication_features;
+
+comment on view public.publication_features_public is
+  'Anon-readable advertiser graph: publishable fields only; contact details excluded by design.';
+
+grant select on public.publication_features_public to anon, authenticated;


### PR DESCRIPTION
The app's anon key cannot read `publication_features` at all (RLS), which keeps the 294-link Guest Book advertiser graph invisible in every frontend. This adds `publication_features_public` — a view exposing only publishable fields (printed name, page, category, confidence, org link) with `details` (raw contact blocks) deliberately excluded, so it composes with the org-lockdown direction rather than fighting it.

Frontend can query it exactly like a table via PostgREST. Applying the migration to the live DB is a separate step (supabase migration deploy or execute_sql).

🤖 Generated with [Claude Code](https://claude.com/claude-code)