### PR TITLE
Advertiser graph in the app: Guest Book sections on org panel + publication profile

### DIFF
--- a/nuke_frontend/src/components/map/panels/MapOrgDetail.tsx
+++ b/nuke_frontend/src/components/map/panels/MapOrgDetail.tsx
@@ -27,6 +27,14 @@ interface BrandDesignLanguage {
   logos?: { svg?: string; primary_dark?: string; primary_light?: string };
 }
 
+interface PubFeature {
+  org_name_printed: string | null;
+  printed_page: number | null;
+  page: number | null;
+  category: string | null;
+  feature_kind: string | null;
+}
+
 interface OrgData {
   id: string;
   name: string | null;
@@ -44,6 +52,7 @@ interface OrgData {
 
 export default function MapOrgDetail({ orgId, onBack, onNavigate }: Props) {
   const [org, setOrg] = useState<OrgData | null>(null);
+  const [features, setFeatures] = useState<PubFeature[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -72,8 +81,20 @@ export default function MapOrgDetail({ orgId, onBack, onNavigate }: Props) {
         if (!cancelled && vehs) vehicles = vehs as OrgVehicle[];
       }
 
+      // Guest Book advertiser graph — the view may not exist yet; treat errors as empty
+      let feats: PubFeature[] = [];
+      if (o) {
+        const { data: featData, error: featErr } = await supabase
+          .from('publication_features_public')
+          .select('org_name_printed, printed_page, page, category, feature_kind')
+          .eq('org_id', o.id)
+          .order('page', { ascending: true });
+        if (!featErr && featData) feats = featData as PubFeature[];
+      }
+
       if (!cancelled && o) {
         setOrg({ ...o, vehicles } as OrgData);
+        setFeatures(feats);
       }
       setLoading(false);
     }
@@ -286,6 +307,49 @@ export default function MapOrgDetail({ orgId, onBack, onNavigate }: Props) {
               })}
             </div>
           </>
+        )}
+
+        {/* Guest Book advertiser graph — only render when rows exist (no empty shells) */}
+        {features.length > 0 && (
+          <div style={{ marginTop: 12 }}>
+            <div style={{ fontSize: 8, fontWeight: 700, textTransform: 'uppercase' as const, color: 'var(--text-secondary)', letterSpacing: '1px', marginBottom: 6 }}>
+              FEATURED IN — SAINT BARTH GUEST BOOK 2024
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              {features.map((f, i) => (
+                <div
+                  key={i}
+                  style={{
+                    display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8,
+                    padding: '4px 6px', border: '1px solid var(--border)',
+                  }}
+                >
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>
+                      {f.org_name_printed || org.name}
+                    </div>
+                    {f.category && (
+                      <div style={{ fontSize: 7, textTransform: 'uppercase' as const, color: 'var(--text-disabled)', letterSpacing: '0.3px' }}>
+                        {f.category}
+                      </div>
+                    )}
+                  </div>
+                  <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexShrink: 0 }}>
+                    {f.feature_kind && (
+                      <span style={{ fontSize: 7, textTransform: 'uppercase' as const, border: '1px solid var(--border)', padding: '1px 4px', color: 'var(--text-secondary)', letterSpacing: '0.3px' }}>
+                        {f.feature_kind}
+                      </span>
+                    )}
+                    {(f.printed_page ?? f.page) != null && (
+                      <span style={{ fontSize: 9, fontFamily: 'Courier New, monospace', color: 'var(--text-secondary)' }}>
+                        p.{f.printed_page ?? f.page}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
         )}
       </div>
     </div>

--- a/nuke_frontend/src/pages/publishing/PublicationProfile.tsx
+++ b/nuke_frontend/src/pages/publishing/PublicationProfile.tsx
@@ -31,6 +31,20 @@ interface CreditRow {
   confidence: number;
 }
 
+interface FeatureRow {
+  org_id: string | null;
+  org_name_printed: string | null;
+  printed_page: number | null;
+  page: number | null;
+  category: string | null;
+  feature_kind: string | null;
+}
+
+interface FeatureOrg {
+  name: string | null;
+  slug: string | null;
+}
+
 const S: Record<string, React.CSSProperties> = {
   container: { padding: '0 12px', maxWidth: '960px', margin: '0 auto' },
   header: {
@@ -95,6 +109,8 @@ export default function PublicationProfile() {
   const navigate = useNavigate();
   const [issues, setIssues] = useState<PubRow[]>([]);
   const [credits, setCredits] = useState<CreditRow[]>([]);
+  const [features, setFeatures] = useState<FeatureRow[]>([]);
+  const [featureOrgs, setFeatureOrgs] = useState<Record<string, FeatureOrg>>({});
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -119,9 +135,35 @@ export default function PublicationProfile() {
             .in('publication_id', pubIds)
         : { data: [] };
 
+      // Advertiser graph (Guest Book) — the view may not exist yet; treat errors as empty
+      let featRows: FeatureRow[] = [];
+      const orgMap: Record<string, FeatureOrg> = {};
+      if (pubIds.length > 0) {
+        const featRes = await supabase
+          .from('publication_features_public')
+          .select('org_id, org_name_printed, printed_page, page, category, feature_kind')
+          .in('publication_id', pubIds)
+          .order('page', { ascending: true });
+        if (!featRes.error && featRes.data) {
+          featRows = featRes.data as FeatureRow[];
+          const orgIds = Array.from(new Set(featRows.map(f => f.org_id).filter((x): x is string => !!x)));
+          if (orgIds.length > 0) {
+            const orgRes = await supabase
+              .from('organizations')
+              .select('id, name, slug')
+              .in('id', orgIds);
+            for (const o of (orgRes.data ?? []) as { id: string; name: string | null; slug: string | null }[]) {
+              orgMap[o.id] = { name: o.name, slug: o.slug };
+            }
+          }
+        }
+      }
+
       if (cancelled) return;
       setIssues((pubRes.data ?? []) as PubRow[]);
       setCredits((credRes.data ?? []) as CreditRow[]);
+      setFeatures(featRows);
+      setFeatureOrgs(orgMap);
       setLoading(false);
     }
 
@@ -165,6 +207,9 @@ export default function PublicationProfile() {
   const topContribs = Array.from(contribMap.values())
     .sort((a, b) => b.count - a.count)
     .slice(0, 20);
+
+  // Advertiser graph rows (paid placements only — editorial/menu/listing kinds excluded)
+  const adRows = features.filter(f => f.feature_kind === 'ad');
 
   return (
     <div style={S.container}>
@@ -240,6 +285,39 @@ export default function PublicationProfile() {
                     </div>
                   </div>
                 ))}
+              </div>
+            </div>
+          )}
+
+          {/* Advertisers (Guest Book advertiser graph) — only render when rows exist */}
+          {adRows.length > 0 && (
+            <div style={S.widget}>
+              <div style={S.widgetHeader}>
+                <span style={S.widgetLabel}>ADVERTISERS</span>
+                <span style={S.widgetCount}>{adRows.length}</span>
+              </div>
+              <div style={S.widgetBody}>
+                {adRows.map((f, i) => {
+                  const linked = f.org_id ? featureOrgs[f.org_id] : undefined;
+                  const clickable = !!f.org_id;
+                  return (
+                    <div
+                      key={`${f.org_id ?? f.org_name_printed ?? 'row'}-${i}`}
+                      style={{ ...S.row, cursor: clickable ? 'pointer' : 'default' }}
+                      onClick={clickable ? () => navigate(`/org/${featureOrgs[f.org_id!]?.slug || f.org_id}`) : undefined}
+                      onMouseEnter={clickable ? e => { (e.currentTarget as HTMLElement).style.background = 'var(--surface-hover)'; } : undefined}
+                      onMouseLeave={clickable ? e => { (e.currentTarget as HTMLElement).style.background = 'transparent'; } : undefined}
+                    >
+                      <span style={S.rowLabel}>{linked?.name || f.org_name_printed || 'Unknown'}</span>
+                      <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                        {f.category && <span style={S.badge}>{f.category}</span>}
+                        {(f.printed_page ?? f.page) != null && (
+                          <span style={S.rowMono}>p.{f.printed_page ?? f.page}</span>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
             </div>
           )}


### PR DESCRIPTION
Surfaces the Saint Barth Guest Book 2024 advertiser graph in the app, reading from the anon-safe `publication_features_public` view.

## Changes

**`nuke_frontend/src/components/map/panels/MapOrgDetail.tsx`** — new "FEATURED IN — SAINT BARTH GUEST BOOK 2024" section on the map org detail panel. Queries the view by the resolved org id (works for both slug and uuid panel entry) and renders printed name, category, feature kind, and printed page (`p.N`, falls back to PDF page). Section renders only when rows exist.

**`nuke_frontend/src/pages/publishing/PublicationProfile.tsx`** — new "ADVERTISERS" widget on the publication series profile. Queries the view by `publication_id` across the series' issues, filters to `feature_kind = 'ad'` (144 rows for the Guest Book; editorial/menu/listing kinds excluded from this widget), joins canonical org name + slug via a second `organizations` query, and renders rows as printed-order listing with category badge and page number. Linked rows navigate to `/org/{slug|id}`; unlinked printed names render without a link. Widget renders only when rows exist.

## Dependency

Depends on the `publication_features_public` view (migration merged in PR #337; **live apply pending** — the view does not exist in the database yet as of this PR). Both surfaces treat query errors as empty result sets, so they degrade silently (render nothing) until the view is applied. No loading states, no empty shells.

## Design rules

Arial, ALL-CAPS 8px labels, Courier New for page numbers, zero border-radius/shadows/gradients, data checked before render. Each section follows the border idiom of its host file (1px row borders in the map panel, 2px widget frame on the publishing page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
